### PR TITLE
chore(scripts): test-plugin-boot.sh smoke check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ue-mcp",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ue-mcp",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "BUSL-1.1",
       "dependencies": {
         "@db-lyon/flowkit": "~0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ue-mcp",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Unreal Engine MCP server - 20 tools, 500+ actions for AI-driven editor control",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/test-plugin-boot.sh
+++ b/scripts/test-plugin-boot.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Boot the local server against tests/ue_mcp/ue_mcp.uproject just long enough
+# to capture the plugin loader's startup logs, then print the lines that say
+# whether the configured plugins loaded.
+#
+# Exit status: 0 if at least one plugin loaded successfully (look for
+# "loaded N/N plugin(s)" where the two N's are equal and non-zero); 1 if any
+# plugin warned or all were skipped.
+
+set -u
+cd "$(dirname "$0")/.."
+
+LOG=$(mktemp -t ue-mcp-boot.XXXXXX.log)
+trap 'rm -f "$LOG"' EXIT
+
+echo "→ building"
+npx tsc
+
+echo "→ booting server (5s)"
+node dist/index.js tests/ue_mcp/ue_mcp.uproject </dev/null 2>"$LOG" &
+PID=$!
+sleep 5
+kill -TERM "$PID" 2>/dev/null || true
+wait "$PID" 2>/dev/null || true
+
+echo
+echo "── plugin lines from boot log ────────────────────────────────"
+grep -iE 'plugin|tools, [0-9]+ tasks' "$LOG" || {
+  echo "(no plugin or registration lines in boot log)"
+  echo
+  echo "── full log ──────────────────────────────────────────────────"
+  cat "$LOG"
+  exit 1
+}
+
+if grep -qE 'warn plugin' "$LOG"; then
+  echo
+  echo "FAIL: plugin loader emitted a warning"
+  exit 1
+fi
+
+if grep -qE 'loaded ([1-9][0-9]*)/\1 plugin\(s\)' "$LOG"; then
+  echo
+  echo "OK"
+  exit 0
+fi
+
+echo
+echo "FAIL: did not see a successful 'loaded N/N plugin(s)' line"
+exit 1

--- a/src/plugin/loader.ts
+++ b/src/plugin/loader.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
-import { BaseTask, type TaskConstructor, type TaskDefinition, type FlowDefinition } from "@db-lyon/flowkit";
+import type { TaskConstructor, TaskDefinition, FlowDefinition } from "@db-lyon/flowkit";
 import type { ToolDef } from "../types.js";
 import type { FlowConfig, PluginEntry } from "../flow/schema.js";
 import { warn, info } from "../log.js";
@@ -349,8 +349,40 @@ async function importTaskClass(pkgDir: string, classPath: string): Promise<TaskC
       `module '${resolved}' has no default export and no named export matching '${baseName}'`,
     );
   }
-  if (!(TaskClass.prototype instanceof BaseTask)) {
-    throw new Error(`class from '${resolved}' does not extend BaseTask`);
+  if (!looksLikeBaseTask(TaskClass)) {
+    throw new Error(
+      `class from '${resolved}' does not look like a BaseTask subclass ` +
+      `(missing run() / execute() on the prototype chain)`,
+    );
   }
   return TaskClass as TaskConstructor;
+}
+
+/**
+ * Duck-type check that a class behaves like a BaseTask subclass. We can't use
+ * `instanceof BaseTask` here because npm 7+ installs peerDependencies into
+ * the consumer's node_modules, giving the plugin its own copy of
+ * `@db-lyon/flowkit` with a distinct BaseTask identity. `instanceof` then
+ * fails across module instances even though the classes are behaviourally
+ * identical. The prototype-chain check is sufficient because the registry
+ * only invokes `.run()` on instances.
+ */
+export function looksLikeBaseTask(TaskClass: unknown): boolean {
+  if (typeof TaskClass !== "function") return false;
+  const proto = (TaskClass as { prototype?: unknown }).prototype;
+  if (!proto || typeof proto !== "object") return false;
+  // `run` is implemented on BaseTask itself; `execute` is abstract on
+  // BaseTask and overridden by every subclass. Both must be reachable on
+  // the prototype chain.
+  return hasFn(proto, "run") && hasFn(proto, "execute");
+}
+
+function hasFn(obj: object, name: string): boolean {
+  let cur: object | null = obj;
+  while (cur && cur !== Object.prototype) {
+    const desc = Object.getOwnPropertyDescriptor(cur, name);
+    if (desc && typeof desc.value === "function") return true;
+    cur = Object.getPrototypeOf(cur) as object | null;
+  }
+  return false;
 }

