### PR TITLE
Add UE 5.5 bridge compatibility guards

### DIFF
--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AnimationHandlers_StateMachine.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AnimationHandlers_StateMachine.cpp
@@ -34,10 +34,13 @@
 #include "PoseSearch/PoseSearchSchema.h"
 #include "PoseSearch/PoseSearchDerivedData.h"
 #include "AssetRegistry/AssetRegistryModule.h"
+#include "Animation/AnimComposite.h"
 #include "Animation/BlendSpace.h"
 #include "Animation/Skeleton.h"
+#include "InstancedStruct.h"
 #include "UObject/Package.h"
 #include "Misc/PackageName.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "UObject/SavePackage.h"
 #include "UObject/UnrealType.h"
 #include "UObject/UObjectGlobals.h"
@@ -47,17 +50,52 @@
 #include "Dom/JsonValue.h"
 
 
-// UPoseSearchDatabase's "asset count" accessor was renamed between 5.4 and 5.5:
-//   5.4: GetAnimationAssets().Num()
-//   5.5+: GetNumAnimationAssets()
-// Use one helper so the call sites stay readable.
-static int32 GetPoseSearchAssetCount(const UPoseSearchDatabase* Database)
+#define UE_MCP_HAS_POSESEARCH_DATABASE_ASSET_API (ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4))
+
+static int32 GetPoseSearchAnimationAssetCount(const UPoseSearchDatabase* Database)
 {
-#if UE_MCP_HAS_5_5_API
+#if UE_MCP_HAS_POSESEARCH_DATABASE_ASSET_API
 	return Database->GetNumAnimationAssets();
 #else
-	return GetPoseSearchAssetCount(Database);
+	return Database->AnimationAssets.Num();
 #endif
+}
+
+static bool AddPoseSearchAnimationAsset(UPoseSearchDatabase* Database, UObject* AnimAsset, FString& OutError)
+{
+	FInstancedStruct NewEntry;
+	if (UAnimSequence* Sequence = Cast<UAnimSequence>(AnimAsset))
+	{
+		NewEntry.InitializeAs<FPoseSearchDatabaseSequence>();
+		NewEntry.GetMutablePtr<FPoseSearchDatabaseSequence>()->Sequence = Sequence;
+	}
+	else if (UBlendSpace* BlendSpace = Cast<UBlendSpace>(AnimAsset))
+	{
+		NewEntry.InitializeAs<FPoseSearchDatabaseBlendSpace>();
+		NewEntry.GetMutablePtr<FPoseSearchDatabaseBlendSpace>()->BlendSpace = BlendSpace;
+	}
+	else if (UAnimComposite* Composite = Cast<UAnimComposite>(AnimAsset))
+	{
+		NewEntry.InitializeAs<FPoseSearchDatabaseAnimComposite>();
+		NewEntry.GetMutablePtr<FPoseSearchDatabaseAnimComposite>()->AnimComposite = Composite;
+	}
+	else if (UAnimMontage* Montage = Cast<UAnimMontage>(AnimAsset))
+	{
+		NewEntry.InitializeAs<FPoseSearchDatabaseAnimMontage>();
+		NewEntry.GetMutablePtr<FPoseSearchDatabaseAnimMontage>()->AnimMontage = Montage;
+	}
+	else
+	{
+		OutError = FString::Printf(TEXT("Animation asset type not supported by PoseSearch: %s"), *AnimAsset->GetClass()->GetName());
+		return false;
+	}
+
+#if UE_MCP_HAS_POSESEARCH_DATABASE_ASSET_API
+	Database->AddAnimationAsset(MoveTemp(NewEntry));
+#else
+	Database->AnimationAssets.Add(MoveTemp(NewEntry));
+#endif
+	return true;
 }
 
 // ─── State Machine Helpers ────────────────────────────────────────
@@ -984,14 +1022,22 @@ TSharedPtr<FJsonValue> FAnimationHandlers::CreateIKRetargeter(const TSharedPtr<F
 				{
 					if (UIKRigDefinition* SrcRig = Cast<UIKRigDefinition>(LoadObject<UObject>(nullptr, *SourceRigPath)))
 					{
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7)
 						Controller->AssignIKRigToAllOps(ERetargetSourceOrTarget::Source, SrcRig);
+#else
+						Controller->SetIKRig(ERetargetSourceOrTarget::Source, SrcRig);
+#endif
 					}
 				}
 				if (!TargetRigPath.IsEmpty())
 				{
 					if (UIKRigDefinition* TgtRig = Cast<UIKRigDefinition>(LoadObject<UObject>(nullptr, *TargetRigPath)))
 					{
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7)
 						Controller->AssignIKRigToAllOps(ERetargetSourceOrTarget::Target, TgtRig);
+#else
+						Controller->SetIKRig(ERetargetSourceOrTarget::Target, TgtRig);
+#endif
 					}
 				}
 				Controller->AutoMapChains(EAutoMapChainType::Exact, true);
@@ -1170,15 +1216,17 @@ TSharedPtr<FJsonValue> FAnimationHandlers::AddPoseSearchSequence(const TSharedPt
 		return MCPError(FString::Printf(TEXT("Animation asset type not supported by PoseSearch: %s"), *AnimAsset->GetClass()->GetName()));
 	}
 
-	const int32 PrevCount = GetPoseSearchAssetCount(Database);
-	FPoseSearchDatabaseAnimationAsset NewEntry;
-	NewEntry.AnimAsset = AnimAsset;
+	const int32 PrevCount = GetPoseSearchAnimationAssetCount(Database);
 	Database->Modify();
-	Database->AddAnimationAsset(NewEntry);
+	FString AddError;
+	if (!AddPoseSearchAnimationAsset(Database, AnimAsset, AddError))
+	{
+		return MCPError(AddError);
+	}
 	Database->PostEditChange();
 	UEditorAssetLibrary::SaveLoadedAsset(Database);
 
-	const int32 NewCount = GetPoseSearchAssetCount(Database);
+	const int32 NewCount = GetPoseSearchAnimationAssetCount(Database);
 
 	TSharedPtr<FJsonObject> Res = MCPSuccess();
 	MCPSetUpdated(Res);
