### PR TITLE
Guard ILiveCodingModule include with PLATFORM_WINDOWS in EditorHandlers_Build.cpp

### DIFF
--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EditorHandlers_Build.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EditorHandlers_Build.cpp
@@ -19,7 +19,9 @@
 #include "HAL/PlatformFileManager.h"
 #include "HAL/PlatformFile.h"
 #include "Modules/ModuleManager.h"
+#if PLATFORM_WINDOWS
 #include "ILiveCodingModule.h"
+#endif
 #include "Kismet/KismetSystemLibrary.h"
 #include "EditorValidatorSubsystem.h"
 #include "Dom/JsonObject.h"


### PR DESCRIPTION
## Problem

`EditorHandlers_Build.cpp` fails to compile on non-Windows platforms with:

    fatal error: 'ILiveCodingModule.h' file not found

`ILiveCodingModule.h` lives in the `LiveCoding` engine module, which is Windows-only. The call site in `HotReload()` is already correctly wrapped in `#if PLATFORM_WINDOWS / #endif`, but the include at the top of the file is unguarded — so the preprocessor fails before it ever reaches the gated code.

## Fix

Wrap the include in the same `PLATFORM_WINDOWS` guard already used by its call site:

```cpp
#if PLATFORM_WINDOWS
#include "ILiveCodingModule.h"
#endif
```

Single-line change, matches the existing pattern in the same file, no behavior change on Windows.

## Verified

- Builds on macOS / UE 5.7 with the guard applied.
- Windows build path unchanged (guard already matches the call site).