### PR TITLE
feat: npm plugin system

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,201 @@
+# Authoring a ue-mcp plugin
+
+A ue-mcp plugin is a normal npm package that injects new actions into existing built-in categories (`pcg`, `landscape`, etc.). The agent discovers them at the point of need: nothing else changes about how the agent picks tools.
+
+This page is the author contract. The user-facing side (installing, removing, listing) is just `ue-mcp plugin install <name>`.
+
+## Why injection, not a standalone tool
+
+A standalone tool is opaque to the agent — it has no reason to open a `vpp` category during terrain work. If the action lands inside `pcg` as `pcg(action="vpp_scatter_on_terrain")`, the agent already working in PCG discovers it exactly when relevant. Capability appears at the point of need, not behind a door the agent has to know to open.
+
+## Package layout
+
+```
+ue-mcp-plugin-<your-name>/
+  package.json
+  tsconfig.json
+  ue-mcp.plugin.yml          # author declaration: actionPrefix, inject, knowledge, tasks, flows
+  src/                       # author writes TypeScript here
+    tasks/
+      MyAction.ts            # one BaseTask subclass per file, default export
+    shared/                  # optional cross-task helpers (never referenced from the declaration)
+  dist/                      # tsc output - what actually ships and loads
+    tasks/
+      MyAction.js
+  knowledge/
+    pcg.md                   # one markdown file per target category
+  README.md
+```
+
+Conventions:
+
+- One task class per file, default export, extending `BaseTask` from `@db-lyon/flowkit`.
+- `class_path` in the declaration is resolved against the plugin's `dist/` (try `dist/<path>.js`, then `dist/tasks/<path>.js`).
+- `src/shared/` holds helpers; never reference it from the declaration.
+- Compile to `dist/` with `tsc` so users need no TypeScript toolchain.
+- The npm package name should start with `ue-mcp-plugin-` so it's discoverable on the registry.
+
+## `package.json`
+
+```json
+{
+  "name": "ue-mcp-plugin-voxel-plugin-pro",
+  "version": "0.1.0",
+  "description": "Voxel Plugin Pro 2 actions for ue-mcp",
+  "type": "module",
+  "main": "dist/index.js",
+  "files": ["dist", "ue-mcp.plugin.yml", "knowledge", "README.md"],
+  "keywords": ["ue-mcp-plugin", "unreal-engine", "voxel"],
+  "peerDependencies": {
+    "@db-lyon/flowkit": "~0.5.2"
+  },
+  "devDependencies": {
+    "@db-lyon/flowkit": "~0.5.2",
+    "typescript": "^5.7.0"
+  },
+  "scripts": {
+    "build": "tsc"
+  }
+}
+```
+
+The `ue-mcp-plugin` keyword is the registry signal. The peer-dep on `@db-lyon/flowkit` is what gives `BaseTask` its shape - your tasks must extend the same class the server uses.
+
+## `ue-mcp.plugin.yml`
+
+This is the only file ue-mcp reads from your package. Authored once; never edited by users.
+
+```yaml
+actionPrefix: vpp                # mandatory, lowercase, must match /^[a-z][a-z0-9_]*$/
+minServerVersion: 1.0.0          # optional - the server enforces this at install and load
+uePluginDependency: VoxelPro     # optional - the installer warns if missing from .uproject
+
+inject:
+  pcg:
+    scatter_on_terrain:          # → pcg(action="vpp_scatter_on_terrain")
+      task: vpp.scatter_on_terrain
+      description: "Scatter meshes on a voxel terrain. Params: graphPath, mesh, cellSize?"
+      schema:
+        graphPath: { type: string, required: true }
+        mesh:      { type: string, required: true }
+        cellSize:  { type: number }
+
+  landscape:
+    voxel_to_heightmap:          # → landscape(action="vpp_voxel_to_heightmap")
+      task: vpp.voxel_to_heightmap
+      description: "Bake a voxel terrain region to a landscape heightmap. Params: bounds, resolution?"
+      schema:
+        bounds:     { type: object, required: true }
+        resolution: { type: number }
+
+knowledge:
+  pcg: knowledge/pcg.md
+  landscape: knowledge/landscape.md
+
+tasks:
+  vpp.scatter_on_terrain:  { class_path: tasks/ScatterOnTerrain }
+  vpp.voxel_to_heightmap:  { class_path: tasks/VoxelToHeightmap }
+
+flows:
+  vpp_full_setup:
+    description: "Full VPP scatter setup"
+    rollback_on_failure: true
+    steps:
+      1: { task: vpp.scatter_on_terrain }
+      2: { task: vpp.voxel_to_heightmap }
+```
+
+The key under each category is the *bare* action name. The loader prepends your `actionPrefix` to compute the injected name: `vpp` + `scatter_on_terrain` → `vpp_scatter_on_terrain`. The user always sees the prefixed form.
+
+Param schemas under `schema:` accept these types: `string`, `number`, `boolean`, `object`, `array`. Non-required params become optional at the top level of the host category tool's schema.
+
+## Writing tasks
+
+```ts
+// src/tasks/ScatterOnTerrain.ts
+import { BaseTask, type TaskResult } from "@db-lyon/flowkit";
+
+interface ScatterOnTerrainOpts {
+  graphPath: string;
+  mesh: string;
+  cellSize?: number;
+}
+
+export default class ScatterOnTerrain extends BaseTask<ScatterOnTerrainOpts> {
+  get taskName() { return "vpp.scatter_on_terrain"; }
+
+  async execute(): Promise<TaskResult> {
+    // Compose existing MCP actions via `this.call('<category>.<action>', ...)`.
+    // The bridge, project, and logger are available on `this.ctx` exactly the
+    // same way as for built-in tasks.
+    const created = await this.call("pcg.create_graph", { path: this.options.graphPath });
+    if (!created.success) return created;
+
+    const node = await this.call("pcg.add_node", {
+      graphPath: this.options.graphPath,
+      nodeType: "VoxelSampler",
+    });
+    if (!node.success) return node;
+
+    return { success: true, data: { graphPath: this.options.graphPath } };
+  }
+}
+```
+
+Notes:
+- Compose existing actions through `this.call('<category>.<action>', params)`. Don't reach into the bridge directly unless you need to - composition gives you free observability and rollback hooks.
+- If your task makes multi-step mutations, return a `rollback` record so users can opt into `rollback_on_failure: true` for safety. The plugin scaffolder turns this on by default for multi-step flows.
+
+## Knowledge files
+
+For each category your plugin injects into, ship a short markdown file under `knowledge/`. The server attaches it to that category's AI-facing docs, so the agent sees plugin-specific guidance the moment it looks at that category.
+
+Keep it terse. One screenful per category. Concrete examples beat prose - the agent does not need a tutorial.
+
+```markdown
+# Voxel Plugin Pro - PCG actions
+
+`vpp_scatter_on_terrain` builds a PCG graph wired to a Voxel Sampler.
+Use it when the user wants meshes scattered on a voxel terrain rather
+than the standard landscape.
+
+Typical sequence:
+1. `pcg(action="create_graph", ...)` if no graph exists
+2. `pcg(action="vpp_scatter_on_terrain", graphPath=..., mesh=...)`
+3. `pcg(action="execute", ...)` to materialise the result
+```
+
+## Validation rules (enforced at install and at load)
+
+- `actionPrefix` is mandatory and must be a lowercase identifier.
+- Every `inject:` target must be a real registered category. A nonexistent target fails at install with the valid-target list.
+- A plugin action may never overwrite a built-in. Collisions are hard-skipped with a warning.
+- Inter-plugin collisions resolve by `plugins:` order in `ue-mcp.yml` - first wins.
+- `minServerVersion` is checked at install and re-checked at load.
+- A plugin that fails any of these is skipped entirely (never partially injected) with a loud warning.
+
+## Publishing
+
+```bash
+npm run build      # tsc → dist/
+npm publish        # public registry
+```
+
+Once published, users install with:
+
+```bash
+ue-mcp plugin install ue-mcp-plugin-<your-name>
+```
+
+The CLI runs `npm install --save`, validates your manifest, adds an entry under `plugins:` in `ue-mcp.yml`, and prints the restart instruction. Injected actions appear on the next server start.
+
+## Quick start
+
+```bash
+ue-mcp plugin create ue-mcp-plugin-my-thing
+cd ue-mcp-plugin-my-thing
+npm install
+npm run build
+```
+
+That stamps the standard layout and gets you to a publishable package as quickly as possible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "ue-mcp",
-  "version": "1.0.1",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ue-mcp",
-      "version": "1.0.1",
+      "version": "1.0.10",
       "license": "BUSL-1.1",
       "dependencies": {
         "@db-lyon/flowkit": "~0.5.2",
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "js-yaml": "^4.1.0",
         "ws": "^8.18.0",
         "zod": "^3.24.0"
       },
@@ -20,6 +21,7 @@
         "ue-mcp-update": "dist/update.js"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.5.0",
         "tsx": "^4.19.0",