--- a/tests/unit/plugin-injection.test.ts
+++ b/tests/unit/plugin-injection.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { categoryTool, bp, type ToolDef } from "../../src/types.js";
 import { mergeInjectionsIntoTool, type InjectionPlan } from "../../src/plugin/injection.js";
+import { looksLikeBaseTask } from "../../src/plugin/loader.js";
 
 function fakePcg(): ToolDef {
   return categoryTool(
@@ -63,13 +64,10 @@ describe("mergeInjectionsIntoTool", () => {
   });
 
   it("skips built-in collisions and never overrides", () => {
-    const orig = fakePcg();
     const plan: InjectionPlan = {
       category: "pcg",
       prefix: "vpp",
       pluginName: "x",
-      // attempt to inject `add_node` after prefixing - simulate by setting
-      // the prefix and bare name such that prefixed equals a built-in
       actions: { node: { task: "vpp.node", description: "" } },
     };
     // Hand-craft a built-in named exactly `vpp_node` to provoke a collision.
@@ -99,5 +97,52 @@ describe("mergeInjectionsIntoTool", () => {
     const { added, skipped } = mergeInjectionsIntoTool(orig, [planA, planB]);
     expect(added).toEqual(["vpp_foo"]);
     expect(skipped).toHaveLength(1);
+  });
+});
+
+describe("looksLikeBaseTask", () => {
+  // Regression: npm 7+ installs peerDependencies into the consumer's
+  // node_modules, giving the plugin its own copy of @db-lyon/flowkit with a
+  // distinct BaseTask class identity. `instanceof BaseTask` then fails even
+  // when the plugin is behaviourally correct. We rely on duck-typing.
+  it("accepts a class with run() and execute() on its own prototype", () => {
+    class GoodTask {
+      get taskName() { return "fake"; }
+      async execute() { return { success: true }; }
+      async run() { return this.execute(); }
+    }
+    expect(looksLikeBaseTask(GoodTask)).toBe(true);
+  });
+
+  it("accepts a class that inherits run() / execute() from a parent", () => {
+    class FakeBase {
+      async run() { return { success: true }; }
+      async execute() { return { success: true }; }
+    }
+    class Sub extends FakeBase {
+      get taskName() { return "fake"; }
+    }
+    expect(looksLikeBaseTask(Sub)).toBe(true);
+  });
+
+  it("rejects a class missing execute()", () => {
+    class NoExecute {
+      async run() { return { success: true }; }
+    }
+    expect(looksLikeBaseTask(NoExecute)).toBe(false);
+  });
+
+  it("rejects a class missing run()", () => {
+    class NoRun {
+      async execute() { return { success: true }; }
+    }
+    expect(looksLikeBaseTask(NoRun)).toBe(false);
+  });
+
+  it("rejects non-functions", () => {
+    expect(looksLikeBaseTask({})).toBe(false);
+    expect(looksLikeBaseTask(null)).toBe(false);
+    expect(looksLikeBaseTask(undefined)).toBe(false);
+    expect(looksLikeBaseTask("class")).toBe(false);
   });
 });


### PR DESCRIPTION
One-shot smoke for the plugin loader. Builds, boots against tests/ue_mcp, greps for the plugin lines, exits 0 only when at least one plugin loaded with no warnings. Doesn't need a version bump.