### PR TITLE
Document PIE gameplay actions in tool reference

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -606,6 +606,25 @@ UE-MCP exposes **<!-- count:tools -->21<!-- /count --> category tools** covering
 | `get_framework_info` | Get level framework classes |
 | `get_navmesh_details` | Read RecastNavMesh generation params (cellSize, agentHeight, maxStepHeight, etc.) (#163) |
 | `apply_damage_in_pie` | Apply damage to PIE actor. Params: `actorLabel, baseDamage?, damageTypeClass? (#186)` |
+| `inject_input` | Single-frame Enhanced Input injection during PIE. Params: `action, value_x?, value_y?, value_z?` |
+| `inject_input_start` | Begin holding an Enhanced Input action until stopped. Params: `action, value_x?, value_y?, value_z?, injection_id?` |
+| `inject_input_update` | Change the value of a running hold. Params: `injection_id, value_x?, value_y?` |
+| `inject_input_stop` | Stop a running hold or tape by id. |
+| `inject_input_tape` | Play a per-frame value array through Enhanced Input. Params: `action, values, hz?` |
+| `pie_record_arm` | Arm a PIE input recording. Params: `actions?, track_values?, track_actors?, axis_threshold?, sample_hz?, pin_fps?, capture_pawn_state?, capture_montage?, rng_seed?, run_gap_frames?, recording_dir?, id?` |
+| `pie_record_disarm` | Cancel an armed recording before it starts. |
+| `pie_record_stop` | Finalize an in-flight PIE recording immediately. |
+| `pie_record_status` | Read recorder state and current frame/progress. |
+| `pie_record_list` | Enumerate recordings under `Saved/MCPRecordings`. Params: `recording_dir?, record_limit?` |
+| `pie_record_read` | Read a recording artifact. Params: `id, file? (manifest\|sequence\|csv\|drift\|tracked), recording_dir?, record_limit?, record_offset?` |
+| `pie_record_delete` | Delete a recording directory. Params: `id, confirm` |
+| `pie_mark` | Insert a labelled marker into an active recording or replay. Params: `label` |
+| `pie_replay_arm` | Arm a PIE replay or monitor session. Params: `recording_id?, sequence_path?, steps?, settle_ms?, sample_hz?, pin_fps?, apply_rng_seed?, record_drift?, auto_stop_pie?, mode?, drift_thresholds?, rng_seed?` |
+| `pie_replay_disarm` | Cancel an armed replay before it starts. |
+| `pie_replay_stop` | Stop an in-flight replay and write drift output when applicable. |
+| `pie_replay_status` | Read replay state, current step, elapsed time, and drift maxima. |
+| `pie_snapshot` | Dump a live PIE actor's UProperty state to JSON. Params: `target, recording_id?, recording_dir?, snapshot_name?, include_components?` |
+| `pie_record_diff` | Offline diff of two PIE recordings. Params: `a_id, b_id, recording_dir?, position_cm?, rotation_deg?, velocity_cms?, tracked_default?, tracked_thresholds?` |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add the existing PIE input, recording, replay, snapshot, and diff gameplay actions to `docs/tool-reference.md`.
- Bring the generated tool reference back in sync with the TypeScript action surface.

## Why

`npm run audit:docs` currently reports these gameplay actions as missing from the docs even though they are already exposed by the server. This is a docs-only sync PR so later feature PRs do not need to carry unrelated documentation drift.

## Validation

- `npm run audit:docs`