### PR TITLE
Improve editor engine discovery and startup

### DIFF
--- a/src/deployer.ts
+++ b/src/deployer.ts
@@ -264,14 +264,15 @@ export function findEngineInstall(
   engineAssociation: string | null,
 ): string | null {
   if (!engineAssociation) return null;
+  const normalizedAssociation = engineAssociation.replace(/^\{|\}$/g, "");
 
   const guidRegex =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-  if (guidRegex.test(engineAssociation)) {
-    return findEngineByGuid(engineAssociation);
+  if (guidRegex.test(normalizedAssociation)) {
+    return findEngineByGuid(normalizedAssociation);
   }
 
-  return findLauncherEngine(engineAssociation);
+  return findLauncherEngine(normalizedAssociation);
 }
 
 function findEngineByGuid(guid: string): string | null {

--- a/src/editor-control.ts
+++ b/src/editor-control.ts
@@ -41,7 +41,7 @@ function findUEBuildTool(): string | null {
 
 function findEditorExecutable(project?: ProjectContext): string | null {
   const envPath = process.env.UE_EDITOR_PATH;
-  if (envPath && fs.existsSync(envPath)) return envPath;
+  if (envPath) return envPath;
 
   const associatedEngineRoot = findEngineInstall(project?.engineAssociation ?? null);
   if (associatedEngineRoot) {
@@ -146,18 +146,7 @@ export async function startEditor(project: ProjectContext): Promise<{ success: b
   }
 
   try {
-    const projectDir = path.dirname(project.projectPath);
-    const localDataCachePath = path.join(projectDir, "Saved", "DerivedDataCache");
-    fs.mkdirSync(localDataCachePath, { recursive: true });
-
-    const editorArgs = [
-      project.projectPath,
-      `-LocalDataCachePath=${localDataCachePath}`,
-      "-AssetGatherAll=false",
-      "-LiveCoding=0",
-    ];
-
-    const editorProcess = spawn(editorExe, editorArgs, {
+    const editorProcess = spawn(editorExe, [project.projectPath], {
       stdio: "ignore",
       detached: true,
     });

--- a/src/editor-control.ts
+++ b/src/editor-control.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { spawn, execSync } from "child_process";
 import * as net from "net";
 import type { ProjectContext } from "./project.js";
+import { findEngineInstall } from "./deployer.js";
 
 // editor-control relies on Windows-only tools (tasklist/taskkill, Build.bat).
 // The MCP server itself is cross-platform; only process control is gated.
@@ -38,9 +39,17 @@ function findUEBuildTool(): string | null {
   return null;
 }
 
-function findEditorExecutable(): string | null {
+function findEditorExecutable(project?: ProjectContext): string | null {
   const envPath = process.env.UE_EDITOR_PATH;
-  if (envPath) return envPath;
+  if (envPath && fs.existsSync(envPath)) return envPath;
+
+  const associatedEngineRoot = findEngineInstall(project?.engineAssociation ?? null);
+  if (associatedEngineRoot) {
+    const associatedEditorExe = path.join(associatedEngineRoot, "Engine", "Binaries", "Win64", "UnrealEditor.exe");
+    if (fs.existsSync(associatedEditorExe)) {
+      return associatedEditorExe;
+    }
+  }
 
   const buildTool = findUEBuildTool();
   if (!buildTool) return null;
@@ -124,7 +133,7 @@ export async function startEditor(project: ProjectContext): Promise<{ success: b
     return { success: false, message: "Editor is already running" };
   }
 
-  const editorExe = findEditorExecutable();
+  const editorExe = findEditorExecutable(project);
   if (!editorExe) {
     return {
       success: false,
@@ -137,7 +146,18 @@ export async function startEditor(project: ProjectContext): Promise<{ success: b
   }
 
   try {
-    const editorProcess = spawn(editorExe, [project.projectPath], {
+    const projectDir = path.dirname(project.projectPath);
+    const localDataCachePath = path.join(projectDir, "Saved", "DerivedDataCache");
+    fs.mkdirSync(localDataCachePath, { recursive: true });
+
+    const editorArgs = [
+      project.projectPath,
+      `-LocalDataCachePath=${localDataCachePath}`,
+      "-AssetGatherAll=false",
+      "-LiveCoding=0",
+    ];
+
+    const editorProcess = spawn(editorExe, editorArgs, {
       stdio: "ignore",
       detached: true,
     });


### PR DESCRIPTION
## Summary

- Normalize brace-wrapped `.uproject` engine GUIDs before registry lookup.
- Let editor launch resolve the project-associated engine install before falling back to default launcher paths.
- Validate `UE_EDITOR_PATH` before using it.
- Start the editor with a project-local DDC path and stability-oriented launch flags.

## Why

Projects using source-built Unreal installs or GUID engine associations may not live under standard launcher paths. This makes `editor.start_editor` more likely to launch the editor associated with the project instead of requiring manual environment overrides.

## Validation

- `npx tsc --noEmit`
- `git diff --check`