### PR TITLE
fix(cli): plugin install on Windows by routing npm through cmd.exe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ue-mcp",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ue-mcp",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "BUSL-1.1",
       "dependencies": {
         "@db-lyon/flowkit": "~0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ue-mcp",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Unreal Engine MCP server - 20 tools, 500+ actions for AI-driven editor control",
   "type": "module",
   "main": "dist/index.js",

--- a/src/plugin-cli.ts
+++ b/src/plugin-cli.ts
@@ -64,13 +64,21 @@ function findProjectDir(startDir: string): ProjectInfo {
 }
 
 function runNpm(args: string[], cwd: string): void {
-  const r = spawnSync(process.platform === "win32" ? "npm.cmd" : "npm", args, {
+  // On Windows, npm is `npm.cmd`. Node's child_process with `shell: false`
+  // cannot launch a `.cmd` file directly (it expects a real executable), so
+  // spawnSync returns status=null and an ENOENT-style error. Setting
+  // `shell: true` routes through cmd.exe which resolves the .cmd correctly.
+  // On POSIX `shell: true` is also safe; `npm` is a plain binary.
+  const r = spawnSync("npm", args, {
     cwd,
     stdio: "inherit",
-    shell: false,
+    shell: true,
   });
+  if (r.error) {
+    fail(`npm ${args.join(" ")} failed to start: ${r.error.message}`);
+  }
   if (r.status !== 0) {
-    fail(`npm ${args.join(" ")} exited ${r.status}`);
+    fail(`npm ${args.join(" ")} exited ${r.status ?? "(killed by signal)"}`);
   }
 }
 


### PR DESCRIPTION
Windows fix only. spawnSync with shell:false cannot launch npm.cmd; switched to shell:true. Also surfaces r.error.message so future spawn failures print something useful.