@@ -1200,12 +1248,13 @@ TSharedPtr<FJsonValue> FAnimationHandlers::BuildPoseSearchIndex(const TSharedPtr
 	UPoseSearchDatabase* Database = Cast<UPoseSearchDatabase>(UEditorAssetLibrary::LoadAsset(AssetPath));
 	if (!Database) return MCPError(FString::Printf(TEXT("PoseSearchDatabase not found: %s"), *AssetPath));
 	if (!Database->Schema) return MCPError(TEXT("Database has no Schema set — call set_pose_search_schema first"));
-	if (GetPoseSearchAssetCount(Database) == 0) return MCPError(TEXT("Database has no animation assets — call add_pose_search_sequence first"));
+	if (GetPoseSearchAnimationAssetCount(Database) == 0) return MCPError(TEXT("Database has no animation assets — call add_pose_search_sequence first"));
 
 	using namespace UE::PoseSearch;
 	const ERequestAsyncBuildFlag Flag = bWait
 		? (ERequestAsyncBuildFlag::NewRequest | ERequestAsyncBuildFlag::WaitForCompletion)
 		: ERequestAsyncBuildFlag::NewRequest;
+#if UE_MCP_HAS_POSESEARCH_DATABASE_ASSET_API
 	const EAsyncBuildIndexResult Result = FAsyncPoseSearchDatabasesManagement::RequestAsyncBuildIndex(Database, Flag);
 
 	FString ResultStr;
@@ -1216,6 +1265,10 @@ TSharedPtr<FJsonValue> FAnimationHandlers::BuildPoseSearchIndex(const TSharedPtr
 		case EAsyncBuildIndexResult::InProgress: ResultStr = TEXT("InProgress"); bSuccess = true; break;
 		case EAsyncBuildIndexResult::Failed:     ResultStr = TEXT("Failed"); break;
 	}
+#else
+	const bool bSuccess = FAsyncPoseSearchDatabasesManagement::RequestAsyncBuildIndex(Database, Flag);
+	const FString ResultStr = bSuccess ? TEXT("Success") : TEXT("Failed");
+#endif
 
 	UEditorAssetLibrary::SaveLoadedAsset(Database);
 
@@ -1225,7 +1278,7 @@ TSharedPtr<FJsonValue> FAnimationHandlers::BuildPoseSearchIndex(const TSharedPtr
 	Res->SetStringField(TEXT("path"), AssetPath);
 	Res->SetStringField(TEXT("result"), ResultStr);
 	Res->SetBoolField(TEXT("waitedForCompletion"), bWait);
-	Res->SetNumberField(TEXT("animationAssetCount"), GetPoseSearchAssetCount(Database));
+	Res->SetNumberField(TEXT("animationAssetCount"), GetPoseSearchAnimationAssetCount(Database));
 	return MCPResult(Res);
 }
 
@@ -1242,23 +1295,32 @@ TSharedPtr<FJsonValue> FAnimationHandlers::ReadPoseSearchDatabase(const TSharedP
 	Res->SetStringField(TEXT("path"), AssetPath);
 	Res->SetStringField(TEXT("name"), Database->GetName());
 	Res->SetStringField(TEXT("schemaPath"), Database->Schema ? Database->Schema->GetPathName() : FString());
+#if UE_MCP_HAS_POSESEARCH_DATABASE_ASSET_API
 	Res->SetNumberField(TEXT("continuingPoseCostBias"), Database->ContinuingPoseCostBias);
 	Res->SetNumberField(TEXT("baseCostBias"), Database->BaseCostBias);
 	Res->SetNumberField(TEXT("loopingCostBias"), Database->LoopingCostBias);
+#endif
 	Res->SetNumberField(TEXT("kdTreeQueryNumNeighbors"), Database->KDTreeQueryNumNeighbors);
 
-	const int32 AssetCount = GetPoseSearchAssetCount(Database);
+	const int32 AssetCount = GetPoseSearchAnimationAssetCount(Database);
 	Res->SetNumberField(TEXT("animationAssetCount"), AssetCount);
 
 	TArray<TSharedPtr<FJsonValue>> Animations;
 	for (int32 i = 0; i < AssetCount; ++i)
 	{
-		const FPoseSearchDatabaseAnimationAsset* Entry = Database->GetDatabaseAnimationAsset(i);
+#if UE_MCP_HAS_POSESEARCH_DATABASE_ASSET_API
+		const FPoseSearchDatabaseAnimationAssetBase* Entry = Database->GetDatabaseAnimationAsset<FPoseSearchDatabaseAnimationAssetBase>(i);
 		if (!Entry) continue;
+		UObject* AnimationAsset = Entry->GetAnimationAsset();
+#else
+		const FPoseSearchDatabaseAnimationAssetBase* Entry = Database->GetAnimationAssetBase(i);
+		if (!Entry) continue;
+		UObject* AnimationAsset = Entry->GetAnimationAsset();
+#endif
 		TSharedPtr<FJsonObject> A = MakeShared<FJsonObject>();
 		A->SetNumberField(TEXT("index"), i);
-		A->SetStringField(TEXT("assetPath"), Entry->AnimAsset ? Entry->AnimAsset->GetPathName() : FString());
-		A->SetStringField(TEXT("assetClass"), Entry->AnimAsset ? Entry->AnimAsset->GetClass()->GetName() : FString());
+		A->SetStringField(TEXT("assetPath"), AnimationAsset ? AnimationAsset->GetPathName() : FString());
+		A->SetStringField(TEXT("assetClass"), AnimationAsset ? AnimationAsset->GetClass()->GetName() : FString());
 		A->SetBoolField(TEXT("isLooping"), Entry->IsLooping());
 		A->SetBoolField(TEXT("isRootMotionEnabled"), Entry->IsRootMotionEnabled());
 		Animations.Add(MakeShared<FJsonValueObject>(A));
@@ -1266,7 +1328,9 @@ TSharedPtr<FJsonValue> FAnimationHandlers::ReadPoseSearchDatabase(const TSharedP
 	Res->SetArrayField(TEXT("animationAssets"), Animations);
 
 	TArray<TSharedPtr<FJsonValue>> Tags;
+#if UE_MCP_HAS_POSESEARCH_DATABASE_ASSET_API
 	for (const FName& T : Database->Tags) Tags.Add(MakeShared<FJsonValueString>(T.ToString()));
+#endif
 	Res->SetArrayField(TEXT("tags"), Tags);
 
 	if (Database->Schema)

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DemoHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DemoHandlers.cpp
@@ -17,10 +17,12 @@
 #include "IAssetTools.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "EditorAssetLibrary.h"
+#include "Factories/Factory.h"
 #include "UObject/UObjectGlobals.h"
 #include "UObject/Package.h"
 #include "UObject/SavePackage.h"
 #include "Misc/PackageName.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 // Static mesh actors / components
 #include "Engine/StaticMeshActor.h"
@@ -75,6 +77,19 @@
 // JSON
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
+
+namespace
+{
+	UFactory* CreateEditorFactoryByClassPath(const TCHAR* ClassPath)
+	{
+		UClass* FactoryClass = LoadObject<UClass>(nullptr, ClassPath);
+		if (!FactoryClass || !FactoryClass->IsChildOf(UFactory::StaticClass()))
+		{
+			return nullptr;
+		}
+		return NewObject<UFactory>(GetTransientPackage(), FactoryClass);
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -952,15 +967,26 @@ TSharedPtr<FJsonObject> FDemoHandlers::StepNiagaraVfx()
 		return Result;
 	}
 
-	// Create the system using the factory with the Fountain emitter pre-configured
+	// Create the system using the stock editor factory. The concrete factory
+	// class is NO_API in UE 5.5, so instantiate it reflectively.
 	FAssetToolsModule& AssetToolsModule = FModuleManager::LoadModuleChecked<FAssetToolsModule>(TEXT("AssetTools"));
 	IAssetTools& AssetTools = AssetToolsModule.Get();
 
-	UNiagaraSystemFactoryNew* Factory = NewObject<UNiagaraSystemFactoryNew>();
+	UFactory* Factory = CreateEditorFactoryByClassPath(TEXT("/Script/NiagaraEditor.NiagaraSystemFactoryNew"));
+	if (!Factory)
+	{
+		Result->SetStringField(TEXT("error"), TEXT("Could not create Niagara system factory"));
+		Result->SetBoolField(TEXT("success"), false);
+		return Result;
+	}
+
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4)
+	UNiagaraSystemFactoryNew* NiagaraFactory = static_cast<UNiagaraSystemFactoryNew*>(Factory);
 	FVersionedNiagaraEmitter VersionedEmitter;
 	VersionedEmitter.Emitter = FountainEmitter;
 	VersionedEmitter.Version = FountainEmitter->GetExposedVersion().VersionGuid;
-	Factory->EmittersToAddToNewSystem.Add(VersionedEmitter);
+	NiagaraFactory->EmittersToAddToNewSystem.Add(VersionedEmitter);
+#endif
 
 	UObject* NSAsset = AssetTools.CreateAsset(
 		TEXT("NS_Demo_Aura"), DemoConstants::MAT_DIR,
@@ -968,13 +994,11 @@ TSharedPtr<FJsonObject> FDemoHandlers::StepNiagaraVfx()
 	UNiagaraSystem* NiagaraSys = Cast<UNiagaraSystem>(NSAsset);
 	if (!NiagaraSys)
 	{
-		Result->SetStringField(TEXT("error"), TEXT("Failed to create NiagaraSystem from Fountain emitter"));
+		Result->SetStringField(TEXT("error"), TEXT("Failed to create NiagaraSystem"));
 		Result->SetBoolField(TEXT("success"), false);
 		return Result;
 	}
 
-	// Initialize and save
-	UNiagaraSystemFactoryNew::InitializeSystem(NiagaraSys, true);
 	UEditorAssetLibrary::SaveAsset(NiagaraSys->GetPathName());
 
 	// Spawn a dedicated actor and attach a NiagaraComponent with the system

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/MaterialHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/MaterialHandlers.cpp
@@ -3,6 +3,7 @@
 #include "HandlerRegistry.h"
 #include "HandlerUtils.h"
 #include "HandlerAssetCreate.h"
+#include "MaterialDomain.h"
 #include "Materials/Material.h"
 #include "Materials/MaterialInstance.h"
 #include "Materials/MaterialInstanceConstant.h"

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/NiagaraHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/NiagaraHandlers.cpp
@@ -24,7 +24,6 @@
 #include "NiagaraGraph.h"
 #include "NiagaraNodeFunctionCall.h"
 #include "NiagaraNodeCustomHlsl.h"
-#include "NiagaraScriptFactoryNew.h"
 #include "NiagaraEmitterHandle.h"
 #include "NiagaraEditorUtilities.h"
 #include "Editor.h"
@@ -35,6 +34,19 @@
 #include "EdGraph/EdGraph.h"
 #include "EdGraph/EdGraphPin.h"
 #include "EdGraph/EdGraphNode.h"
+
+namespace
+{
+	UFactory* CreateNiagaraEditorFactoryByClassPath(const TCHAR* ClassPath)
+	{
+		UClass* FactoryClass = LoadObject<UClass>(nullptr, ClassPath);
+		if (!FactoryClass || !FactoryClass->IsChildOf(UFactory::StaticClass()))
+		{
+			return nullptr;
+		}
+		return NewObject<UFactory>(GetTransientPackage(), FactoryClass);
+	}
+}
 
 void FNiagaraHandlers::RegisterHandlers(FMCPHandlerRegistry& Registry)
 {
@@ -1394,7 +1406,8 @@ TSharedPtr<FJsonValue> FNiagaraHandlers::CreateModuleFromHlsl(const TSharedPtr<F
 
 	// Use the stock module factory to create a baseline module with Param-map get/set scaffolding,
 	// then add a CustomHLSL node that carries the user's HLSL body.
-	UNiagaraModuleScriptFactory* Factory = NewObject<UNiagaraModuleScriptFactory>();
+	UFactory* Factory = CreateNiagaraEditorFactoryByClassPath(TEXT("/Script/NiagaraEditor.NiagaraModuleScriptFactory"));
+	if (!Factory) return MCPError(TEXT("Failed to create Niagara module factory. Ensure Niagara editor module is available."));
 	auto Created = MCPCreateAssetIdempotent<UNiagaraScript>(Name, PackagePath, OptionalString(Params, TEXT("onConflict"), TEXT("skip")), TEXT("NiagaraScript"), Factory);
 	if (Created.EarlyReturn) return Created.EarlyReturn;
 	UNiagaraScript* Script = Created.Asset;
@@ -1453,7 +1466,8 @@ TSharedPtr<FJsonValue> FNiagaraHandlers::CreateScratchModule(const TSharedPtr<FJ
 	FString PackagePath = OptionalString(Params, TEXT("packagePath"), TEXT("/Game/VFX"));
 
 	// Use the stock Niagara module factory to create a baseline module script
-	UNiagaraModuleScriptFactory* Factory = NewObject<UNiagaraModuleScriptFactory>();
+	UFactory* Factory = CreateNiagaraEditorFactoryByClassPath(TEXT("/Script/NiagaraEditor.NiagaraModuleScriptFactory"));
+	if (!Factory) return MCPError(TEXT("Failed to create Niagara module factory. Ensure Niagara editor module is available."));
 	auto Created = MCPCreateAssetIdempotent<UNiagaraScript>(Name, PackagePath, OptionalString(Params, TEXT("onConflict"), TEXT("skip")), TEXT("NiagaraScript"), Factory);
 	if (Created.EarlyReturn) return Created.EarlyReturn;
 	UNiagaraScript* Script = Created.Asset;

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/PCGHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/PCGHandlers.cpp
@@ -24,13 +24,6 @@
 #include "PCGVolume.h"
 #include "Elements/PCGStaticMeshSpawner.h"
 #include "MeshSelectors/PCGMeshSelectorWeighted.h"
-// UPCGEditorGraphNodeBase ships in the PCGEditor module starting in UE 5.5.
-// On 5.4 the editor-node-position round-trip is unavailable; we fall back to
-// the runtime UPCGNode::PositionX/Y instead (only populated when this bridge
-// authored the node).
-#if UE_MCP_HAS_5_5_API
-#include "Nodes/PCGEditorGraphNodeBase.h"
-#endif
 #include "UObject/UObjectIterator.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/Brush.h"
@@ -43,11 +36,19 @@
 #include "Misc/PackageName.h"
 #include "UObject/SavePackage.h"
 #include "GameFramework/Actor.h"
+#include "EdGraph/EdGraphNode.h"
 #include "UObject/UnrealType.h"
 #include "UObject/PropertyPortFlags.h"
 #include "UObject/SoftObjectPtr.h"
 #include "ScopedTransaction.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include <functional>
+
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4)
+#define UE_MCP_HAS_PCG_EDITOR_GRAPH_NODE_LAYOUT 1
+#else
+#define UE_MCP_HAS_PCG_EDITOR_GRAPH_NODE_LAYOUT 0
+#endif
 
 namespace
 {
@@ -1726,7 +1727,7 @@ TSharedPtr<FJsonValue> FPCGHandlers::ImportGraph(const TSharedPtr<FJsonObject>& 
 		// to the local id when nothing else in the graph already uses it.
 		if (!LocalName.IsEmpty() && NewNode->GetName() != LocalName)
 		{
-			const bool bClashes = (StaticFindObject(nullptr, NewNode->GetOuter(), *LocalName, EFindObjectFlags::ExactClass) != nullptr);
+			const bool bClashes = (StaticFindObject(nullptr, NewNode->GetOuter(), *LocalName, true) != nullptr);
 			if (!bClashes)
 			{
 				NewNode->Rename(*LocalName, NewNode->GetOuter(), REN_DontCreateRedirectors | REN_DoNotDirty);
@@ -1915,14 +1916,16 @@ TSharedPtr<FJsonValue> FPCGHandlers::ExportGraph(const TSharedPtr<FJsonObject>& 
 	// only populated when the node was authored through this bridge - the PCG
 	// editor never writes back to it. Build a lookup so editor-authored
 	// graphs round-trip their hand-laid-out positions.
-	// (5.4 lacks UPCGEditorGraphNodeBase; falls back to runtime PositionX/Y below.)
-#if UE_MCP_HAS_5_5_API
-	TMap<const UPCGNode*, const UPCGEditorGraphNodeBase*> EditorNodeByPCGNode;
-	for (TObjectIterator<UPCGEditorGraphNodeBase> It; It; ++It)
+	// Use reflection instead of including private PCG editor graph-node headers.
+#if UE_MCP_HAS_PCG_EDITOR_GRAPH_NODE_LAYOUT
+	TMap<const UPCGNode*, const UEdGraphNode*> EditorNodeByPCGNode;
+	for (TObjectIterator<UEdGraphNode> It; It; ++It)
 	{
-		const UPCGEditorGraphNodeBase* EdNode = *It;
+		const UEdGraphNode* EdNode = *It;
 		if (!EdNode || EdNode->IsTemplate()) continue;
-		const UPCGNode* PCGN = EdNode->GetPCGNode();
+		const FObjectPropertyBase* PCGNodeProp = FindFProperty<FObjectPropertyBase>(EdNode->GetClass(), TEXT("PCGNode"));
+		if (!PCGNodeProp) continue;
+		const UPCGNode* PCGN = Cast<UPCGNode>(PCGNodeProp->GetObjectPropertyValue_InContainer(EdNode));
 		if (!PCGN) continue;
 		if (PCGN->GetTypedOuter<UPCGGraph>() == Graph)
 		{
@@ -1941,8 +1944,8 @@ TSharedPtr<FJsonValue> FPCGHandlers::ExportGraph(const TSharedPtr<FJsonObject>& 
 
 		double PosX = Node->PositionX;
 		double PosY = Node->PositionY;
-#if UE_MCP_HAS_5_5_API
-		if (const UPCGEditorGraphNodeBase* const* EdNodePtr = EditorNodeByPCGNode.Find(Node); EdNodePtr && *EdNodePtr)
+#if UE_MCP_HAS_PCG_EDITOR_GRAPH_NODE_LAYOUT
+		if (const UEdGraphNode* const* EdNodePtr = EditorNodeByPCGNode.Find(Node); EdNodePtr && *EdNodePtr)
 		{
 			PosX = (*EdNodePtr)->NodePosX;
 			PosY = (*EdNodePtr)->NodePosY;

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/PCGHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/PCGHandlers.cpp
@@ -50,6 +50,8 @@
 #define UE_MCP_HAS_PCG_EDITOR_GRAPH_NODE_LAYOUT 0
 #endif
 
+#define UE_MCP_HAS_STATIC_FIND_OBJECT_FLAGS (ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7))
+
 namespace
 {
 	// #149: recursive JSON→FProperty setter used by set_pcg_node_settings.
@@ -1727,7 +1729,11 @@ TSharedPtr<FJsonValue> FPCGHandlers::ImportGraph(const TSharedPtr<FJsonObject>& 
 		// to the local id when nothing else in the graph already uses it.
 		if (!LocalName.IsEmpty() && NewNode->GetName() != LocalName)
 		{
+#if UE_MCP_HAS_STATIC_FIND_OBJECT_FLAGS
+			const bool bClashes = (StaticFindObject(nullptr, NewNode->GetOuter(), *LocalName, EFindObjectFlags::ExactClass) != nullptr);
+#else
 			const bool bClashes = (StaticFindObject(nullptr, NewNode->GetOuter(), *LocalName, true) != nullptr);
+#endif
 			if (!bClashes)
 			{
 				NewNode->Rename(*LocalName, NewNode->GetOuter(), REN_DontCreateRedirectors | REN_DoNotDirty);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/StateTreeHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/StateTreeHandlers.cpp
@@ -3,7 +3,7 @@
 #include "HandlerUtils.h"
 
 // StateTree authoring depends on UStateTreeEditingSubsystem (compile +
-// validate entry points) and the generic FPropertyBindingPath system, both
+// validate entry points) and editor property binding support, both
 // introduced in UE 5.5. On 5.4 we register no handlers and emit a one-line
 // log so the rest of the plugin still loads.
 #if UE_MCP_HAS_5_5_API
@@ -17,10 +17,9 @@
 #include "StateTreeCompilerLog.h"
 #include "StateTreeTypes.h"
 #include "StateTreeNodeBase.h"
-#include "PropertyBindingPath.h"
-#include "PropertyBindingTypes.h"
 
 #include "Editor.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "StructUtils/InstancedStruct.h"
 #include "UObject/UObjectIterator.h"
 #include "GameplayTagContainer.h"
@@ -28,6 +27,11 @@
 #include "StateTreeEvaluatorBase.h"
 #include "StateTreeTaskBase.h"
 #include "StateTreeEditorTypes.h"
+
+#define UE_MCP_HAS_STATETREE_STATE_DESCRIPTION (ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6))
+#define UE_MCP_HAS_STATETREE_STATE_CUSTOM_TICK_RATE (ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6))
+#define UE_MCP_HAS_STATETREE_COMPILER_TOKENIZED_MESSAGES (ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6))
+#define UE_MCP_HAS_STATETREE_EXECUTION_RUNTIME_DATA (ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6))
 
 #endif // UE_MCP_HAS_5_5_API
 
@@ -365,15 +369,19 @@ TSharedPtr<FJsonObject> FStateTreeHandlers::SerializeStateHierarchy(const UState
 	Obj->SetStringField(TEXT("type"), StateTypeToString(State->Type));
 	Obj->SetStringField(TEXT("selectionBehavior"), SelectionBehaviorToString(State->SelectionBehavior));
 	Obj->SetBoolField(TEXT("bEnabled"), State->bEnabled);
+#if UE_MCP_HAS_STATETREE_STATE_DESCRIPTION
 	Obj->SetStringField(TEXT("description"), State->Description);
+#endif
 	if (State->Tag.IsValid())
 	{
 		Obj->SetStringField(TEXT("tag"), State->Tag.ToString());
 	}
+#if UE_MCP_HAS_STATETREE_STATE_CUSTOM_TICK_RATE
 	if (State->bHasCustomTickRate)
 	{
 		Obj->SetNumberField(TEXT("customTickRate"), State->CustomTickRate);
 	}
+#endif
 	if (State->ColorRef.ID.IsValid())
 	{
 		const UStateTreeEditorData* EditorData = Cast<UStateTreeEditorData>(State->GetOuter());
@@ -531,10 +539,12 @@ static bool AddEditorNodeToArray(TArray<FStateTreeEditorNode>& Arr, const FStrin
 		EditorNode.Instance.InitializeAs(InstanceType);
 	}
 
+#if UE_MCP_HAS_STATETREE_EXECUTION_RUNTIME_DATA
 	if (const UScriptStruct* ExecType = Cast<const UScriptStruct>(Node.GetExecutionRuntimeDataType()))
 	{
 		EditorNode.ExecutionRuntimeData.InitializeAs(ExecType);
 	}
+#endif
 
 	if (InstanceProperties.IsValid() && EditorNode.Instance.IsValid())
 	{
@@ -573,6 +583,7 @@ bool FStateTreeHandlers::CompileAndSave(UStateTree* StateTree, TSharedPtr<FJsonO
 	TArray<TSharedPtr<FJsonValue>> Errors;
 	TArray<TSharedPtr<FJsonValue>> Warnings;
 
+#if UE_MCP_HAS_STATETREE_COMPILER_TOKENIZED_MESSAGES
 	for (const TSharedRef<FTokenizedMessage>& Msg : Log.ToTokenizedMessages())
 	{
 		FString MsgText = Msg->ToText().ToString();
@@ -586,6 +597,12 @@ bool FStateTreeHandlers::CompileAndSave(UStateTree* StateTree, TSharedPtr<FJsonO
 			Warnings.Add(MakeShared<FJsonValueString>(MsgText));
 		}
 	}
+#else
+	if (!bSuccess)
+	{
+		Errors.Add(MakeShared<FJsonValueString>(TEXT("CompileStateTree returned failure; detailed compiler diagnostics are not exposed by the UE 5.5 FStateTreeCompilerLog API.")));
+	}
+#endif
 
 	OutResult->SetArrayField(TEXT("errors"), Errors);
 	OutResult->SetArrayField(TEXT("warnings"), Warnings);
@@ -646,7 +663,7 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::ReadStateTree(const TSharedPtr<FJsonO
 	Result->SetArrayField(TEXT("globalTasks"), GTArr);
 
 	// Root Parameters
-	const FInstancedPropertyBag& RootParams = EditorData->GetRootParametersPropertyBag();
+	const FInstancedPropertyBag& RootParams = EditorData->RootParameters.Parameters;
 	if (RootParams.IsValid())
 	{
 		auto ParamsObj = MakeShared<FJsonObject>();
@@ -887,7 +904,11 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::SetStateProperty(const TSharedPtr<FJs
 	}
 	else if (PropName == TEXT("description"))
 	{
+#if UE_MCP_HAS_STATETREE_STATE_DESCRIPTION
 		State->Description = Value;
+#else
+		return MCPError(TEXT("State description is not available in this UE version"));
+#endif
 	}
 	else if (PropName == TEXT("tag"))
 	{
@@ -907,6 +928,7 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::SetStateProperty(const TSharedPtr<FJs
 	}
 	else if (PropName == TEXT("customTickRate"))
 	{
+#if UE_MCP_HAS_STATETREE_STATE_CUSTOM_TICK_RATE
 		if (Value.IsEmpty())
 		{
 			State->bHasCustomTickRate = false;
@@ -917,6 +939,9 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::SetStateProperty(const TSharedPtr<FJs
 			State->bHasCustomTickRate = true;
 			State->CustomTickRate = FCString::Atof(*Value);
 		}
+#else
+		return MCPError(TEXT("State customTickRate is not available in this UE version"));
+#endif
 	}
 	else if (PropName == TEXT("color"))
 	{
@@ -1792,14 +1817,14 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::AddBinding(const TSharedPtr<FJsonObje
 	const FString TargetStructIdStr = Params->GetStringField(TEXT("targetStructId"));
 	const FString TargetPathStr = Params->GetStringField(TEXT("targetPath"));
 
-	FPropertyBindingPath SourcePath;
+	FStateTreePropertyPath SourcePath;
 	SourcePath.SetStructID(ParseGuid(SourceStructIdStr));
 	if (!SourcePath.FromString(SourcePathStr))
 	{
 		return MCPError(FString::Printf(TEXT("Failed to parse source path: %s"), *SourcePathStr));
 	}
 
-	FPropertyBindingPath TargetPath;
+	FStateTreePropertyPath TargetPath;
 	TargetPath.SetStructID(ParseGuid(TargetStructIdStr));
 	if (!TargetPath.FromString(TargetPathStr))
 	{
@@ -1827,7 +1852,7 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::RemoveBinding(const TSharedPtr<FJsonO
 	const FString TargetStructIdStr = Params->GetStringField(TEXT("targetStructId"));
 	const FString TargetPathStr = Params->GetStringField(TEXT("targetPath"));
 
-	FPropertyBindingPath TargetPath;
+	FStateTreePropertyPath TargetPath;
 	TargetPath.SetStructID(ParseGuid(TargetStructIdStr));
 	if (!TargetPath.FromString(TargetPathStr))
 	{
@@ -1841,7 +1866,7 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::RemoveBinding(const TSharedPtr<FJsonO
 	}
 
 	EditorData->Modify();
-	Bindings->RemoveBindings(TargetPath);
+	Bindings->RemovePropertyBindings(TargetPath);
 
 	auto Result = MCPSuccess();
 	Result->SetBoolField(TEXT("removed"), true);
@@ -2066,7 +2091,7 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::AddStateParameter(const TSharedPtr<FJ
 	State->Modify();
 	TArray<FPropertyBagPropertyDesc> NewDescs;
 	NewDescs.Add(FPropertyBagPropertyDesc(FName(*ParamName), BagType));
-	State->Parameters.Parameters.AddProperties(NewDescs, /*bOverwrite=*/ false);
+	State->Parameters.Parameters.AddProperties(NewDescs);
 
 	UStateTreeEditingSubsystem::ValidateStateTree(ST);
 
@@ -2177,7 +2202,7 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::SetRootParameters(const TSharedPtr<FJ
 
 	const TArray<TSharedPtr<FJsonValue>>& ParamsArr = Params->GetArrayField(TEXT("parameters"));
 
-	TArray<UE::PropertyBinding::FPropertyCreationDescriptor> Descs;
+	TArray<FStateTreeEditorPropertyCreationDesc> Descs;
 	for (const TSharedPtr<FJsonValue>& PVal : ParamsArr)
 	{
 		const TSharedPtr<FJsonObject>& PObj = PVal->AsObject();
@@ -2194,12 +2219,12 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::SetRootParameters(const TSharedPtr<FJ
 		else if (TypeStr == TEXT("string")) BagType = EPropertyBagPropertyType::String;
 		else if (TypeStr == TEXT("double")) BagType = EPropertyBagPropertyType::Double;
 
-		UE::PropertyBinding::FPropertyCreationDescriptor& Desc = Descs.AddDefaulted_GetRef();
+		FStateTreeEditorPropertyCreationDesc& Desc = Descs.AddDefaulted_GetRef();
 		Desc.PropertyDesc = FPropertyBagPropertyDesc(FName(*PropName), BagType);
 	}
 
 	EditorData->Modify();
-	EditorData->CreateRootProperties(Descs);
+	EditorData->CreateParameters(EditorData->RootParameters.ID, Descs);
 
 	auto Result = MCPSuccess();
 	MCPSetUpdated(Result);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/StateTreeHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/StateTreeHandlers.cpp
@@ -20,6 +20,10 @@
 
 #include "Editor.h"
 #include "Runtime/Launch/Resources/Version.h"
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7)
+#include "PropertyBindingPath.h"
+#include "PropertyBindingTypes.h"
+#endif
 #include "StructUtils/InstancedStruct.h"
 #include "UObject/UObjectIterator.h"
 #include "GameplayTagContainer.h"
@@ -32,6 +36,15 @@
 #define UE_MCP_HAS_STATETREE_STATE_CUSTOM_TICK_RATE (ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6))
 #define UE_MCP_HAS_STATETREE_COMPILER_TOKENIZED_MESSAGES (ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6))
 #define UE_MCP_HAS_STATETREE_EXECUTION_RUNTIME_DATA (ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6))
+#define UE_MCP_HAS_STATETREE_GENERAL_PROPERTY_BINDING (ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7))
+
+#if UE_MCP_HAS_STATETREE_GENERAL_PROPERTY_BINDING
+using FUE_MCPStateTreePropertyPath = FPropertyBindingPath;
+using FUE_MCPStateTreePropertyCreationDesc = UE::PropertyBinding::FPropertyCreationDescriptor;
+#else
+using FUE_MCPStateTreePropertyPath = FStateTreePropertyPath;
+using FUE_MCPStateTreePropertyCreationDesc = FStateTreeEditorPropertyCreationDesc;
+#endif
 
 #endif // UE_MCP_HAS_5_5_API
 
@@ -663,7 +676,11 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::ReadStateTree(const TSharedPtr<FJsonO
 	Result->SetArrayField(TEXT("globalTasks"), GTArr);
 
 	// Root Parameters
+#if UE_MCP_HAS_STATETREE_GENERAL_PROPERTY_BINDING
+	const FInstancedPropertyBag& RootParams = EditorData->GetRootParametersPropertyBag();
+#else
 	const FInstancedPropertyBag& RootParams = EditorData->RootParameters.Parameters;
+#endif
 	if (RootParams.IsValid())
 	{
 		auto ParamsObj = MakeShared<FJsonObject>();
@@ -1817,14 +1834,14 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::AddBinding(const TSharedPtr<FJsonObje
 	const FString TargetStructIdStr = Params->GetStringField(TEXT("targetStructId"));
 	const FString TargetPathStr = Params->GetStringField(TEXT("targetPath"));
 
-	FStateTreePropertyPath SourcePath;
+	FUE_MCPStateTreePropertyPath SourcePath;
 	SourcePath.SetStructID(ParseGuid(SourceStructIdStr));
 	if (!SourcePath.FromString(SourcePathStr))
 	{
 		return MCPError(FString::Printf(TEXT("Failed to parse source path: %s"), *SourcePathStr));
 	}
 
-	FStateTreePropertyPath TargetPath;
+	FUE_MCPStateTreePropertyPath TargetPath;
 	TargetPath.SetStructID(ParseGuid(TargetStructIdStr));
 	if (!TargetPath.FromString(TargetPathStr))
 	{
@@ -1852,7 +1869,7 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::RemoveBinding(const TSharedPtr<FJsonO
 	const FString TargetStructIdStr = Params->GetStringField(TEXT("targetStructId"));
 	const FString TargetPathStr = Params->GetStringField(TEXT("targetPath"));
 
-	FStateTreePropertyPath TargetPath;
+	FUE_MCPStateTreePropertyPath TargetPath;
 	TargetPath.SetStructID(ParseGuid(TargetStructIdStr));
 	if (!TargetPath.FromString(TargetPathStr))
 	{
@@ -1866,7 +1883,11 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::RemoveBinding(const TSharedPtr<FJsonO
 	}
 
 	EditorData->Modify();
+#if UE_MCP_HAS_STATETREE_GENERAL_PROPERTY_BINDING
+	Bindings->RemoveBindings(TargetPath);
+#else
 	Bindings->RemovePropertyBindings(TargetPath);
+#endif
 
 	auto Result = MCPSuccess();
 	Result->SetBoolField(TEXT("removed"), true);
@@ -2091,7 +2112,11 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::AddStateParameter(const TSharedPtr<FJ
 	State->Modify();
 	TArray<FPropertyBagPropertyDesc> NewDescs;
 	NewDescs.Add(FPropertyBagPropertyDesc(FName(*ParamName), BagType));
+#if UE_MCP_HAS_STATETREE_GENERAL_PROPERTY_BINDING
+	State->Parameters.Parameters.AddProperties(NewDescs, /*bOverwrite=*/ false);
+#else
 	State->Parameters.Parameters.AddProperties(NewDescs);
+#endif
 
 	UStateTreeEditingSubsystem::ValidateStateTree(ST);
 
@@ -2202,7 +2227,7 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::SetRootParameters(const TSharedPtr<FJ
 
 	const TArray<TSharedPtr<FJsonValue>>& ParamsArr = Params->GetArrayField(TEXT("parameters"));
 
-	TArray<FStateTreeEditorPropertyCreationDesc> Descs;
+	TArray<FUE_MCPStateTreePropertyCreationDesc> Descs;
 	for (const TSharedPtr<FJsonValue>& PVal : ParamsArr)
 	{
 		const TSharedPtr<FJsonObject>& PObj = PVal->AsObject();
@@ -2219,12 +2244,16 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::SetRootParameters(const TSharedPtr<FJ
 		else if (TypeStr == TEXT("string")) BagType = EPropertyBagPropertyType::String;
 		else if (TypeStr == TEXT("double")) BagType = EPropertyBagPropertyType::Double;
 
-		FStateTreeEditorPropertyCreationDesc& Desc = Descs.AddDefaulted_GetRef();
+		FUE_MCPStateTreePropertyCreationDesc& Desc = Descs.AddDefaulted_GetRef();
 		Desc.PropertyDesc = FPropertyBagPropertyDesc(FName(*PropName), BagType);
 	}
 
 	EditorData->Modify();
+#if UE_MCP_HAS_STATETREE_GENERAL_PROPERTY_BINDING
+	EditorData->CreateRootProperties(Descs);
+#else
 	EditorData->CreateParameters(EditorData->RootParameters.ID, Descs);
+#endif
 
 	auto Result = MCPSuccess();
 	MCPSetUpdated(Result);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/WidgetHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/WidgetHandlers.cpp
@@ -537,10 +537,8 @@ TSharedPtr<FJsonValue> FWidgetHandlers::AddWidget(const TSharedPtr<FJsonObject>&
 		}
 	}
 
-	// Register widget GUID so the compiler doesn't assert.
-	// WidgetVariableNameToGuidMap was added in UE 5.5; the assert it dodges
-	// only exists in 5.5+, so the registration is unnecessary on 5.4.
-#if UE_MCP_HAS_5_5_API
+	// UE 5.4 exposed this map; UE 5.5 removed it from UWidgetBlueprint.
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION == 4
 	if (!WidgetBP->WidgetVariableNameToGuidMap.Contains(NewWidget->GetFName()))
 	{
 		WidgetBP->WidgetVariableNameToGuidMap.Add(NewWidget->GetFName(), FGuid::NewGuid());

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/PIE/PIEInputRecorder.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/PIE/PIEInputRecorder.cpp
@@ -19,7 +19,7 @@ namespace UEMCPPIE
 {
 	namespace
 	{
-		FString ISOTimestampNow()
+		FString RecorderISOTimestampNow()
 		{
 			// Approximate ISO 8601 UTC. UE's FDateTime has no timezone awareness,
 			// so we treat it as local and append the local offset.
@@ -158,7 +158,7 @@ namespace UEMCPPIE
 		ActorRows.Reset();
 		Markers.Reset();
 		StartTime = FPlatformTime::Seconds();
-		StartedAt = ISOTimestampNow();
+		StartedAt = RecorderISOTimestampNow();
 
 		State = ERecorderState::WaitingForPawn;
 
@@ -432,7 +432,7 @@ namespace UEMCPPIE
 		FManifest M;
 		M.Id = CurrentId;
 		M.StartedAt = StartedAt;
-		M.EndedAt = ISOTimestampNow();
+		M.EndedAt = RecorderISOTimestampNow();
 		M.DurationSeconds = Rows.Num() >= 2 ? (Rows.Last().Time - Rows[0].Time) : 0.0;
 		M.TotalFrames = Rows.Num();
 		M.SampleHz = Pending.SampleHz;

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/PIE/PIEInputReplayer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/PIE/PIEInputReplayer.cpp
@@ -23,7 +23,7 @@ namespace UEMCPPIE
 {
 	namespace
 	{
-		FString ISOTimestampNow()
+		FString ReplayerISOTimestampNow()
 		{
 			return FDateTime::Now().ToString(TEXT("%Y-%m-%dT%H:%M:%S"));
 		}
@@ -348,7 +348,7 @@ namespace UEMCPPIE
 
 		State = EReplayerState::WaitingForPawn;
 		AttachTime = 0.0;
-		StartedAt = ISOTimestampNow();
+		StartedAt = ReplayerISOTimestampNow();
 
 		if (!bEndFrameBound)
 		{

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
@@ -5,6 +5,8 @@ public class UE_MCP_Bridge : ModuleRules
 	public UE_MCP_Bridge(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+		bUseUnity = false;
+		ShadowVariableWarningLevel = WarningLevel.Off;
 
 		PublicDependencyModuleNames.AddRange(
 			new string[]
@@ -57,22 +59,25 @@ public class UE_MCP_Bridge : ModuleRules
 				"MaterialEditor",
 				"MovieScene",
 				"MovieSceneTracks",
+				"MeshDescription",
 				"NavigationSystem",
 				"Niagara",
 				"NiagaraEditor",
 				"PCG",
 				"PCGEditor",
-			"PoseSearch",
-			"PropertyBindingUtils",
-			"PropertyEditor",
+				"PoseSearch",
+				"PropertyBindingUtils",
+				"PropertyEditor",
 				"PythonScriptPlugin",
 				"Sequencer",
 				"Slate",
 				"SlateCore",
-			"StateTreeModule",
-			"StateTreeEditorModule",
-			"SubobjectDataInterface",
-			"ToolMenus",
+				"StructUtils",
+				"StateTreeModule",
+				"StateTreeEditorModule",
+				"StaticMeshDescription",
+				"SubobjectDataInterface",
+				"ToolMenus",
 				"UMG",
 				"UMGEditor",
 				"UnrealEd",

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
@@ -5,8 +5,6 @@ public class UE_MCP_Bridge : ModuleRules
 	public UE_MCP_Bridge(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-		bUseUnity = false;
-		ShadowVariableWarningLevel = WarningLevel.Off;
 
 		PublicDependencyModuleNames.AddRange(
 			new string[]

--- a/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
+++ b/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
@@ -68,6 +68,10 @@
 			"Enabled": true
 		},
 		{
+			"Name": "StructUtils",
+			"Enabled": true
+		},
+		{
 			"Name": "StateTree",
 			"Enabled": true
 		}


### PR DESCRIPTION
## Summary

- Add UE 5.5-compatible guards/paths for PoseSearch, IK Retargeter, StateTree, PCG graph layout, Widget Blueprint GUID handling, and Niagara editor factories.
- Add missing build dependencies needed by the non-unity bridge build.
- Add the material-domain include needed by UE 5.5 non-unity compilation.
- Use reflected/lazy factory creation where direct editor factory symbols are not link-safe.

## Why

Some bridge handlers assume APIs or exported symbols from newer engine versions. These guards keep the bridge buildable against UE 5.5 while preserving the newer paths where available.

## Validation

- `npx tsc --noEmit`
- `git diff --check`
- UE 5.5.4 `RunUAT BuildPlugin -TargetPlatforms=Win64` succeeded

## Notes

The UE 5.5.4 build emits existing warnings for `StructUtils` deprecation and Recast navmesh fields, but completes successfully.