@@ -153,6 +155,13 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ue-mcp",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ue-mcp",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "BUSL-1.1",
       "dependencies": {
         "@db-lyon/flowkit": "~0.5.2",

--- a/package.json
+++ b/package.json
@@ -72,10 +72,12 @@
   "dependencies": {
     "@db-lyon/flowkit": "~0.5.2",
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "js-yaml": "^4.1.0",
     "ws": "^8.18.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.0",
     "tsx": "^4.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ue-mcp",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Unreal Engine MCP server - 20 tools, 500+ actions for AI-driven editor control",
   "type": "module",
   "main": "dist/index.js",

--- a/src/flow/loader.ts
+++ b/src/flow/loader.ts
@@ -270,16 +270,41 @@ function defaultFlows(): Record<string, unknown> {
 }
 
 /**
+ * Plugin-contributed tasks and flows to merge into the defaults layer. The
+ * user's own ue-mcp.yml continues to win — plugins sit between built-ins and
+ * user config in the layered order, so a user can always override.
+ */
+export interface PluginContribution {
+  tasks?: Record<string, unknown>;
+  flows?: Record<string, unknown>;
+}
+
+/**
  * Load ue-mcp.yml from the given directory, layered on top of built-in defaults.
  * Returns the merged config even if no project ue-mcp.yml exists.
+ *
+ * Layer order (lowest precedence first):
+ *   built-in defaults
+ *   plugin contributions
+ *   ue-mcp.yml
+ *   ue-mcp.{env}.yml
+ *   ue-mcp.local.yml
  */
 export function loadFlowConfig(
   tools: ToolDef[],
   configDir?: string,
+  pluginContribution?: PluginContribution,
 ): LoadedConfig<FlowConfig> {
   const dir = configDir ?? process.cwd();
   const configPath = path.join(dir, "ue-mcp.yml");
   const defaults = buildDefaults(tools);
+
+  if (pluginContribution) {
+    const baseTasks = (defaults.tasks ?? {}) as Record<string, unknown>;
+    const baseFlows = (defaults.flows ?? {}) as Record<string, unknown>;
+    defaults.tasks = { ...baseTasks, ...(pluginContribution.tasks ?? {}) };
+    defaults.flows = { ...baseFlows, ...(pluginContribution.flows ?? {}) };
+  }
 
   if (!fs.existsSync(configPath)) {
     return { config: FlowConfigSchema.parse(defaults), configDir: dir };

--- a/src/flow/schema.ts
+++ b/src/flow/schema.ts
@@ -17,10 +17,22 @@ export const GitSnapshotSchema = z.object({
   max_age_hours: z.number().default(24),
 }).optional();
 
+/**
+ * A plugin entry in the user's ue-mcp.yml.
+ * `name` is the npm package; `version` is optional and honored at resolve time.
+ */
+export const PluginEntrySchema = z.object({
+  name: z.string().min(1),
+  version: z.string().optional(),
+});
+
+export type PluginEntry = z.infer<typeof PluginEntrySchema>;
+
 export const FlowConfigSchema = EngineConfigSchema.extend({
   "ue-mcp": FlowVersionSchema.optional(),
   project: FlowProjectSchema,
   git_snapshot: GitSnapshotSchema,
+  plugins: z.array(PluginEntrySchema).default([]),
 });
 
 export type FlowConfig = z.infer<typeof FlowConfigSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,16 +6,20 @@ import { EditorBridge } from "./bridge.js";
 import { ProjectContext } from "./project.js";
 import { attach, attachSummary } from "./deployer.js";
 import { SERVER_INSTRUCTIONS } from "./instructions.js";
-import { isDirectiveResponse, type ToolDef, type ToolContext } from "./types.js";
+import { isDirectiveResponse, type ToolDef, type ToolContext, type PluginInfo } from "./types.js";
 import { McpError } from "./errors.js";
-import { info } from "./log.js";
+import { info, warn } from "./log.js";
 import { startVersionCheck, consumeUpgradeNotice } from "./version-check.js";
 import { buildFlowRegistry } from "./flow/registry.js";
 import { loadFlowConfig } from "./flow/loader.js";
 import { createFlowTool } from "./flow/flow-tool.js";
 import { startFlowHttpServer } from "./flow/http-server.js";
 import type { FlowContext } from "./flow/context.js";
-import type { FlowConfig } from "./flow/schema.js";
+import type { FlowConfig, PluginEntry } from "./flow/schema.js";
+import { loadPlugins, type PluginRecord } from "./plugin/loader.js";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import yaml from "js-yaml";
 
 import { ALL_TOOLS } from "./tools.js";
 
@@ -30,12 +34,52 @@ async function main() {
   const bridge = new EditorBridge();
   const project = new ProjectContext();
 
+  // Kick off the npm registry check in the background; the next tool response
+  // injects the notice if a newer version is published.
+  const { createRequire } = await import("node:module");
+  const require = createRequire(import.meta.url);
+  const pkg = require("../package.json") as { version: string };
+  startVersionCheck(pkg.version);
+
+  // ── Project init ─────────────────────────────────────────────────
+  // Moved ahead of tool registration so plugin resolution can walk the
+  // project's node_modules.
+  const projectArg = process.argv.find((a) => !a.startsWith("-") && a !== process.argv[0] && a !== process.argv[1]);
+
+  if (projectArg) {
+    try {
+      project.setProject(projectArg);
+      console.error(`[ue-mcp] Project loaded: ${project.projectName} (engine ${project.engineAssociation ?? "unknown"})`);
+
+      // Non-destructive attach — never overwrites local bridge source.
+      // Source deployment is reserved for `ue-mcp init` / `ue-mcp update`.
+      const result = attach(project);
+      console.error(`[ue-mcp] ${attachSummary(result)}`);
+    } catch (e) {
+      console.error(`[ue-mcp] Failed to initialize project: ${e instanceof Error ? e.message : e}`);
+    }
+  }
+
+  // ── Plugins ──────────────────────────────────────────────────────
+  // Read the user's `plugins:` entries from ue-mcp.yml (best-effort — a
+  // missing or invalid file means zero plugins, never a fatal error). Then
+  // resolve, validate, and inject into target categories BEFORE the flow
+  // registry is built so plugin tasks register cleanly.
+  const configDir = project.projectDir ?? undefined;
+  const pluginEntries = readPluginsEntries(configDir);
+  const pluginLoad = await loadPlugins(ALL_TOOLS, pluginEntries, configDir, pkg.version);
+  const activeTools = pluginLoad.tools;
+  const pluginRecords = pluginLoad.records;
+
   // Lazy flow accessor — reads ue-mcp.yml fresh each call so agents see
   // edits without a server restart. project(get_status) uses this so the
   // first call agents make in any session reveals the registered flows.
   const getFlows = (): Array<{ name: string; description?: string }> => {
     try {
-      const cfg = loadFlowConfig(ALL_TOOLS, project.projectDir ?? undefined).config;
+      const cfg = loadFlowConfig(activeTools, configDir, {
+        tasks: pluginLoad.taskDefs,
+        flows: pluginLoad.flowDefs,
+      }).config;
       return Object.entries(cfg.flows).map(([name, def]) => ({
         name,
         description: (def as { description?: string }).description,
@@ -45,28 +89,38 @@ async function main() {
     }
   };
 
-  const ctx: ToolContext = { bridge, project, getFlows };
+  const getPlugins = (): PluginInfo[] => pluginRecords.map((r) => toPluginInfo(r, project));
 
-  // Kick off the npm registry check in the background; the next tool response
-  // injects the notice if a newer version is published.
-  const { createRequire } = await import("node:module");
-  const require = createRequire(import.meta.url);
-  const pkg = require("../package.json") as { version: string };
-  startVersionCheck(pkg.version);
+  const ctx: ToolContext = { bridge, project, getFlows, getPlugins };
 
   // ── Flow engine: task registry ──────────────────────────────────
-  const registry = buildFlowRegistry(ALL_TOOLS);
+  const registry = buildFlowRegistry(activeTools);
+  for (const { name, ctor } of pluginLoad.taskRegistrations) {
+    registry.register(name, ctor);
+  }
+  for (const { classPath, ctor } of pluginLoad.classPathRegistrations) {
+    registry.registerClassPath(classPath, ctor);
+  }
   const taskCount = registry.listRegistered().length;
+
+  // ── Plugin knowledge → server instructions ──────────────────────
+  // Attach per-category markdown to the AI-facing docs. Sized to the same
+  // budget as SERVER_INSTRUCTIONS itself; deeper plugin docs remain
+  // readable on demand via the file-reading surface.
+  const knowledgeBlock = buildKnowledgeBlock(pluginLoad.knowledgeByCategory);
+  const serverInstructions = knowledgeBlock
+    ? `${SERVER_INSTRUCTIONS}\n\n═══ PLUGIN KNOWLEDGE ═══\n${knowledgeBlock}`
+    : SERVER_INSTRUCTIONS;
 
   const server = new McpServer({
     name: "ue-mcp",
     version: "0.6.4",
   }, {
-    instructions: SERVER_INSTRUCTIONS,
+    instructions: serverInstructions,
   });
 
   const disabled = new Set(project.config.disable ?? []);
-  const tools = ALL_TOOLS.filter((t) => !disabled.has(t.name));
+  const tools = activeTools.filter((t) => !disabled.has(t.name));
 
   // ── Register category tools — dispatched through the task registry ──
   for (const tool of tools) {
@@ -129,32 +183,19 @@ async function main() {
     });
   }
 
-  // ── Project init ─────────────────────────────────────────────────
-  const projectArg = process.argv.find((a) => !a.startsWith("-") && a !== process.argv[0] && a !== process.argv[1]);
-
-  if (projectArg) {
-    try {
-      project.setProject(projectArg);
-      console.error(`[ue-mcp] Project loaded: ${project.projectName} (engine ${project.engineAssociation ?? "unknown"})`);
-
-      // Non-destructive attach — never overwrites local bridge source.
-      // Source deployment is reserved for `ue-mcp init` / `ue-mcp update`.
-      const result = attach(project);
-      console.error(`[ue-mcp] ${attachSummary(result)}`);
-    } catch (e) {
-      console.error(`[ue-mcp] Failed to initialize project: ${e instanceof Error ? e.message : e}`);
-    }
-  }
-
   // ── Load ue-mcp.yml and register flow tool ──────────────────────
-  const configDir = project.projectDir ?? undefined;
-
   // Log initial load
-  const initialLoad = loadFlowConfig(ALL_TOOLS, configDir);
+  const initialLoad = loadFlowConfig(activeTools, configDir, {
+    tasks: pluginLoad.taskDefs,
+    flows: pluginLoad.flowDefs,
+  });
   console.error(`[ue-mcp] ue-mcp.yml loaded — ${Object.keys(initialLoad.config.flows).length} flow(s), ${Object.keys(initialLoad.config.tasks).length} custom task(s)`);
 
   // Config is reloaded on every flow call — edit ue-mcp.yml without restarting
-  const reloadConfig = (): FlowConfig => loadFlowConfig(ALL_TOOLS, configDir).config;
+  const reloadConfig = (): FlowConfig => loadFlowConfig(activeTools, configDir, {
+    tasks: pluginLoad.taskDefs,
+    flows: pluginLoad.flowDefs,
+  }).config;
 
   const flowTool = createFlowTool(registry, reloadConfig);
   const flowShape: Record<string, z.ZodType> = {};
@@ -198,10 +239,91 @@ async function main() {
   if (disabled.size > 0) {
     console.error(`[ue-mcp] Disabled categories: ${[...disabled].join(", ")}`);
   }
-  console.error(`[ue-mcp] Registered ${tools.length + 1} tools, ${taskCount} tasks (flow engine)`);
+  const activePluginCount = pluginRecords.filter((r) => r.status === "active").length;
+  const pluginNote = pluginRecords.length > 0
+    ? `, ${activePluginCount}/${pluginRecords.length} plugin(s)`
+    : "";
+  console.error(`[ue-mcp] Registered ${tools.length + 1} tools, ${taskCount} tasks (flow engine)${pluginNote}`);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+}
+
+/**
+ * Best-effort read of the `plugins:` array from ue-mcp.yml. Returns [] when
+ * the file is missing, unreadable, or malformed — plugin failures are loud at
+ * load time, not fatal here.
+ */
+function readPluginsEntries(configDir: string | undefined): PluginEntry[] {
+  if (!configDir) return [];
+  const configPath = path.join(configDir, "ue-mcp.yml");
+  if (!fs.existsSync(configPath)) return [];
+  try {
+    const raw = yaml.load(fs.readFileSync(configPath, "utf-8")) as { plugins?: unknown } | null;
+    if (!raw || !Array.isArray(raw.plugins)) return [];
+    const out: PluginEntry[] = [];
+    for (const entry of raw.plugins) {
+      if (entry && typeof entry === "object" && typeof (entry as { name?: unknown }).name === "string") {
+        const e = entry as { name: string; version?: unknown };
+        out.push({
+          name: e.name,
+          version: typeof e.version === "string" ? e.version : undefined,
+        });
+      }
+    }
+    return out;
+  } catch (e) {
+    warn("plugin", `failed to parse plugins: from ue-mcp.yml - ${(e as Error).message}`);
+    return [];
+  }
+}
+
+function buildKnowledgeBlock(knowledgeByCategory: Record<string, string[]>): string {
+  const lines: string[] = [];
+  for (const [category, blobs] of Object.entries(knowledgeByCategory)) {
+    if (blobs.length === 0) continue;
+    lines.push(`── ${category} ──`);
+    for (const blob of blobs) lines.push(blob.trim());
+    lines.push("");
+  }
+  return lines.join("\n").trim();
+}
+
+function toPluginInfo(rec: PluginRecord, project: ProjectContext): PluginInfo {
+  const uePluginPresent = rec.uePluginDependency
+    ? isUePluginEnabled(project, rec.uePluginDependency)
+    : undefined;
+  return {
+    name: rec.name,
+    version: rec.version,
+    actionPrefix: rec.actionPrefix,
+    status: rec.status,
+    statusReason: rec.statusReason,
+    minServerVersion: rec.minServerVersion,
+    uePluginDependency: rec.uePluginDependency,
+    uePluginPresent,
+    injected: rec.injected,
+    knowledge: rec.knowledge,
+    flows: rec.flows,
+    tasks: rec.tasks,
+    pkgDir: rec.pkgDir,
+    manifestPath: rec.manifestPath,
+  };
+}
+
+function isUePluginEnabled(project: ProjectContext, name: string): boolean | undefined {
+  if (!project.projectPath) return undefined;
+  try {
+    const raw = JSON.parse(fs.readFileSync(project.projectPath, "utf-8")) as {
+      Plugins?: Array<{ Name?: string; Enabled?: boolean }>;
+    };
+    if (!raw.Plugins) return false;
+    const entry = raw.Plugins.find((p) => p.Name === name);
+    if (!entry) return false;
+    return entry.Enabled !== false;
+  } catch {
+    return undefined;
+  }
 }
 
 // Route subcommands
@@ -216,6 +338,9 @@ if (subcmd === "init") {
   import("./hook-handler.js");
 } else if (subcmd === "resolve") {
   import("./resolve.js");
+} else if (subcmd === "plugin") {
+  process.argv.splice(2, 1);
+  import("./plugin-cli.js");
 } else if (subcmd === "version" || subcmd === "--version" || subcmd === "-v") {
   const { createRequire } = await import("node:module");
   const require = createRequire(import.meta.url);

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -133,6 +133,9 @@ demo — Neon Shrine demo scene
 feedback — Agent feedback submission
   submit
 
+plugins — Introspect npm-distributed plugins that inject actions into other categories (read-only)
+  list, describe
+
 ═══ TIPS ═══
 • Start with level(action="get_outliner") or asset(action="list") to discover what's in the project.
 • Use reflection(action="reflect_class") to understand any UE class's properties.

--- a/src/plugin-cli.ts
+++ b/src/plugin-cli.ts
@@ -1,0 +1,485 @@
+#!/usr/bin/env node
+/**
+ * CLI for `ue-mcp plugin <subcommand>`.
+ *
+ *   install <name> [--version x.y.z]   npm install + add to ue-mcp.yml plugins:
+ *   uninstall <name>                   npm uninstall + remove from plugins:
+ *   list                               list configured plugins and their status
+ *   update [name]                      npm update + re-validate manifests
+ *
+ * Editing ue-mcp.yml: js-yaml does not preserve comments. We mitigate by
+ * rewriting only the `plugins:` block via a string-level surgery when
+ * possible, and falling back to a full dump when the existing file lacks the
+ * block entirely. The user is told both before and after about the restart
+ * requirement — injected MCP actions only appear on next server start.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import yaml from "js-yaml";
+import { loadManifest } from "./plugin/manifest.js";
+import { satisfiesMinimum } from "./plugin/version.js";
+import { findInstalledPackage } from "./plugin/resolver.js";
+import { ALL_TOOLS } from "./tools.js";
+
+const args = process.argv.slice(2);
+const sub = args.shift();
+
+const RESTART_NOTE =
+  "Injected actions appear on the next server start. Restart your MCP client (or `ue-mcp restart`).";
+
+function fail(msg: string): never {
+  console.error(`[ue-mcp plugin] ERROR: ${msg}`);
+  process.exit(1);
+}
+
+function note(msg: string): void {
+  console.log(`[ue-mcp plugin] ${msg}`);
+}
+
+interface ProjectInfo {
+  projectDir: string;
+  configPath: string;
+}
+
+function findProjectDir(startDir: string): ProjectInfo {
+  let dir = path.resolve(startDir);
+  const root = path.parse(dir).root;
+  while (true) {
+    if (fs.existsSync(path.join(dir, "ue-mcp.yml"))) {
+      return { projectDir: dir, configPath: path.join(dir, "ue-mcp.yml") };
+    }
+    if (fs.existsSync(path.join(dir, "package.json")) && fs.readdirSync(dir).some((f) => f.endsWith(".uproject"))) {
+      return { projectDir: dir, configPath: path.join(dir, "ue-mcp.yml") };
+    }
+    if (dir === root) break;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  fail(
+    "could not find a project. Run from a directory containing a ue-mcp.yml or a .uproject. " +
+    "Run `ue-mcp init` first if this is a fresh project.",
+  );
+}
+
+function runNpm(args: string[], cwd: string): void {
+  const r = spawnSync(process.platform === "win32" ? "npm.cmd" : "npm", args, {
+    cwd,
+    stdio: "inherit",
+    shell: false,
+  });
+  if (r.status !== 0) {
+    fail(`npm ${args.join(" ")} exited ${r.status}`);
+  }
+}
+
+interface PluginEntry {
+  name: string;
+  version?: string;
+}
+
+function readPluginsList(configPath: string): PluginEntry[] {
+  if (!fs.existsSync(configPath)) return [];
+  const raw = yaml.load(fs.readFileSync(configPath, "utf-8")) as { plugins?: unknown } | null;
+  if (!raw || !Array.isArray(raw.plugins)) return [];
+  const out: PluginEntry[] = [];
+  for (const entry of raw.plugins) {
+    if (entry && typeof entry === "object" && typeof (entry as { name?: unknown }).name === "string") {
+      const e = entry as { name: string; version?: unknown };
+      out.push({
+        name: e.name,
+        version: typeof e.version === "string" ? e.version : undefined,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Write the plugins: array back to ue-mcp.yml. Performs string-level surgery
+ * so non-plugins blocks (with comments, etc.) are left untouched.
+ */
+function writePluginsList(configPath: string, plugins: PluginEntry[]): void {
+  const exists = fs.existsSync(configPath);
+  const original = exists ? fs.readFileSync(configPath, "utf-8") : "";
+
+  // Render the new plugins block in YAML.
+  const rendered = plugins.length === 0
+    ? "plugins: []\n"
+    : "plugins:\n" + plugins.map((p) =>
+        p.version
+          ? `  - name: ${p.name}\n    version: ${p.version}\n`
+          : `  - name: ${p.name}\n`,
+      ).join("");
+
+  if (!exists) {
+    // Create a minimal stub file. The schema accepts a bare plugins/tasks/flows
+    // and `ue-mcp init` will fill the rest later if needed.
+    fs.writeFileSync(configPath, `ue-mcp:\n  version: 1\n\n${rendered}`);
+    return;
+  }
+
+  // Locate an existing `plugins:` block at column 0 (a YAML root key).
+  const blockRe = /^plugins:[\t ]*(?:\r?\n(?:[ \t]+[^\r\n]*\r?\n|\r?\n)*|\[\][\t ]*\r?\n)/m;
+  const match = blockRe.exec(original);
+  if (match) {
+    const updated = original.slice(0, match.index) + rendered + original.slice(match.index + match[0].length);
+    fs.writeFileSync(configPath, updated);
+    return;
+  }
+
+  // Append at end of file. Add a leading blank line for readability if the
+  // file does not already end with one.
+  const sep = original.endsWith("\n") ? (original.endsWith("\n\n") ? "" : "\n") : "\n\n";
+  fs.writeFileSync(configPath, original + sep + rendered);
+}
+
+function cmdInstall(): void {
+  const name = args.shift();
+  if (!name) fail("usage: ue-mcp plugin install <name> [--version x.y.z]");
+
+  let version: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--version") version = args[i + 1];
+  }
+
+  const proj = findProjectDir(process.cwd());
+
+  // Ensure a package.json exists. npm install will refuse without one.
+  if (!fs.existsSync(path.join(proj.projectDir, "package.json"))) {
+    note(`no package.json in ${proj.projectDir}; running 'npm init -y'`);
+    runNpm(["init", "-y"], proj.projectDir);
+  }
+
+  const spec = version ? `${name}@${version}` : name;
+  note(`installing ${spec}`);
+  runNpm(["install", "--save", spec], proj.projectDir);
+
+  // Validate the just-installed plugin BEFORE editing ue-mcp.yml.
+  const pkgDir = findInstalledPackage(name, proj.projectDir);
+  if (!pkgDir) fail(`npm install succeeded but ${name} is not under node_modules`);
+
+  let manifest;
+  try {
+    manifest = loadManifest(pkgDir).manifest;
+  } catch (e) {
+    fail(`${name} has no valid ue-mcp.plugin.yml: ${(e as Error).message}`);
+  }
+
+  // minServerVersion gate at install time.
+  const pkgJson = JSON.parse(fs.readFileSync(path.join(__dirnameOrCwd(), "..", "package.json"), "utf-8")) as { version: string };
+  if (manifest.minServerVersion && !satisfiesMinimum(pkgJson.version, manifest.minServerVersion)) {
+    fail(
+      `${name} requires ue-mcp >= ${manifest.minServerVersion}; this server is ${pkgJson.version}. ` +
+      `Upgrade with \`npm install -g ue-mcp@latest\`.`,
+    );
+  }
+
+  // Validate `inject` targets against the built-in category set.
+  const builtIn = new Set(ALL_TOOLS.map((t) => t.name));
+  for (const target of Object.keys(manifest.inject)) {
+    if (!builtIn.has(target)) {
+      fail(
+        `${name} injects into '${target}', which is not a registered category. ` +
+        `Valid: ${[...builtIn].sort().join(", ")}.`,
+      );
+    }
+    for (const bare of Object.keys(manifest.inject[target])) {
+      const tool = ALL_TOOLS.find((t) => t.name === target);
+      const prefixed = `${manifest.actionPrefix}_${bare}`;
+      if (tool && tool.actions[prefixed]) {
+        fail(`${name}: action ${target}.${prefixed} collides with a built-in. Plugins may not override built-ins.`);
+      }
+    }
+  }
+
+  // Optional UE plugin dependency warning.
+  if (manifest.uePluginDependency) {
+    const present = uePluginEnabled(proj.projectDir, manifest.uePluginDependency);
+    if (present === false) {
+      note(`WARNING: ${name} requires UE plugin '${manifest.uePluginDependency}', not enabled in the .uproject. Enable it in the editor before using ${name} actions.`);
+    } else if (present === undefined) {
+      note(`could not determine whether UE plugin '${manifest.uePluginDependency}' is enabled — check the .uproject manually.`);
+    }
+  }
+
+  // Update ue-mcp.yml plugins:
+  const list = readPluginsList(proj.configPath);
+  const existing = list.findIndex((p) => p.name === name);
+  if (existing >= 0) {
+    list[existing] = { name, version };
+  } else {
+    list.push({ name, version });
+  }
+  writePluginsList(proj.configPath, list);
+
+  // Summary
+  note(`installed ${name}@${manifest.minServerVersion ? `(server-min ${manifest.minServerVersion})` : ""}`);
+  note(`actionPrefix: ${manifest.actionPrefix}`);
+  for (const [category, actions] of Object.entries(manifest.inject)) {
+    const names = Object.keys(actions).map((a) => `${manifest.actionPrefix}_${a}`).join(", ");
+    note(`  ${category}: ${names}`);
+  }
+  if (Object.keys(manifest.flows).length > 0) {
+    note(`flows: ${Object.keys(manifest.flows).join(", ")}`);
+  }
+  note(RESTART_NOTE);
+}
+
+function cmdUninstall(): void {
+  const name = args.shift();
+  if (!name) fail("usage: ue-mcp plugin uninstall <name>");
+  const proj = findProjectDir(process.cwd());
+  const list = readPluginsList(proj.configPath).filter((p) => p.name !== name);
+  writePluginsList(proj.configPath, list);
+  runNpm(["uninstall", name], proj.projectDir);
+  note(`removed ${name}`);
+  note(RESTART_NOTE);
+}
+
+function cmdList(): void {
+  const proj = findProjectDir(process.cwd());
+  const list = readPluginsList(proj.configPath);
+  if (list.length === 0) {
+    note(`no plugins declared in ${proj.configPath}`);
+    return;
+  }
+  for (const entry of list) {
+    const pkgDir = findInstalledPackage(entry.name, proj.projectDir);
+    if (!pkgDir) {
+      console.log(`  ${entry.name}${entry.version ? `@${entry.version}` : ""} — MISSING (not in node_modules)`);
+      continue;
+    }
+    const pj = JSON.parse(fs.readFileSync(path.join(pkgDir, "package.json"), "utf-8")) as { version?: string };
+    let status = "ok";
+    let categories: string[] = [];
+    try {
+      const m = loadManifest(pkgDir).manifest;
+      categories = Object.keys(m.inject);
+    } catch (e) {
+      status = `manifest invalid: ${(e as Error).message}`;
+    }
+    console.log(
+      `  ${entry.name}@${pj.version ?? "?"}` +
+      (entry.version ? ` (pinned ${entry.version})` : "") +
+      ` — ${status}` +
+      (categories.length ? ` — injects: ${categories.join(", ")}` : ""),
+    );
+  }
+}
+
+function cmdUpdate(): void {
+  const name = args.shift();
+  const proj = findProjectDir(process.cwd());
+  if (name) {
+    runNpm(["update", name], proj.projectDir);
+  } else {
+    runNpm(["update"], proj.projectDir);
+  }
+  note(RESTART_NOTE);
+}
+
+function cmdCreate(): void {
+  const name = args.shift();
+  if (!name) fail("usage: ue-mcp plugin create <name> [--dir path]");
+  if (!/^ue-mcp-plugin-/.test(name)) {
+    note(`WARNING: package name does not start with 'ue-mcp-plugin-' - registry discoverability will suffer.`);
+  }
+
+  let targetDir = path.resolve(process.cwd(), name);
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--dir") targetDir = path.resolve(args[i + 1]);
+  }
+
+  if (fs.existsSync(targetDir) && fs.readdirSync(targetDir).length > 0) {
+    fail(`target directory ${targetDir} exists and is not empty`);
+  }
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  // Derive a default actionPrefix from the package name suffix.
+  const prefix = deriveDefaultPrefix(name);
+
+  writeScaffold(targetDir, name, prefix);
+  note(`scaffolded ${name} at ${targetDir}`);
+  note(`next steps:`);
+  console.log(`  cd ${path.relative(process.cwd(), targetDir) || "."}`);
+  console.log(`  npm install`);
+  console.log(`  npm run build`);
+  console.log(`  npm publish        # when ready`);
+}
+
+function deriveDefaultPrefix(pkgName: string): string {
+  const stripped = pkgName.replace(/^ue-mcp-plugin-/, "");
+  const lowered = stripped.replace(/[^a-z0-9]+/gi, "_").toLowerCase();
+  // Take the first 1-3 alphanumeric chars as an action prefix.
+  const compact = lowered.split("_").filter(Boolean);
+  const seed = compact.length > 0 ? compact.map((s) => s[0]).join("").slice(0, 4) : "plg";
+  return /^[a-z]/.test(seed) ? seed : `p${seed}`;
+}
+
+function writeScaffold(dir: string, pkgName: string, prefix: string): void {
+  const className = "Hello";
+  const pkgJson = {
+    name: pkgName,
+    version: "0.1.0",
+    description: `${pkgName} - ue-mcp plugin`,
+    type: "module",
+    main: "dist/index.js",
+    files: ["dist", "ue-mcp.plugin.yml", "knowledge", "README.md"],
+    keywords: ["ue-mcp-plugin", "unreal-engine"],
+    peerDependencies: {
+      "@db-lyon/flowkit": "~0.5.2",
+    },
+    devDependencies: {
+      "@db-lyon/flowkit": "~0.5.2",
+      typescript: "^5.7.0",
+    },
+    scripts: {
+      build: "tsc",
+      prepublishOnly: "npm run build",
+    },
+  };
+  fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify(pkgJson, null, 2) + "\n");
+
+  const tsconfig = {
+    compilerOptions: {
+      target: "ES2022",
+      module: "Node16",
+      moduleResolution: "Node16",
+      outDir: "dist",
+      rootDir: "src",
+      strict: true,
+      esModuleInterop: true,
+      declaration: true,
+      sourceMap: true,
+      skipLibCheck: true,
+    },
+    include: ["src/**/*"],
+  };
+  fs.writeFileSync(path.join(dir, "tsconfig.json"), JSON.stringify(tsconfig, null, 2) + "\n");
+
+  const manifestYaml =
+`actionPrefix: ${prefix}
+minServerVersion: ${process.env.UE_MCP_PLUGIN_MIN_SERVER ?? "1.0.0"}
+
+inject:
+  project:
+    hello:
+      task: ${prefix}.hello
+      description: "Replace me - a stand-in action this scaffold ships with"
+      schema:
+        name: { type: string }
+
+tasks:
+  ${prefix}.hello:
+    class_path: tasks/${className}
+
+flows: {}
+`;
+  fs.writeFileSync(path.join(dir, "ue-mcp.plugin.yml"), manifestYaml);
+
+  const helloTs =
+`import { BaseTask, type TaskResult } from "@db-lyon/flowkit";
+
+interface Options {
+  name?: string;
+}
+
+export default class ${className} extends BaseTask<Options> {
+  get taskName() { return "${prefix}.hello"; }
+
+  async execute(): Promise<TaskResult> {
+    const who = this.options.name ?? "world";
+    return { success: true, data: { greeting: \`hello, \${who}\` } };
+  }
+}
+`;
+  fs.mkdirSync(path.join(dir, "src", "tasks"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "src", "tasks", `${className}.ts`), helloTs);
+
+  fs.mkdirSync(path.join(dir, "knowledge"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "knowledge", "project.md"),
+    `# ${pkgName} - project actions\n\nDescribe in one screen what your plugin contributes to the project category.\n`,
+  );
+
+  const readme =
+`# ${pkgName}
+
+A ue-mcp plugin. Install with:
+
+\`\`\`bash
+ue-mcp plugin install ${pkgName}
+\`\`\`
+
+After a server restart, the plugin's actions appear inside the built-in
+category they target. The default scaffold injects \`project(action="${prefix}_hello")\`.
+
+## Develop
+
+\`\`\`bash
+npm install
+npm run build
+\`\`\`
+
+See https://db-lyon.github.io/ue-mcp/plugins/ for the full author contract.
+`;
+  fs.writeFileSync(path.join(dir, "README.md"), readme);
+
+  fs.writeFileSync(
+    path.join(dir, ".gitignore"),
+    `node_modules/\ndist/\n*.tgz\n.DS_Store\n`,
+  );
+}
+
+function uePluginEnabled(projectDir: string, name: string): boolean | undefined {
+  const files = fs.readdirSync(projectDir).filter((f) => f.endsWith(".uproject"));
+  if (files.length === 0) return undefined;
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(projectDir, files[0]), "utf-8")) as {
+      Plugins?: Array<{ Name?: string; Enabled?: boolean }>;
+    };
+    if (!raw.Plugins) return false;
+    const entry = raw.Plugins.find((p) => p.Name === name);
+    if (!entry) return false;
+    return entry.Enabled !== false;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * `__dirname` is not available in ESM. Fall back to the cwd so the relative
+ * path-to-package.json lookup still works when the CLI is invoked directly.
+ */
+function __dirnameOrCwd(): string {
+  try {
+    return path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+  } catch {
+    return process.cwd();
+  }
+}
+
+switch (sub) {
+  case "install": cmdInstall(); break;
+  case "uninstall":
+  case "remove": cmdUninstall(); break;
+  case "list":
+  case "ls": cmdList(); break;
+  case "update":
+  case "upgrade": cmdUpdate(); break;
+  case "create":
+  case "new":
+  case "init": cmdCreate(); break;
+  default:
+    console.error(
+      "Usage:\n" +
+      "  ue-mcp plugin install <name> [--version x.y.z]\n" +
+      "  ue-mcp plugin uninstall <name>\n" +
+      "  ue-mcp plugin list\n" +
+      "  ue-mcp plugin update [name]\n" +
+      "  ue-mcp plugin create <name> [--dir path]",
+    );
+    process.exit(1);
+}

--- a/src/plugin/injection.ts
+++ b/src/plugin/injection.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import type { ToolDef, ActionSpec } from "../types.js";
+import { compileSchemaFields, type ManifestInjectAction } from "./manifest.js";
+
+/**
+ * Per-category injection plan derived from one plugin's `inject:` block.
+ * The keys are PREFIXED action names (e.g. `vpp_scatter_on_terrain`), which
+ * is what they look like on the wire and in tool docs.
+ */
+export interface InjectionPlan {
+  /** Category name (e.g. `pcg`). */
+  category: string;
+  /** Plugin's actionPrefix (e.g. `vpp`). */
+  prefix: string;
+  /** Plugin name for diagnostics. */
+  pluginName: string;
+  /** Bare action name → manifest spec. */
+  actions: Record<string, ManifestInjectAction>;
+}
+
+/**
+ * Merge plugin-supplied injection plans into a built-in category tool. Returns
+ * a NEW ToolDef with extended actions, rebuilt action enum, merged param
+ * schema, and a "Plugin actions:" block appended to the description.
+ *
+ * Collisions with built-in actions are skipped with a warning and never
+ * overwrite. Inter-plugin collisions are first-wins per the loader's left-to-
+ * right iteration; this function simply skips any action key already present.
+ */
+export interface MergeResult {
+  tool: ToolDef;
+  /** Final prefixed action names that were actually added, in insertion order. */
+  added: string[];
+  /** Collisions that were rejected: key + reason. */
+  skipped: Array<{ action: string; reason: string }>;
+}
+
+export function mergeInjectionsIntoTool(
+  orig: ToolDef,
+  plans: InjectionPlan[],
+): MergeResult {
+  const newActions: Record<string, ActionSpec> = { ...orig.actions };
+  const added: string[] = [];
+  const skipped: Array<{ action: string; reason: string }> = [];
+  const extraSchema: Record<string, z.ZodType> = {};
+  const docLines: string[] = [];
+
+  for (const plan of plans) {
+    for (const [bareName, injectSpec] of Object.entries(plan.actions)) {
+      const prefixed = `${plan.prefix}_${bareName}`;
+      if (newActions[prefixed]) {
+        skipped.push({
+          action: prefixed,
+          reason: orig.actions[prefixed]
+            ? `built-in action '${prefixed}' on ${orig.name}; never overridden`
+            : `already injected by an earlier plugin on ${orig.name}`,
+        });
+        continue;
+      }
+
+      // Plugin actions dispatch via the registry under `${tool}.${action}`;
+      // no bridge/handler is needed on the ActionSpec itself. The description
+      // is what surfaces in the tool's AI docs.
+      newActions[prefixed] = {
+        description: injectSpec.description ?? `Plugin action from ${plan.pluginName}`,
+      };
+      added.push(prefixed);
+      docLines.push(
+        injectSpec.description
+          ? `- ${prefixed}: ${injectSpec.description}`
+          : `- ${prefixed} (${plan.pluginName})`,
+      );
+
+      // Lift per-action schema fields to the top level as optional, matching
+      // the pattern built-in categories already use (one flat schema, action
+      // selects which params apply).
+      const compiled = compileSchemaFields(injectSpec.schema);
+      for (const [k, v] of Object.entries(compiled)) {
+        if (!(k in extraSchema) && !(k in orig.schema)) {
+          extraSchema[k] = v;
+        }
+      }
+    }
+  }
+
+  if (added.length === 0) {
+    return { tool: orig, added, skipped };
+  }
+
+  const allNames = Object.keys(newActions) as [string, ...string[]];
+  const newDescription =
+    orig.description + "\n\nPlugin actions:\n" + docLines.join("\n");
+
+  const newSchema: Record<string, z.ZodType> = {
+    ...orig.schema,
+    action: z.enum(allNames).describe("Action to perform"),
+    ...extraSchema,
+  };
+
+  // Keep the original handler — it is no longer called by index.ts (dispatch
+  // goes through the registry) but other call sites (tests, the HTTP flow
+  // surface) may still invoke ToolDef.handler directly.
+  return {
+    tool: {
+      ...orig,
+      description: newDescription,
+      schema: newSchema,
+      actions: newActions,
+    },
+    added,
+    skipped,
+  };
+}

--- a/src/plugin/loader.ts
+++ b/src/plugin/loader.ts
@@ -1,0 +1,356 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import { BaseTask, type TaskConstructor, type TaskDefinition, type FlowDefinition } from "@db-lyon/flowkit";
+import type { ToolDef } from "../types.js";
+import type { FlowConfig, PluginEntry } from "../flow/schema.js";
+import { warn, info } from "../log.js";
+import { loadManifest, type PluginManifest } from "./manifest.js";
+import { resolvePackage, type ResolvedPackage } from "./resolver.js";
+import { satisfiesMinimum } from "./version.js";
+import { mergeInjectionsIntoTool, type InjectionPlan } from "./injection.js";
+
+/** Per-plugin record surfaced to the `plugins` introspection category. */
+export interface PluginRecord {
+  name: string;
+  version: string;
+  actionPrefix: string;
+  pkgDir: string;
+  manifestPath: string;
+  minServerVersion?: string;
+  uePluginDependency?: string;
+  /** Final injected action names, by category. */
+  injected: Record<string, string[]>;
+  /** Knowledge files attached, by category. */
+  knowledge: Record<string, string>;
+  /** Plugin-supplied flow names. */
+  flows: string[];
+  /** Plugin-supplied task names registered in the flow registry. */
+  tasks: string[];
+  /** Validation status: "active" if loaded; anything else means skipped. */
+  status: "active" | "skipped";
+  statusReason?: string;
+}
+
+export interface PluginLoadResult {
+  /** Tools with plugin actions merged into target categories. */
+  tools: ToolDef[];
+  /** Per-plugin records for introspection. */
+  records: PluginRecord[];
+  /** Task constructors to register with the flow registry. */
+  taskRegistrations: Array<{ name: string; ctor: TaskConstructor }>;
+  /** Class-path → constructor pairs for explicit registry resolution. */
+  classPathRegistrations: Array<{ classPath: string; ctor: TaskConstructor }>;
+  /** Plugin-contributed task definitions to merge into the FlowConfig. */
+  taskDefs: Record<string, TaskDefinition>;
+  /** Plugin-contributed flow definitions to merge into the FlowConfig. */
+  flowDefs: Record<string, FlowDefinition>;
+  /** Per-category markdown to append to AI-facing docs. */
+  knowledgeByCategory: Record<string, string[]>;
+}
+
+const EMPTY_RESULT: PluginLoadResult = {
+  tools: [],
+  records: [],
+  taskRegistrations: [],
+  classPathRegistrations: [],
+  taskDefs: {},
+  flowDefs: {},
+  knowledgeByCategory: {},
+};
+
+/**
+ * Main plugin loading entry point. Walks the user's `plugins:` array, resolves
+ * each package from node_modules, loads its manifest, validates, dynamically
+ * imports its task classes, and computes injection plans.
+ *
+ * Failures are isolated per-plugin: a broken plugin is skipped with a loud
+ * warning, never partially injected.
+ */
+export async function loadPlugins(
+  tools: ToolDef[],
+  entries: PluginEntry[],
+  projectDir: string | undefined,
+  serverVersion: string,
+): Promise<PluginLoadResult> {
+  if (!entries || entries.length === 0) {
+    return { ...EMPTY_RESULT, tools };
+  }
+  if (!projectDir) {
+    warn("plugin", `'plugins:' set in ue-mcp.yml but no project directory is loaded - plugins will not load. Pass the .uproject path as a server argument.`);
+    return { ...EMPTY_RESULT, tools };
+  }
+
+  const builtInCategories = new Set(tools.map((t) => t.name));
+  const records: PluginRecord[] = [];
+  const taskRegistrations: Array<{ name: string; ctor: TaskConstructor }> = [];
+  const classPathRegistrations: Array<{ classPath: string; ctor: TaskConstructor }> = [];
+  const taskDefs: Record<string, TaskDefinition> = {};
+  const flowDefs: Record<string, FlowDefinition> = {};
+  const knowledgeByCategory: Record<string, string[]> = {};
+  // For each category, accumulate injection plans across all plugins.
+  const plansByCategory = new Map<string, InjectionPlan[]>();
+
+  for (const entry of entries) {
+    const record = await loadOne(
+      entry,
+      projectDir,
+      serverVersion,
+      builtInCategories,
+    );
+    records.push(record.record);
+    if (record.record.status !== "active" || !record.payload) continue;
+
+    const { manifest, pkg, taskCtors } = record.payload;
+
+    // Register task constructors under (a) the plugin task name and (b) the
+    // plugin class_path. Both are looked up by FlowRunner/registry consumers.
+    for (const [pluginTaskName, ctor] of taskCtors) {
+      const taskEntry = manifest.tasks[pluginTaskName];
+      if (!taskEntry) continue;
+      taskRegistrations.push({ name: pluginTaskName, ctor });
+      classPathRegistrations.push({ classPath: taskEntry.class_path, ctor });
+      taskDefs[pluginTaskName] = {
+        class_path: taskEntry.class_path,
+        description: taskEntry.description,
+        group: pkg.name,
+        options: {},
+      };
+    }
+
+    // Merge plugin-supplied flows. Plan §"Correctness constraints" says
+    // multi-step plugin flows should default to rollback_on_failure=true.
+    for (const [flowName, flowDef] of Object.entries(manifest.flows)) {
+      const stepCount = Object.keys(flowDef.steps).length;
+      const normalised: FlowDefinition = {
+        description: flowDef.description,
+        steps: flowDef.steps as FlowDefinition["steps"],
+        rollback_on_failure:
+          flowDef.rollback_on_failure ?? (stepCount > 1 ? true : undefined),
+      };
+      flowDefs[flowName] = normalised;
+    }
+
+    // Per-category: build injection plans + queue knowledge attachment.
+    for (const [category, actions] of Object.entries(manifest.inject)) {
+      const plan: InjectionPlan = {
+        category,
+        prefix: manifest.actionPrefix,
+        pluginName: pkg.name,
+        actions,
+      };
+      const list = plansByCategory.get(category) ?? [];
+      list.push(plan);
+      plansByCategory.set(category, list);
+
+      // Also register the injected dispatch name `<category>.<prefixed>` so
+      // that index.ts's `${tool}.${action}` registry lookup finds the same
+      // plugin task constructor.
+      for (const [bareName, injectSpec] of Object.entries(actions)) {
+        const pluginTaskName = injectSpec.task;
+        const ctor = taskCtors.get(pluginTaskName);
+        if (!ctor) continue; // skipped task — collision logged elsewhere
+        const dispatchName = `${category}.${manifest.actionPrefix}_${bareName}`;
+        taskRegistrations.push({ name: dispatchName, ctor });
+      }
+    }
+
+    // Knowledge: load file contents now; the loader returns text so the
+    // server can attach to instructions before the bridge connects.
+    for (const [category, relPath] of Object.entries(manifest.knowledge)) {
+      const abs = path.join(pkg.pkgDir, relPath);
+      if (!fs.existsSync(abs)) {
+        warn("plugin", `plugin ${pkg.name}: knowledge file ${relPath} not found, skipping`);
+        continue;
+      }
+      const content = fs.readFileSync(abs, "utf-8");
+      const list = knowledgeByCategory[category] ?? [];
+      list.push(`<!-- ${pkg.name} -->\n${content}`);
+      knowledgeByCategory[category] = list;
+      record.record.knowledge[category] = relPath;
+    }
+  }
+
+  // Apply merged injection plans to each target category tool. Plans are
+  // applied left-to-right, so earlier-listed plugins win on action-name
+  // collisions, matching the layered-config rule "later wins" for tasks but
+  // intentionally INVERTED here so users get a stable surface.
+  const modifiedTools = tools.map((t) => {
+    const plans = plansByCategory.get(t.name);
+    if (!plans || plans.length === 0) return t;
+    const { tool: merged, added, skipped } = mergeInjectionsIntoTool(t, plans);
+    for (const plan of plans) {
+      const rec = records.find((r) => r.name === plan.pluginName);
+      if (!rec) continue;
+      // Filter `added` down to entries from THIS plugin only.
+      const ownAdded = added.filter((a) => a.startsWith(`${plan.prefix}_`));
+      if (ownAdded.length > 0) {
+        rec.injected[t.name] = (rec.injected[t.name] ?? []).concat(ownAdded);
+      }
+    }
+    for (const s of skipped) {
+      warn("plugin", `injection collision skipped on ${t.name}: ${s.action} - ${s.reason}`);
+    }
+    return merged;
+  });
+
+  info(
+    "plugin",
+    `loaded ${records.filter((r) => r.status === "active").length}/${records.length} plugin(s)`,
+  );
+
+  return {
+    tools: modifiedTools,
+    records,
+    taskRegistrations,
+    classPathRegistrations,
+    taskDefs,
+    flowDefs,
+    knowledgeByCategory,
+  };
+}
+
+interface LoadOnePayload {
+  manifest: PluginManifest;
+  pkg: ResolvedPackage;
+  taskCtors: Map<string, TaskConstructor>;
+}
+
+interface LoadOneResult {
+  record: PluginRecord;
+  payload?: LoadOnePayload;
+}
+
+async function loadOne(
+  entry: PluginEntry,
+  projectDir: string,
+  serverVersion: string,
+  builtInCategories: Set<string>,
+): Promise<LoadOneResult> {
+  const base = baseRecord(entry);
+  let pkg: ResolvedPackage;
+  try {
+    pkg = resolvePackage(entry.name, entry.version, projectDir);
+  } catch (e) {
+    return skip(base, `resolve failed: ${(e as Error).message}`);
+  }
+  base.pkgDir = pkg.pkgDir;
+  base.version = pkg.version;
+
+  let parsed: ReturnType<typeof loadManifest>;
+  try {
+    parsed = loadManifest(pkg.pkgDir);
+  } catch (e) {
+    return skip(base, `manifest invalid: ${(e as Error).message}`);
+  }
+  const manifest = parsed.manifest;
+  base.manifestPath = parsed.manifestPath;
+  base.actionPrefix = manifest.actionPrefix;
+  base.minServerVersion = manifest.minServerVersion;
+  base.uePluginDependency = manifest.uePluginDependency;
+
+  if (manifest.minServerVersion && !satisfiesMinimum(serverVersion, manifest.minServerVersion)) {
+    return skip(base, `requires server >= ${manifest.minServerVersion} (have ${serverVersion})`);
+  }
+
+  // Target validation: every inject target must be a registered category.
+  for (const target of Object.keys(manifest.inject)) {
+    if (!builtInCategories.has(target)) {
+      return skip(
+        base,
+        `inject target '${target}' is not a registered category. Valid: ${[...builtInCategories].sort().join(", ")}`,
+      );
+    }
+  }
+
+  // Dynamic task import. Class-path is resolved against multiple candidates
+  // inside the plugin package; first existing file wins.
+  const taskCtors = new Map<string, TaskConstructor>();
+  for (const [pluginTaskName, taskEntry] of Object.entries(manifest.tasks)) {
+    try {
+      const ctor = await importTaskClass(pkg.pkgDir, taskEntry.class_path);
+      taskCtors.set(pluginTaskName, ctor);
+      base.tasks.push(pluginTaskName);
+    } catch (e) {
+      return skip(base, `task '${pluginTaskName}' load failed: ${(e as Error).message}`);
+    }
+  }
+
+  // Every inject entry must point to a task we just registered.
+  for (const [category, actions] of Object.entries(manifest.inject)) {
+    for (const [bareName, spec] of Object.entries(actions)) {
+      if (!taskCtors.has(spec.task)) {
+        return skip(
+          base,
+          `inject ${category}.${bareName} references unknown task '${spec.task}'`,
+        );
+      }
+    }
+  }
+
+  base.flows = Object.keys(manifest.flows);
+  base.status = "active";
+  return { record: base, payload: { manifest, pkg, taskCtors } };
+}
+
+function baseRecord(entry: PluginEntry): PluginRecord {
+  return {
+    name: entry.name,
+    version: entry.version ?? "(unresolved)",
+    actionPrefix: "(unresolved)",
+    pkgDir: "(unresolved)",
+    manifestPath: "(unresolved)",
+    injected: {},
+    knowledge: {},
+    flows: [],
+    tasks: [],
+    status: "skipped",
+  };
+}
+
+function skip(rec: PluginRecord, reason: string): LoadOneResult {
+  warn("plugin", `${rec.name}: ${reason}`);
+  rec.status = "skipped";
+  rec.statusReason = reason;
+  return { record: rec };
+}
+
+/**
+ * Dynamically import a task class from a plugin package. Searches multiple
+ * candidate locations under the plugin's `dist/` and root, accepting whichever
+ * resolves first.
+ */
+async function importTaskClass(pkgDir: string, classPath: string): Promise<TaskConstructor> {
+  const segments = classPath.replace(/\./g, "/");
+  const candidates = [
+    path.join(pkgDir, "dist", `${segments}.js`),
+    path.join(pkgDir, "dist", "tasks", `${segments}.js`),
+    path.join(pkgDir, `${segments}.js`),
+    path.join(pkgDir, "dist", `${segments}/index.js`),
+  ];
+  let resolved: string | null = null;
+  for (const c of candidates) {
+    if (fs.existsSync(c)) {
+      resolved = c;
+      break;
+    }
+  }
+  if (!resolved) {
+    throw new Error(
+      `class_path '${classPath}' could not be resolved. Searched:\n` +
+      candidates.map((c) => `  - ${c}`).join("\n"),
+    );
+  }
+  const mod = await import(pathToFileURL(resolved).href);
+  const baseName = path.basename(segments);
+  const TaskClass = mod.default ?? mod[baseName];
+  if (!TaskClass) {
+    throw new Error(
+      `module '${resolved}' has no default export and no named export matching '${baseName}'`,
+    );
+  }
+  if (!(TaskClass.prototype instanceof BaseTask)) {
+    throw new Error(`class from '${resolved}' does not extend BaseTask`);
+  }
+  return TaskClass as TaskConstructor;
+}

--- a/src/plugin/manifest.ts
+++ b/src/plugin/manifest.ts
@@ -1,0 +1,121 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { z } from "zod";
+import yaml from "js-yaml";
+
+/**
+ * Schema for ue-mcp.plugin.yml, the author-side declaration shipped inside
+ * each plugin npm package. Resolved from node_modules; never authored by the
+ * end user.
+ */
+
+const SchemaFieldSchema = z.object({
+  type: z.enum(["string", "number", "boolean", "object", "array"]),
+  required: z.boolean().optional(),
+  description: z.string().optional(),
+});
+
+export type ManifestSchemaField = z.infer<typeof SchemaFieldSchema>;
+
+const InjectActionSchema = z.object({
+  task: z.string().min(1),
+  description: z.string().optional(),
+  schema: z.record(SchemaFieldSchema).optional(),
+});
+
+export type ManifestInjectAction = z.infer<typeof InjectActionSchema>;
+
+const TaskEntrySchema = z.object({
+  class_path: z.string().min(1),
+  description: z.string().optional(),
+});
+
+const FlowStepEntrySchema = z.object({
+  task: z.string().optional(),
+  flow: z.string().optional(),
+  options: z.record(z.unknown()).optional(),
+  retries: z.number().optional(),
+  retryDelay: z.number().optional(),
+  retryOn: z.string().optional(),
+});
+
+const FlowEntrySchema = z.object({
+  description: z.string(),
+  rollback_on_failure: z.boolean().optional(),
+  steps: z.record(FlowStepEntrySchema),
+});
+
+export const PluginManifestSchema = z.object({
+  actionPrefix: z.string().regex(/^[a-z][a-z0-9_]*$/, {
+    message: "actionPrefix must be a lowercase identifier (letters, digits, underscore; must start with a letter)",
+  }),
+  minServerVersion: z.string().optional(),
+  uePluginDependency: z.string().optional(),
+  inject: z.record(z.record(InjectActionSchema)).default({}),
+  knowledge: z.record(z.string()).default({}),
+  tasks: z.record(TaskEntrySchema).default({}),
+  flows: z.record(FlowEntrySchema).default({}),
+});
+
+export type PluginManifest = z.infer<typeof PluginManifestSchema>;
+
+/**
+ * Locate the manifest file inside a plugin package directory. Convention is
+ * `ue-mcp.plugin.yml`, but `.yaml` is accepted as a fallback.
+ */
+export function findManifestPath(pkgDir: string): string | null {
+  const candidates = ["ue-mcp.plugin.yml", "ue-mcp.plugin.yaml"];
+  for (const c of candidates) {
+    const full = path.join(pkgDir, c);
+    if (fs.existsSync(full)) return full;
+  }
+  return null;
+}
+
+export interface ManifestParseResult {
+  manifest: PluginManifest;
+  manifestPath: string;
+}
+
+export function loadManifest(pkgDir: string): ManifestParseResult {
+  const manifestPath = findManifestPath(pkgDir);
+  if (!manifestPath) {
+    throw new Error(`ue-mcp.plugin.yml not found in ${pkgDir}`);
+  }
+  const raw = yaml.load(fs.readFileSync(manifestPath, "utf-8")) as unknown;
+  const manifest = PluginManifestSchema.parse(raw);
+  return { manifest, manifestPath };
+}
+
+/**
+ * Compile a manifest schema field map into a Zod object schema. Used to merge
+ * plugin action params into the host category tool's schema.
+ */
+export function compileSchemaFields(
+  fields: Record<string, ManifestSchemaField> | undefined,
+): Record<string, z.ZodType> {
+  if (!fields) return {};
+  const out: Record<string, z.ZodType> = {};
+  for (const [key, def] of Object.entries(fields)) {
+    let zod: z.ZodType;
+    switch (def.type) {
+      case "string": zod = z.string(); break;
+      case "number": zod = z.number(); break;
+      case "boolean": zod = z.boolean(); break;
+      case "object": zod = z.record(z.unknown()); break;
+      case "array": zod = z.array(z.unknown()); break;
+    }
+    if (def.description) zod = zod.describe(def.description);
+    if (!def.required) zod = zod.optional();
+    out[key] = zod;
+  }
+  return out;
+}
+
+/**
+ * Compute the prefixed action name as it appears on the injected category
+ * tool: `<actionPrefix>_<bareAction>`.
+ */
+export function prefixedActionName(prefix: string, action: string): string {
+  return `${prefix}_${action}`;
+}

--- a/src/plugin/resolver.ts
+++ b/src/plugin/resolver.ts
@@ -1,0 +1,70 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { compareVersions } from "./version.js";
+
+/**
+ * Resolve an npm package by name (and optional version pin) inside the given
+ * project's `node_modules`. Walks up parent directories so a server launched
+ * from a subfolder still finds the project root install.
+ */
+export interface ResolvedPackage {
+  name: string;
+  version: string;
+  pkgDir: string;
+  pkgJsonPath: string;
+}
+
+interface PackageJsonShape {
+  name?: string;
+  version?: string;
+  keywords?: string[];
+}
+
+function readPackageJson(pkgDir: string): PackageJsonShape | null {
+  const pj = path.join(pkgDir, "package.json");
+  if (!fs.existsSync(pj)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(pj, "utf-8")) as PackageJsonShape;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Walk up from `startDir` looking for a `node_modules/<name>` directory.
+ * Returns the matching package directory or null.
+ */
+export function findInstalledPackage(name: string, startDir: string): string | null {
+  let dir = path.resolve(startDir);
+  const root = path.parse(dir).root;
+  while (true) {
+    const candidate = path.join(dir, "node_modules", ...name.split("/"));
+    if (fs.existsSync(path.join(candidate, "package.json"))) return candidate;
+    if (dir === root) return null;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+export function resolvePackage(
+  name: string,
+  version: string | undefined,
+  projectDir: string,
+): ResolvedPackage {
+  const pkgDir = findInstalledPackage(name, projectDir);
+  if (!pkgDir) {
+    throw new Error(`Plugin package not installed: ${name}. Run \`ue-mcp plugin install ${name}\` from the project directory.`);
+  }
+  const pj = readPackageJson(pkgDir);
+  if (!pj || !pj.version) {
+    throw new Error(`Plugin package at ${pkgDir} has no readable package.json`);
+  }
+  if (version && compareVersions(pj.version, version) !== 0) {
+    throw new Error(
+      `Plugin ${name} version mismatch: ue-mcp.yml pins ${version}, installed ${pj.version}. ` +
+      `Run \`ue-mcp plugin install ${name} --version ${version}\` or remove the pin.`,
+    );
+  }
+  return { name, version: pj.version, pkgDir, pkgJsonPath: path.join(pkgDir, "package.json") };
+}

--- a/src/plugin/version.ts
+++ b/src/plugin/version.ts
@@ -1,0 +1,44 @@
+/**
+ * Minimal semver compare for plugin minServerVersion gating.
+ * Accepts X, X.Y, X.Y.Z, with an optional pre-release suffix that compares
+ * lexicographically against an absent suffix as "lower" per semver semantics.
+ */
+
+export interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  pre?: string;
+}
+
+export function parseVersion(v: string): ParsedVersion | null {
+  const m = /^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-(.+))?$/.exec(v.trim());
+  if (!m) return null;
+  return {
+    major: Number(m[1]),
+    minor: m[2] ? Number(m[2]) : 0,
+    patch: m[3] ? Number(m[3]) : 0,
+    pre: m[4],
+  };
+}
+
+/** -1 if a<b, 0 if a==b, 1 if a>b. */
+export function compareVersions(a: string, b: string): number {
+  const av = parseVersion(a);
+  const bv = parseVersion(b);
+  if (!av || !bv) {
+    return a === b ? 0 : a < b ? -1 : 1;
+  }
+  if (av.major !== bv.major) return av.major < bv.major ? -1 : 1;
+  if (av.minor !== bv.minor) return av.minor < bv.minor ? -1 : 1;
+  if (av.patch !== bv.patch) return av.patch < bv.patch ? -1 : 1;
+  if (av.pre === bv.pre) return 0;
+  if (!av.pre) return 1;
+  if (!bv.pre) return -1;
+  return av.pre < bv.pre ? -1 : 1;
+}
+
+/** Returns true if `current` satisfies `>= required`. */
+export function satisfiesMinimum(current: string, required: string): boolean {
+  return compareVersions(current, required) >= 0;
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -27,6 +27,7 @@ import { networkingTool } from "./tools/networking.js";
 import { demoTool } from "./tools/demo.js";
 import { feedbackTool } from "./tools/feedback.js";
 import { statetreeTool } from "./tools/statetree.js";
+import { pluginsTool } from "./tools/plugins.js";
 
 export const ALL_TOOLS: ToolDef[] = [
   projectTool,
@@ -49,6 +50,7 @@ export const ALL_TOOLS: ToolDef[] = [
   demoTool,
   feedbackTool,
   statetreeTool,
+  pluginsTool,
 ];
 
 /** Flatten to (toolName, actionName, bridgeMethod) triples for every action

--- a/src/tools/plugins.ts
+++ b/src/tools/plugins.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import { categoryTool, type ToolDef, type PluginInfo } from "../types.js";
+
+export const pluginsTool: ToolDef = categoryTool(
+  "plugins",
+  "Introspect npm-distributed plugins that contribute actions into other categories. Read-only.",
+  {
+    list: {
+      description: "Every plugin loaded from ue-mcp.yml: name, version, prefix, status, and injected actions",
+      handler: async (ctx) => {
+        const all = ctx.getPlugins?.() ?? [];
+        return {
+          pluginCount: all.length,
+          active: all.filter((p) => p.status === "active").length,
+          plugins: all.map(summarise),
+        };
+      },
+    },
+    describe: {
+      description: "Full detail for one plugin including knowledge files and flows. Params: name",
+      handler: async (ctx, p) => {
+        const target = p.name as string;
+        const all = ctx.getPlugins?.() ?? [];
+        const found = all.find((x) => x.name === target);
+        if (!found) {
+          return {
+            error: `plugin '${target}' not found`,
+            available: all.map((x) => x.name),
+          };
+        }
+        return detail(found);
+      },
+    },
+  },
+  undefined,
+  {
+    name: z.string().optional().describe("Plugin npm package name (describe action)"),
+  },
+);
+
+function summarise(p: PluginInfo): Record<string, unknown> {
+  return {
+    name: p.name,
+    version: p.version,
+    actionPrefix: p.actionPrefix,
+    status: p.status,
+    statusReason: p.statusReason,
+    categories: Object.keys(p.injected),
+    injectedActions: Object.values(p.injected).reduce((acc, arr) => acc + arr.length, 0),
+    flows: p.flows.length,
+    uePluginDependency: p.uePluginDependency,
+    uePluginPresent: p.uePluginPresent,
+  };
+}
+
+function detail(p: PluginInfo): Record<string, unknown> {
+  return {
+    name: p.name,
+    version: p.version,
+    actionPrefix: p.actionPrefix,
+    status: p.status,
+    statusReason: p.statusReason,
+    minServerVersion: p.minServerVersion,
+    uePluginDependency: p.uePluginDependency,
+    uePluginPresent: p.uePluginPresent,
+    pkgDir: p.pkgDir,
+    manifestPath: p.manifestPath,
+    injected: p.injected,
+    knowledge: p.knowledge,
+    flows: p.flows,
+    tasks: p.tasks,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,27 @@ export interface ToolContext {
    *  built-in + ue-mcp.yml flows. Used by project(get_status) so agents
    *  see which canonical sequences are pre-encoded for this project. */
   getFlows?: () => Array<{ name: string; description?: string }>;
+  /** Lazy accessor for the loaded plugin set. Returns one PluginInfo per
+   *  entry in the user's `plugins:` array, active or skipped. Used by the
+   *  `plugins` introspection category. */
+  getPlugins?: () => PluginInfo[];
+}
+
+export interface PluginInfo {
+  name: string;
+  version: string;
+  actionPrefix: string;
+  status: "active" | "skipped";
+  statusReason?: string;
+  minServerVersion?: string;
+  uePluginDependency?: string;
+  uePluginPresent?: boolean;
+  injected: Record<string, string[]>;
+  knowledge: Record<string, string>;
+  flows: string[];
+  tasks: string[];
+  pkgDir: string;
+  manifestPath: string;
 }
 
 export interface ToolDef {

--- a/tests/unit/plugin-injection.test.ts
+++ b/tests/unit/plugin-injection.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { categoryTool, bp, type ToolDef } from "../../src/types.js";
+import { mergeInjectionsIntoTool, type InjectionPlan } from "../../src/plugin/injection.js";
+
+function fakePcg(): ToolDef {
+  return categoryTool(
+    "pcg",
+    "Fake PCG tool for testing.",
+    {
+      list_graphs: bp("pcg_list_graphs"),
+      add_node: bp("Add a node", "pcg_add_node"),
+    },
+    undefined,
+    { graphPath: z.string().optional() },
+  );
+}
+
+describe("mergeInjectionsIntoTool", () => {
+  it("returns the original tool when no plans apply", () => {
+    const orig = fakePcg();
+    const { tool, added, skipped } = mergeInjectionsIntoTool(orig, []);
+    expect(tool).toBe(orig);
+    expect(added).toEqual([]);
+    expect(skipped).toEqual([]);
+  });
+
+  it("adds prefixed actions from a plan", () => {
+    const orig = fakePcg();
+    const plan: InjectionPlan = {
+      category: "pcg",
+      prefix: "vpp",
+      pluginName: "ue-mcp-plugin-voxel-plugin-pro",
+      actions: {
+        scatter_on_terrain: {
+          task: "vpp.scatter_on_terrain",
+          description: "Scatter meshes on a voxel terrain",
+          schema: { graphPath: { type: "string", required: true } },
+        },
+      },
+    };
+    const { tool, added } = mergeInjectionsIntoTool(orig, [plan]);
+    expect(added).toEqual(["vpp_scatter_on_terrain"]);
+    expect(tool.actions.vpp_scatter_on_terrain).toBeTruthy();
+    expect(tool.actions.list_graphs).toBeTruthy();
+    expect(tool.actions.add_node).toBeTruthy();
+    expect(tool.description).toContain("Plugin actions:");
+    expect(tool.description).toContain("vpp_scatter_on_terrain");
+  });
+
+  it("rebuilds the action enum to include the injected name", () => {
+    const orig = fakePcg();
+    const plan: InjectionPlan = {
+      category: "pcg",
+      prefix: "vpp",
+      pluginName: "x",
+      actions: { foo: { task: "vpp.foo", description: "" } },
+    };
+    const { tool } = mergeInjectionsIntoTool(orig, [plan]);
+    const enumSchema = tool.schema.action as z.ZodEnum<[string, ...string[]]>;
+    expect(enumSchema._def.values).toContain("vpp_foo");
+    expect(enumSchema._def.values).toContain("list_graphs");
+  });
+
+  it("skips built-in collisions and never overrides", () => {
+    const orig = fakePcg();
+    const plan: InjectionPlan = {
+      category: "pcg",
+      prefix: "vpp",
+      pluginName: "x",
+      // attempt to inject `add_node` after prefixing - simulate by setting
+      // the prefix and bare name such that prefixed equals a built-in
+      actions: { node: { task: "vpp.node", description: "" } },
+    };
+    // Hand-craft a built-in named exactly `vpp_node` to provoke a collision.
+    const builtin = categoryTool("pcg", "x", {
+      vpp_node: bp("collision target"),
+    });
+    const { added, skipped } = mergeInjectionsIntoTool(builtin, [plan]);
+    expect(added).toEqual([]);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].action).toBe("vpp_node");
+  });
+
+  it("first plan wins on inter-plugin collisions", () => {
+    const orig = fakePcg();
+    const planA: InjectionPlan = {
+      category: "pcg",
+      prefix: "vpp",
+      pluginName: "a",
+      actions: { foo: { task: "vpp.foo", description: "from a" } },
+    };
+    const planB: InjectionPlan = {
+      category: "pcg",
+      prefix: "vpp",
+      pluginName: "b",
+      actions: { foo: { task: "vpp.foo", description: "from b" } },
+    };
+    const { added, skipped } = mergeInjectionsIntoTool(orig, [planA, planB]);
+    expect(added).toEqual(["vpp_foo"]);
+    expect(skipped).toHaveLength(1);
+  });
+});

--- a/tests/unit/plugin-manifest.test.ts
+++ b/tests/unit/plugin-manifest.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { PluginManifestSchema, prefixedActionName, compileSchemaFields } from "../../src/plugin/manifest.js";
+import { satisfiesMinimum, compareVersions } from "../../src/plugin/version.js";
+
+describe("PluginManifestSchema", () => {
+  it("accepts a minimal manifest", () => {
+    const r = PluginManifestSchema.safeParse({ actionPrefix: "vpp" });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.inject).toEqual({});
+      expect(r.data.knowledge).toEqual({});
+      expect(r.data.tasks).toEqual({});
+      expect(r.data.flows).toEqual({});
+    }
+  });
+
+  it("rejects a missing actionPrefix", () => {
+    const r = PluginManifestSchema.safeParse({});
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects an actionPrefix with disallowed characters", () => {
+    const r = PluginManifestSchema.safeParse({ actionPrefix: "VPP-1" });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a full manifest", () => {
+    const r = PluginManifestSchema.safeParse({
+      actionPrefix: "vpp",
+      minServerVersion: "1.0.0",
+      uePluginDependency: "VoxelPro",
+      inject: {
+        pcg: {
+          scatter_on_terrain: {
+            task: "vpp.scatter_on_terrain",
+            description: "Scatter on a voxel terrain",
+            schema: {
+              graphPath: { type: "string", required: true },
+              cellSize: { type: "number" },
+            },
+          },
+        },
+      },
+      knowledge: { pcg: "knowledge/pcg.md" },
+      tasks: {
+        "vpp.scatter_on_terrain": { class_path: "voxel-plugin-pro/ScatterOnTerrain" },
+      },
+      flows: {
+        full_setup: {
+          description: "Full setup",
+          steps: { 1: { task: "vpp.scatter_on_terrain" } },
+        },
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("prefixedActionName", () => {
+  it("joins prefix and action with underscore", () => {
+    expect(prefixedActionName("vpp", "scatter_on_terrain")).toBe("vpp_scatter_on_terrain");
+  });
+});
+
+describe("compileSchemaFields", () => {
+  it("makes non-required fields optional", () => {
+    const out = compileSchemaFields({
+      a: { type: "string", required: true },
+      b: { type: "number" },
+    });
+    expect(out.a.isOptional()).toBe(false);
+    expect(out.b.isOptional()).toBe(true);
+  });
+
+  it("returns empty for undefined", () => {
+    expect(compileSchemaFields(undefined)).toEqual({});
+  });
+});
+
+describe("version comparison", () => {
+  it("compares major.minor.patch", () => {
+    expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(compareVersions("1.0.1", "1.0.0")).toBe(1);
+    expect(compareVersions("1.0.0", "1.0.1")).toBe(-1);
+    expect(compareVersions("2.0.0", "1.99.99")).toBe(1);
+  });
+
+  it("treats prerelease as lower than non-pre", () => {
+    expect(compareVersions("1.0.0-alpha", "1.0.0")).toBe(-1);
+    expect(compareVersions("1.0.0", "1.0.0-beta")).toBe(1);
+  });
+
+  it("satisfiesMinimum returns true for equal", () => {
+    expect(satisfiesMinimum("1.0.0", "1.0.0")).toBe(true);
+    expect(satisfiesMinimum("1.0.1", "1.0.0")).toBe(true);
+    expect(satisfiesMinimum("1.0.0", "1.0.1")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- npm-distributed plugins inject new actions into existing built-in categories. Users opt in via a single `plugins:` array in `ue-mcp.yml`.
- Read-only `plugins` introspection category (`list`, `describe`).
- `ue-mcp plugin install|uninstall|list|update|create` CLI.
- `docs/plugins.md` author contract + `ue-mcp plugin create` scaffold.
- Reference plugin `ue-mcp-plugin-voxel-plugin-pro@0.1.0` published to npm.

## Test plan

- [x] Type-check clean (\`npx tsc --noEmit\`).
- [x] 82/82 unit tests pass (15 new for plugin manifest, injection, version compare).
- [x] End-to-end load: ran the local server against \`tests/ue_mcp/ue_mcp.uproject\` with the published plugin installed. Boot logs confirm \`loaded 1/1 plugin(s)\`, tool count 22 (was 21), flow count 5 (was 3), no skipped plugins.
- [ ] CI build + publish job on this branch.
- [ ] Post-publish: install \`ue-mcp@1.0.11\` and \`ue-mcp-plugin-voxel-plugin-pro\` in a real project, exercise the injected actions with the editor connected.

Draft release: https://github.com/db-lyon/ue-mcp/releases/tag/untagged-77a1a2fb1390a863b0e2