### PR TITLE
fix: address security report in #458 (CRITICAL bridge bind, HIGH/MEDIUM others)

### DIFF
--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -27,6 +27,14 @@ If you'd rather submit anonymously as the bot, pass `useBot=true`. The bot is th
 
 The agent is instructed to **strip project-specific details** from feedback submissions. Issues should describe the general capability gap, not your project's internals. You can review the issue content before the agent submits it.
 
+## Security model
+
+`feedback(submit)` posts to a public issue tracker. Treat anything you let the agent submit as already-disclosed. Specific notes:
+
+- **Secret scrubbing is best-effort.** Before submit, the assembled body and title are scanned for common credential shapes (GitHub PATs, AWS access keys, Slack/Stripe/OpenAI/Anthropic tokens, JWTs, PEM blocks, `SECRET=`/`TOKEN=`/`API_KEY=`/`PASSWORD=` style assignments) and replaced with `[REDACTED]`. Novel token shapes still pass through. Read the body before you let the agent post it.
+- **The PostToolUse hook is opt-in.** `npx ue-mcp init` no longer pre-checks the "prompt agents to file a GitHub issue" box. If you opt in, the hook fires after every `execute_python` call and pushes the agent toward calling `feedback(submit)`; the workaround log it would submit includes the Python you ran. Leave it off if your session touches anything sensitive.
+- **`useBot=true` ships an embedded GitHub App key.** The published npm package contains the `ue-mcp-feedback` App's PEM. The App's permissions are scoped to `issues: write` on `db-lyon/ue-mcp` and nowhere else, so the realistic blast radius from key disclosure is bot impersonation (spam-create, edit, or close issues on this one repo as `ue-mcp-feedback[bot]`); not RCE, not exfil of private code, not a foothold on your machine. The proper fix is server-side signing, tracked in [#461](https://github.com/db-lyon/ue-mcp/issues/461). In the meantime: the bot path is opt-in (default flow uses your device-auth token), the App's permissions stay locked, and revocation is one click on the App installation page.
+
 ## Submitting Feedback
 
 The `feedback` tool has one action:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ue-mcp",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ue-mcp",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "BUSL-1.1",
       "dependencies": {
         "@db-lyon/flowkit": "~0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ue-mcp",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Unreal Engine MCP server - 20 tools, 500+ actions for AI-driven editor control",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -169,11 +169,13 @@ uint32 FMCPBridgeServer::Run()
 	int32 NoDelay = 1;
 	setsockopt(ServerSocketFD, IPPROTO_TCP, TCP_NODELAY, (char*)&NoDelay, sizeof(NoDelay));
 
-	// Bind socket
+	// Bind socket to loopback only. The bridge has no authentication on the
+	// WebSocket upgrade, so binding to 0.0.0.0 (INADDR_ANY) would expose every
+	// editor-side handler (including execute_python) to any client on the LAN.
 	sockaddr_in ServerAddr;
 	FMemory::Memset(&ServerAddr, 0, sizeof(ServerAddr));
 	ServerAddr.sin_family = AF_INET;
-	ServerAddr.sin_addr.s_addr = INADDR_ANY;
+	ServerAddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 	ServerAddr.sin_port = htons(ServerPort);
 
 	if (bind(ServerSocketFD, (sockaddr*)&ServerAddr, sizeof(ServerAddr)) < 0)
@@ -207,7 +209,7 @@ uint32 FMCPBridgeServer::Run()
 		return 1;
 	}
 
-	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Bridge listening on ws://localhost:%d"), ServerPort);
+	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Bridge listening on ws://127.0.0.1:%d (loopback only)"), ServerPort);
 	bIsRunning = true;
 
 	// Accept connections
@@ -489,6 +491,41 @@ FString FMCPBridgeServer::PerformWebSocketHandshake(int32 ClientSocketFD)
 	if (Request.IsEmpty())
 	{
 		return TEXT("");
+	}
+
+	// Reject browser-originated upgrades from any origin other than loopback.
+	// Browsers always send an Origin header on WebSocket upgrades, so a present
+	// Origin that isn't loopback is a cross-site websocket hijacking attempt
+	// (a malicious page on the developer's machine reaching the editor bridge).
+	// Native clients (Node ws, curl) omit Origin and are allowed.
+	{
+		int32 OriginStart = Request.Find(TEXT("Origin:"), ESearchCase::IgnoreCase);
+		if (OriginStart != INDEX_NONE)
+		{
+			int32 ValueStart = OriginStart + 7; // strlen("Origin:")
+			while (ValueStart < Request.Len() && (Request[ValueStart] == TEXT(' ') || Request[ValueStart] == TEXT('\t')))
+			{
+				ValueStart++;
+			}
+			int32 ValueEnd = Request.Find(TEXT("\r\n"), ESearchCase::CaseSensitive, ESearchDir::FromStart, ValueStart);
+			FString Origin = (ValueEnd == INDEX_NONE)
+				? Request.Mid(ValueStart).TrimStartAndEnd()
+				: Request.Mid(ValueStart, ValueEnd - ValueStart).TrimStartAndEnd();
+
+			const bool bIsLoopback =
+				Origin.StartsWith(TEXT("http://localhost"), ESearchCase::IgnoreCase) ||
+				Origin.StartsWith(TEXT("https://localhost"), ESearchCase::IgnoreCase) ||
+				Origin.StartsWith(TEXT("http://127.0.0.1"), ESearchCase::IgnoreCase) ||
+				Origin.StartsWith(TEXT("https://127.0.0.1"), ESearchCase::IgnoreCase) ||
+				Origin.StartsWith(TEXT("http://[::1]"), ESearchCase::IgnoreCase) ||
+				Origin.StartsWith(TEXT("https://[::1]"), ESearchCase::IgnoreCase);
+
+			if (!bIsLoopback)
+			{
+				UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Rejected WebSocket upgrade from Origin: %s"), *Origin);
+				return TEXT("");
+			}
+		}
 	}
 
 	// Extract WebSocket-Key from request (case-insensitive search)

--- a/src/flow/http-server.ts
+++ b/src/flow/http-server.ts
@@ -1,13 +1,48 @@
 import * as http from "node:http";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import type { createFlowTool } from "./flow-tool.js";
 import type { ToolContext } from "../types.js";
-import { info, error as logError } from "../log.js";
+import { info, warn, error as logError } from "../log.js";
 
 type FlowTool = ReturnType<typeof createFlowTool>;
 
 export interface HttpServerOptions {
   host?: string;
   port?: number;
+  token?: string;
+}
+
+const ALLOWED_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "[::1]",
+]);
+
+function constantTimeEq(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+function extractToken(req: http.IncomingMessage): string | null {
+  const header = req.headers["x-ue-mcp-token"];
+  if (typeof header === "string" && header.length > 0) return header;
+  const auth = req.headers["authorization"];
+  if (typeof auth === "string" && auth.toLowerCase().startsWith("bearer ")) {
+    return auth.slice(7).trim();
+  }
+  return null;
+}
+
+function hostIsAllowed(req: http.IncomingMessage): boolean {
+  const host = req.headers.host;
+  if (typeof host !== "string" || host.length === 0) return false;
+  // strip optional :port (handle bracketed IPv6 too)
+  const bare = host.startsWith("[")
+    ? host.slice(0, host.indexOf("]") + 1)
+    : host.replace(/:\d+$/, "");
+  return ALLOWED_HOSTS.has(bare.toLowerCase());
 }
 
 // #144 — expose flow.run, flow.plan, flow.list over loopback HTTP so non-MCP
@@ -18,9 +53,15 @@ export function startFlowHttpServer(
   flowTool: FlowTool,
   ctx: ToolContext,
   options: HttpServerOptions = {},
-): { server: http.Server; port: number; host: string } {
+): { server: http.Server; port: number; host: string; token: string } {
   const host = options.host ?? "127.0.0.1";
   const port = options.port ?? 7723;
+  // Token precedence: explicit option > env override > freshly generated.
+  // Env override lets CI scripts pin a known value without parsing stderr.
+  const token =
+    options.token ??
+    process.env.UE_MCP_HTTP_TOKEN ??
+    randomBytes(32).toString("hex");
 
   const server = http.createServer(async (req, res) => {
     try {
@@ -34,6 +75,20 @@ export function startFlowHttpServer(
         res.setHeader("Content-Type", "application/json; charset=utf-8");
         res.end(text);
       };
+
+      // Defeat DNS rebinding: a malicious page can resolve attacker.example
+      // to 127.0.0.1, but the browser still sends the original Host header.
+      if (!hostIsAllowed(req)) {
+        warn("http", `rejected request with disallowed Host: ${req.headers.host ?? "<none>"}`);
+        return send(403, { error: "Host not allowed" });
+      }
+
+      // Bearer token: every route requires it, including /health (otherwise
+      // any local process can probe whether the server is up).
+      const presented = extractToken(req);
+      if (presented === null || !constantTimeEq(presented, token)) {
+        return send(401, { error: "Missing or invalid token" });
+      }
 
       if (method === "GET" && (pathname === "/" || pathname === "/flows")) {
         const result = await flowTool.handler(ctx, { action: "list" });
@@ -87,9 +142,13 @@ export function startFlowHttpServer(
 
   server.listen(port, host, () => {
     info("http", `flow HTTP server listening on http://${host}:${port}`);
+    // Print the token to stderr (where MCP servers' diagnostic output lives)
+    // so the operator can copy it without parsing tool output. Env-supplied
+    // tokens are still echoed; the value is already known to whoever set it.
+    info("http", `flow HTTP token: ${token} (send as 'Authorization: Bearer ...' or 'X-UE-MCP-Token: ...')`);
   });
 
-  return { server, port, host };
+  return { server, port, host, token };
 }
 
 async function readJsonBody(req: http.IncomingMessage): Promise<unknown> {

--- a/src/init.ts
+++ b/src/init.ts
@@ -531,8 +531,8 @@ async function init() {
       },
       {
         label: "Prompt agents to file a GitHub issue when they resort to Python workarounds",
-        checked: true,
-        suffix: "Recommended",
+        checked: false,
+        suffix: "Opt-in; posts session execute_python bodies to a public issue tracker",
       },
     ];
 

--- a/src/secret-scrub.ts
+++ b/src/secret-scrub.ts
@@ -1,0 +1,66 @@
+// Best-effort redaction for strings that get posted to a public GitHub issue
+// via feedback(submit). The agent assembles the body from session state, so
+// we cannot rely on a human reviewer catching pasted credentials before they
+// land in the issue body. This is a safety net, not a guarantee: novel token
+// shapes will pass through. Tighten as new patterns show up in the wild.
+
+interface SecretRule {
+  name: string;
+  re: RegExp;
+}
+
+const RULES: SecretRule[] = [
+  // GitHub PATs and App tokens. All current prefixes are 4 chars + underscore.
+  { name: "github-token", re: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}\b/g },
+  { name: "github-pat", re: /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g },
+  // AWS access key IDs (the secret is paired with these in env files).
+  { name: "aws-access-key", re: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g },
+  // Slack legacy + bot tokens.
+  { name: "slack-token", re: /\bxox[abprs]-[0-9A-Za-z-]{10,}\b/g },
+  // Stripe live/test secret keys.
+  { name: "stripe-key", re: /\bsk_(?:live|test)_[A-Za-z0-9]{16,}\b/g },
+  // Anthropic API keys.
+  { name: "anthropic-key", re: /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g },
+  // OpenAI keys (broad - matches the visible prefix; intentionally narrow on
+  // length to keep false positives manageable).
+  { name: "openai-key", re: /\bsk-[A-Za-z0-9]{32,}\b/g },
+  // JWTs (header.payload.signature).
+  { name: "jwt", re: /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g },
+  // PEM-encoded private keys.
+  {
+    name: "private-key",
+    re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP |ENCRYPTED |)?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |OPENSSH |DSA |PGP |ENCRYPTED |)?PRIVATE KEY-----/g,
+  },
+  // Generic key/value assignments where the key name screams "secret".
+  // Captures up to the next whitespace/quote so multi-word secrets don't leak.
+  {
+    name: "env-style-secret",
+    re: /\b(?:[A-Z][A-Z0-9_]*?_)?(?:SECRET|TOKEN|API[_-]?KEY|PASSWORD|PASSWD|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|CLIENT[_-]?SECRET|AUTH[_-]?TOKEN|BEARER)[A-Z0-9_]*\s*[:=]\s*["']?([^"'\s]{6,})["']?/gi,
+  },
+];
+
+export interface ScrubResult {
+  text: string;
+  hits: Array<{ rule: string; count: number }>;
+}
+
+export function scrubSecrets(input: string): ScrubResult {
+  let text = input;
+  const hits: Array<{ rule: string; count: number }> = [];
+  for (const rule of RULES) {
+    let count = 0;
+    text = text.replace(rule.re, (match, ...args) => {
+      count += 1;
+      // For env-style assignments only the value group is sensitive; preserve
+      // the key so reviewers can see which variable was redacted.
+      if (rule.name === "env-style-secret") {
+        const value = args[0] as string;
+        const idx = match.lastIndexOf(value);
+        return match.slice(0, idx) + "[REDACTED]";
+      }
+      return "[REDACTED]";
+    });
+    if (count > 0) hits.push({ rule: rule.name, count });
+  }
+  return { text, hits };
+}

--- a/src/tools/feedback.ts
+++ b/src/tools/feedback.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import { categoryTool, directive, type ToolDef, type ToolContext } from "../types.js";
 import { submitFeedback } from "../github-app.js";
 import { getWorkarounds, clearWorkarounds } from "../workaround-tracker.js";
+import { scrubSecrets } from "../secret-scrub.js";
+import { warn } from "../log.js";
 
 const PLACEHOLDER_TITLE_RE =
   /^(noop|nop|test|tests?|testing|x|y|z|todo|tbd|tba|ignore|ignored|stop|dummy|temp|tmp|placeholder|accidental|oops|cleanup|n\/?a|none|null|undefined|na|misc|\.+|-+)$/i;
@@ -190,10 +192,23 @@ export const feedbackTool: ToolDef = categoryTool(
 
         sections.push("", "---", "*Submitted via ue-mcp agent feedback*");
 
-        const body = sections.join("\n");
-        const labels = inferLabels(title, summary, idealTool);
+        const rawBody = sections.join("\n");
+        // Strip secret-shaped strings from the body before posting to a public
+        // issue. The agent assembles the body from session state (including
+        // execute_python bodies and arbitrary user text), so we cannot assume
+        // a human reviewed every byte.
+        const scrubbed = scrubSecrets(rawBody);
+        if (scrubbed.hits.length > 0) {
+          warn(
+            "feedback",
+            `redacted ${scrubbed.hits.reduce((n, h) => n + h.count, 0)} secret-shaped strings before submit: ${scrubbed.hits.map((h) => `${h.rule}=${h.count}`).join(", ")}`,
+          );
+        }
+        const scrubbedTitle = scrubSecrets(title).text;
+        const body = scrubbed.text;
+        const labels = inferLabels(scrubbedTitle, summary, idealTool);
         const useBot = params.useBot === true;
-        const result = await submitFeedback(title, body, labels, { useBot });
+        const result = await submitFeedback(scrubbedTitle, body, labels, { useBot });
 
         if (result.kind === "auth_required") {
           return directive(

--- a/src/version-check.ts
+++ b/src/version-check.ts
@@ -47,6 +47,11 @@ function writeCache(entry: CacheEntry): void {
   }
 }
 
+// Strict semver: the registry value is interpolated into a string the agent
+// reads as a system-level message, so anything that doesn't match this shape
+// is dropped to close a prompt-injection channel through a poisoned response.
+const STRICT_SEMVER_RE = /^(\d{1,8})\.(\d{1,8})\.(\d{1,8})(?:-[A-Za-z0-9.-]{1,32})?$/;
+
 async function fetchLatest(): Promise<string | null> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
@@ -54,7 +59,12 @@ async function fetchLatest(): Promise<string | null> {
     const res = await fetch(REGISTRY_URL, { signal: ctrl.signal });
     if (!res.ok) return null;
     const body = (await res.json()) as { version?: unknown };
-    return typeof body.version === "string" ? body.version : null;
+    if (typeof body.version !== "string") return null;
+    if (!STRICT_SEMVER_RE.test(body.version)) {
+      warn("update", `registry returned non-semver version; dropping`);
+      return null;
+    }
+    return body.version;
   } catch {
     return null;
   } finally {


### PR DESCRIPTION
Resolves the actionable items in #458. Comment with full triage and reasoning at #458#issuecomment-4491715517.

## Summary

- **CRITICAL** bridge now binds loopback only and rejects WebSocket upgrades from non-loopback `Origin`. Misleading log message corrected.
- **HIGH** `feedback(submit)` redacts common credential shapes before posting; PostToolUse feedback-nag hook flips to opt-in in `npx ue-mcp init`.
- **HIGH** embedded GitHub App PEM stays for now (App perms scoped to `issues: write` on `db-lyon/ue-mcp` only, blast radius is bounded bot impersonation); tracked for server-side signing in #461. Threat model documented in `docs/feedback.md`.
- **MEDIUM** flow HTTP server requires a per-session bearer token (`Authorization: Bearer` or `X-UE-MCP-Token`) and rejects non-loopback `Host` headers.
- **MEDIUM** npm registry "latest" version values that aren't strict semver are dropped instead of being interpolated into the agent-visible upgrade notice.

Five atomic commits, one per fix, plus a docs commit and the version bump.

## Test plan

- [ ] `npm run build` (UE plugin) succeeds and the editor reconnects.
- [ ] Cold start: bridge logs `ws://127.0.0.1:9877 (loopback only)`.
- [ ] `curl ws://<lan-ip>:9877` from another machine fails (connection refused).
- [ ] Browser `new WebSocket("ws://localhost:9877")` from a non-loopback `Origin` page fails the upgrade.
- [ ] Node-side bridge still connects without an `Origin` header.
- [ ] `npm run test:smoke` passes on `tests/ue_mcp` (no handler regression).
- [ ] `feedback(submit)` with a fake `GITHUB_TOKEN=ghp_...` in the body redacts before posting (dry-run against a private fork).
- [ ] Flow HTTP server: `curl -H "X-UE-MCP-Token: <token>" http://127.0.0.1:7723/health` returns 200; without the token returns 401; with `Host: attacker.example` returns 403.
- [ ] `npx ue-mcp init` shows the feedback-nag hook unchecked by default.