### PR TITLE
Add Codex client configuration to init

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The interactive setup will:
 2. Let you choose which tool categories to enable
 3. Deploy the C++ bridge plugin to your project
 4. Enable required UE plugins (Niagara, PCG, GAS, etc.)
-5. Detect and configure your MCP client (Claude Code, Claude Desktop, Cursor)
+5. Detect and configure your MCP client (Claude Code, Claude Desktop, Cursor, Codex)
 
 Restart the editor once after setup to load the bridge plugin. To update later: `npx ue-mcp update`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,16 @@ The easiest way to configure UE-MCP is to run `npx ue-mcp init` — it detects y
 }
 ```
 
+Codex uses TOML instead:
+
+```toml
+[mcp_servers.ue-mcp]
+command = "npx"
+args = ["ue-mcp", "C:/path/to/MyGame.uproject"]
+cwd = "C:/path/to"
+enabled = true
+```
+
 ### Where to Put This
 
 | Client | Config File |
@@ -24,6 +34,7 @@ The easiest way to configure UE-MCP is to run `npx ue-mcp init` — it detects y
 | Claude Code | `.mcp.json` in project root, or `~/.claude/` global config |
 | Claude Desktop | `claude_desktop_config.json` |
 | Cursor | `mcp.json` in `.cursor/` or project root |
+| Codex | `~/.codex/config.toml` |
 
 ### Without a Project Path
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,7 +27,7 @@ The wizard then:
 3. Copies the C++ bridge plugin into `<YourProject>/Plugins/UE_MCP_Bridge/`.
 4. Enables the plugins it needs in your `.uproject`: `UE_MCP_Bridge`, `PythonScriptPlugin`, plus any of `Niagara`, `PCG`, `GameplayAbilities`, `EnhancedInput` required by the categories you kept.
 5. Scaffolds an empty `ue-mcp.yml` (for custom flows) if missing.
-6. Detects installed MCP clients (Claude Code project + global, Claude Desktop, Cursor) and writes the config for each you confirm. Global/Desktop configs default unchecked since opting them in affects every project on the machine.
+6. Detects installed MCP clients (Claude Code project + global, Claude Desktop, Cursor, Codex) and writes the config for each you confirm. Global/Desktop configs default unchecked since opting them in affects every project on the machine.
 7. Asks about **agent behavior** (all default off on fresh installs — blasting through with Enter adds no surprises): enable the `feedback(submit)` tool, install the Claude-Code-only PostToolUse hook that nudges the agent to offer feedback after `execute_python`, install bundled Claude Code workflow skills.
 8. If you opted into the feedback prompt hook, optionally runs the **GitHub OAuth device flow** so `feedback(submit)` can author issues as your real GitHub user (default `author="user"`). The token is cached at `~/.ue-mcp/auth.json` (mode 600) and reused. Skip if you don't want it now — you can run `npx ue-mcp auth` later, or call `feedback(submit)` with `author="bot"` to post anonymously instead.
 9. Writes the final `ue-mcp.yml` and prints a recap of every file or directory init touched. Per-machine state (e.g. the list of Claude Code settings files where the feedback hook was installed) is kept under `~/.ue-mcp/`, not in the project tree.
@@ -180,6 +180,17 @@ If you'd rather skip `npx ue-mcp init`, edit the MCP client config yourself.
         }
       }
     }
+    ```
+
+=== "Codex"
+
+    `~/.codex/config.toml`:
+    ```toml
+    [mcp_servers.ue-mcp]
+    command = "npx"
+    args = ["ue-mcp", "C:/path/to/MyGame.uproject"]
+    cwd = "C:/path/to"
+    enabled = true
     ```
 
 The first run auto-deploys the C++ plugin. To deploy explicitly: `npx ue-mcp update <path>`, then restart the editor.

--- a/src/init.ts
+++ b/src/init.ts
@@ -13,6 +13,7 @@ import { checkboxSelect, singleSelect, type CheckboxItem } from "./ui/select.js"
 import { installClaudeHooks, uninstallClaudeHooks } from "./hook-installer.js";
 import { runFeedbackAuthStep } from "./auth-cli.js";
 import { getInstalledHooks } from "./user-state.js";
+import { detectMcpClients, isProjectScopedClient, writeMcpConfig } from "./mcp-client-config.js";
 
 /* ------------------------------------------------------------------ */
 /*  Tool categories                                                    */
@@ -51,96 +52,6 @@ const CATEGORIES: ToolCategory[] = [
   // (gated by user approval, but worth surfacing explicitly).
   { name: "feedback",   label: "feedback",      alwaysOn: true },
 ];
-
-/* ------------------------------------------------------------------ */
-/*  MCP client detection                                               */
-/* ------------------------------------------------------------------ */
-
-interface McpClient {
-  name: string;
-  configPath: string;
-  detected: boolean;
-}
-
-/**
- * Project-scoped clients write their MCP config alongside the .uproject,
- * so enabling them only affects this project. Global/Desktop configs touch
- * every project the user opens — they should not be opted in by default.
- */
-function isProjectScopedClient(clientName: string): boolean {
-  return clientName.includes("(project)") || clientName === "Cursor";
-}
-
-function detectMcpClients(projectDir: string): McpClient[] {
-  const home = process.env.HOME || process.env.USERPROFILE || "";
-  const clients: McpClient[] = [];
-
-  const claudeProjectMcp = path.join(projectDir, ".mcp.json");
-  const claudeGlobalMcp = path.join(home, ".claude", ".mcp.json");
-  // "Detected" for both Claude Code scopes means "Claude Code is installed
-  // anywhere on this machine." If we gated project-scope detection on the
-  // project's .mcp.json already existing, first-time users in a fresh
-  // project would never see the project-scope checkbox and would be
-  // funneled into global scope by elimination. Show both scopes whenever
-  // Claude Code has been opened at least once; let the user pick.
-  const claudeInstalled =
-    fs.existsSync(claudeProjectMcp) ||
-    fs.existsSync(path.dirname(claudeGlobalMcp));
-  clients.push({
-    name: "Claude Code (project)",
-    configPath: claudeProjectMcp,
-    detected: claudeInstalled,
-  });
-  clients.push({
-    name: "Claude Code (global)",
-    configPath: claudeGlobalMcp,
-    detected: claudeInstalled,
-  });
-
-  const appData =
-    process.env.APPDATA || path.join(home, "AppData", "Roaming");
-  const claudeDesktop = path.join(
-    appData,
-    "Claude",
-    "claude_desktop_config.json",
-  );
-  clients.push({
-    name: "Claude Desktop",
-    configPath: claudeDesktop,
-    detected: fs.existsSync(path.dirname(claudeDesktop)),
-  });
-
-  const cursorMcp = path.join(projectDir, ".cursor", "mcp.json");
-  clients.push({
-    name: "Cursor",
-    configPath: cursorMcp,
-    detected: fs.existsSync(path.join(projectDir, ".cursor")),
-  });
-
-  return clients;
-}
-
-function writeMcpConfig(configPath: string, uprojectPath: string): void {
-  let existing: Record<string, unknown> = {};
-  if (fs.existsSync(configPath)) {
-    try {
-      existing = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-    } catch (e) {
-      logWarn("init", `MCP client config at ${configPath} was not valid JSON - overwriting with a fresh ue-mcp entry`, e);
-    }
-  }
-
-  const mcpServers = (existing.mcpServers ?? {}) as Record<string, unknown>;
-  mcpServers["ue-mcp"] = {
-    command: "npx",
-    args: ["ue-mcp", uprojectPath.replace(/\\/g, "/")],
-  };
-  existing.mcpServers = mcpServers;
-
-  const dir = path.dirname(configPath);
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(configPath, JSON.stringify(existing, null, 2));
-}
 
 /* ------------------------------------------------------------------ */
 /*  ue-mcp.yml config writer                                            */
@@ -422,7 +333,7 @@ async function init() {
 
     for (let i = 0; i < detected.length; i++) {
       if (clientStates[i]) {
-        writeMcpConfig(detected[i].configPath, project.projectPath!);
+        writeMcpConfig(detected[i], project.projectPath!);
         ok(`${detected[i].name} configured`);
         wrote.push({
           what: `${detected[i].name} MCP server entry`,

--- a/src/mcp-client-config.ts
+++ b/src/mcp-client-config.ts
@@ -128,7 +128,7 @@ export function upsertCodexMcpServer(existingToml: string, uprojectPath: string)
     "[mcp_servers.ue-mcp]",
     'command = "npx"',
     `args = ["ue-mcp", ${tomlString(toMcpPath(uprojectPath))}]`,
-    `cwd = ${tomlString(toMcpPath(path.dirname(uprojectPath)))}`,
+    `cwd = ${tomlString(toMcpPath(getProjectDir(uprojectPath)))}`,
     "enabled = true",
   ].join("\n");
 
@@ -163,6 +163,16 @@ function getTomlTableName(trimmedLine: string): string | undefined {
 
 function toMcpPath(value: string): string {
   return value.replace(/\\/g, "/");
+}
+
+function getProjectDir(uprojectPath: string): string {
+  return looksLikeWindowsPath(uprojectPath)
+    ? path.win32.dirname(uprojectPath)
+    : path.posix.dirname(uprojectPath);
+}
+
+function looksLikeWindowsPath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.includes("\\");
 }
 
 function tomlString(value: string): string {

--- a/src/mcp-client-config.ts
+++ b/src/mcp-client-config.ts
@@ -1,0 +1,170 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { warn as logWarn } from "./log.js";
+
+export type McpClientConfigFormat = "json" | "toml";
+
+export interface McpClient {
+  name: string;
+  configPath: string;
+  detected: boolean;
+  format: McpClientConfigFormat;
+}
+
+/**
+ * Project-scoped clients write their MCP config alongside the .uproject,
+ * so enabling them only affects this project. Global/Desktop configs touch
+ * every project the user opens — they should not be opted in by default.
+ */
+export function isProjectScopedClient(clientName: string): boolean {
+  return clientName.includes("(project)") || clientName === "Cursor";
+}
+
+export function detectMcpClients(projectDir: string): McpClient[] {
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  const clients: McpClient[] = [];
+
+  const claudeProjectMcp = path.join(projectDir, ".mcp.json");
+  const claudeGlobalMcp = path.join(home, ".claude", ".mcp.json");
+  // "Detected" for both Claude Code scopes means "Claude Code is installed
+  // anywhere on this machine." If we gated project-scope detection on the
+  // project's .mcp.json already existing, first-time users in a fresh
+  // project would never see the project-scope checkbox and would be
+  // funneled into global scope by elimination. Show both scopes whenever
+  // Claude Code has been opened at least once; let the user pick.
+  const claudeInstalled =
+    fs.existsSync(claudeProjectMcp) ||
+    fs.existsSync(path.dirname(claudeGlobalMcp));
+  clients.push({
+    name: "Claude Code (project)",
+    configPath: claudeProjectMcp,
+    detected: claudeInstalled,
+    format: "json",
+  });
+  clients.push({
+    name: "Claude Code (global)",
+    configPath: claudeGlobalMcp,
+    detected: claudeInstalled,
+    format: "json",
+  });
+
+  const appData =
+    process.env.APPDATA || path.join(home, "AppData", "Roaming");
+  const claudeDesktop = path.join(
+    appData,
+    "Claude",
+    "claude_desktop_config.json",
+  );
+  clients.push({
+    name: "Claude Desktop",
+    configPath: claudeDesktop,
+    detected: fs.existsSync(path.dirname(claudeDesktop)),
+    format: "json",
+  });
+
+  const cursorMcp = path.join(projectDir, ".cursor", "mcp.json");
+  clients.push({
+    name: "Cursor",
+    configPath: cursorMcp,
+    detected: fs.existsSync(path.join(projectDir, ".cursor")),
+    format: "json",
+  });
+
+  const codexConfig = path.join(home, ".codex", "config.toml");
+  clients.push({
+    name: "Codex",
+    configPath: codexConfig,
+    detected: fs.existsSync(path.dirname(codexConfig)),
+    format: "toml",
+  });
+
+  return clients;
+}
+
+export function writeMcpConfig(client: McpClient, uprojectPath: string): void {
+  if (client.format === "toml") {
+    writeCodexMcpConfig(client.configPath, uprojectPath);
+  } else {
+    writeJsonMcpConfig(client.configPath, uprojectPath);
+  }
+}
+
+export function writeJsonMcpConfig(configPath: string, uprojectPath: string): void {
+  let existing: Record<string, unknown> = {};
+  if (fs.existsSync(configPath)) {
+    try {
+      existing = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    } catch (e) {
+      logWarn("init", `MCP client config at ${configPath} was not valid JSON - overwriting with a fresh ue-mcp entry`, e);
+    }
+  }
+
+  const mcpServers = (existing.mcpServers ?? {}) as Record<string, unknown>;
+  mcpServers["ue-mcp"] = {
+    command: "npx",
+    args: ["ue-mcp", toMcpPath(uprojectPath)],
+  };
+  existing.mcpServers = mcpServers;
+
+  const dir = path.dirname(configPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(existing, null, 2));
+}
+
+export function writeCodexMcpConfig(configPath: string, uprojectPath: string): void {
+  const existing = fs.existsSync(configPath)
+    ? fs.readFileSync(configPath, "utf-8")
+    : "";
+  const next = upsertCodexMcpServer(existing, uprojectPath);
+
+  const dir = path.dirname(configPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(configPath, next, "utf-8");
+}
+
+export function upsertCodexMcpServer(existingToml: string, uprojectPath: string): string {
+  const withoutExisting = removeTomlTable(existingToml, "mcp_servers.ue-mcp").trimEnd();
+  const block = [
+    "[mcp_servers.ue-mcp]",
+    'command = "npx"',
+    `args = ["ue-mcp", ${tomlString(toMcpPath(uprojectPath))}]`,
+    `cwd = ${tomlString(toMcpPath(path.dirname(uprojectPath)))}`,
+    "enabled = true",
+  ].join("\n");
+
+  return `${withoutExisting}${withoutExisting ? "\n\n" : ""}${block}\n`;
+}
+
+function removeTomlTable(toml: string, tableName: string): string {
+  const lines = toml.split(/\r?\n/);
+  const output: string[] = [];
+  let removing = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const currentTable = getTomlTableName(trimmed);
+    if (currentTable) {
+      removing = currentTable === tableName || currentTable.startsWith(`${tableName}.`);
+      if (removing) continue;
+    }
+    if (!removing) output.push(line);
+  }
+
+  return output.join("\n");
+}
+
+function getTomlTableName(trimmedLine: string): string | undefined {
+  const singleTable = trimmedLine.match(/^\[([^\[\]]+)\]$/);
+  if (singleTable) return singleTable[1].trim();
+
+  const arrayTable = trimmedLine.match(/^\[\[([^\[\]]+)\]\]$/);
+  return arrayTable ? arrayTable[1].trim() : undefined;
+}
+
+function toMcpPath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function tomlString(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}

--- a/tests/unit/mcp-client-config.test.ts
+++ b/tests/unit/mcp-client-config.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  detectMcpClients,
+  isProjectScopedClient,
+  upsertCodexMcpServer,
+  writeCodexMcpConfig,
+  writeJsonMcpConfig,
+} from "../../src/mcp-client-config.js";
+
+let tmpRoot: string;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+let originalAppData: string | undefined;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-client-config-test-"));
+  originalHome = process.env.HOME;
+  originalUserProfile = process.env.USERPROFILE;
+  originalAppData = process.env.APPDATA;
+  process.env.HOME = tmpRoot;
+  process.env.USERPROFILE = tmpRoot;
+  delete process.env.APPDATA;
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  if (originalAppData === undefined) delete process.env.APPDATA;
+  else process.env.APPDATA = originalAppData;
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("MCP client config detection", () => {
+  it("detects Codex when ~/.codex exists", () => {
+    const projectDir = path.join(tmpRoot, "project");
+    fs.mkdirSync(projectDir);
+    fs.mkdirSync(path.join(tmpRoot, ".codex"));
+
+    const codex = detectMcpClients(projectDir).find((client) => client.name === "Codex");
+
+    expect(codex).toMatchObject({
+      configPath: path.join(tmpRoot, ".codex", "config.toml"),
+      detected: true,
+      format: "toml",
+    });
+    expect(isProjectScopedClient("Codex")).toBe(false);
+  });
+});
+
+describe("JSON MCP client config", () => {
+  it("writes the existing mcpServers shape for JSON clients", () => {
+    const configPath = path.join(tmpRoot, "project", ".mcp.json");
+
+    writeJsonMcpConfig(configPath, "C:\\Projects\\MyGame\\MyGame.uproject");
+
+    const config = JSON.parse(fs.readFileSync(configPath, "utf-8")) as {
+      mcpServers: Record<string, { command: string; args: string[] }>;
+    };
+    expect(config.mcpServers["ue-mcp"]).toEqual({
+      command: "npx",
+      args: ["ue-mcp", "C:/Projects/MyGame/MyGame.uproject"],
+    });
+  });
+});
+
+describe("Codex MCP client config", () => {
+  it("appends a Codex TOML server block and preserves unrelated settings", () => {
+    const input = [
+      'model = "gpt-5"',
+      "",
+      "[profiles.default]",
+      'approval_policy = "on-request"',
+      "",
+    ].join("\n");
+
+    const result = upsertCodexMcpServer(input, "C:\\Projects\\MyGame\\MyGame.uproject");
+
+    expect(result).toContain('model = "gpt-5"');
+    expect(result).toContain("[profiles.default]");
+    expect(result).toContain("[mcp_servers.ue-mcp]");
+    expect(result).toContain('command = "npx"');
+    expect(result).toContain('args = ["ue-mcp", "C:/Projects/MyGame/MyGame.uproject"]');
+    expect(result).toContain('cwd = "C:/Projects/MyGame"');
+    expect(result).toContain("enabled = true");
+  });
+
+  it("replaces only an existing ue-mcp Codex TOML server block", () => {
+    const input = [
+      "[mcp_servers.other]",
+      'command = "node"',
+      "",
+      "[mcp_servers.ue-mcp]",
+      'command = "old"',
+      'args = ["old"]',
+      "",
+      "[mcp_servers.ue-mcp.env]",
+      'UE_MCP_BRIDGE_PORT = "9999"',
+      "",
+      "[profiles.default]",
+      'sandbox_mode = "workspace-write"',
+      "",
+    ].join("\n");
+
+    const result = upsertCodexMcpServer(input, "/home/alex/Game/Game.uproject");
+
+    expect(result).toContain("[mcp_servers.other]");
+    expect(result).toContain('command = "node"');
+    expect(result).toContain("[profiles.default]");
+    expect(result).toContain('sandbox_mode = "workspace-write"');
+    expect(result).not.toContain('command = "old"');
+    expect(result).not.toContain('UE_MCP_BRIDGE_PORT = "9999"');
+    expect(result).toContain('args = ["ue-mcp", "/home/alex/Game/Game.uproject"]');
+    expect(result).toContain('cwd = "/home/alex/Game"');
+  });
+
+  it("writes Codex config.toml to disk", () => {
+    const configPath = path.join(tmpRoot, ".codex", "config.toml");
+
+    writeCodexMcpConfig(configPath, "M:\\Game\\Game.uproject");
+
+    const result = fs.readFileSync(configPath, "utf-8");
+    expect(result).toContain("[mcp_servers.ue-mcp]");
+    expect(result).toContain('args = ["ue-mcp", "M:/Game/Game.uproject"]');
+  });
+});

--- a/tests/unit/mcp-client-config.test.ts
+++ b/tests/unit/mcp-client-config.test.ts
@@ -6,6 +6,7 @@ import {
   detectMcpClients,
   isProjectScopedClient,
   upsertCodexMcpServer,
+  writeMcpConfig,
   writeCodexMcpConfig,
   writeJsonMcpConfig,
 } from "../../src/mcp-client-config.js";
@@ -126,5 +127,24 @@ describe("Codex MCP client config", () => {
     const result = fs.readFileSync(configPath, "utf-8");
     expect(result).toContain("[mcp_servers.ue-mcp]");
     expect(result).toContain('args = ["ue-mcp", "M:/Game/Game.uproject"]');
+    expect(result).toContain('cwd = "M:/Game"');
+  });
+
+  it("detects and writes Codex config through the init client path without touching the real home", () => {
+    const projectDir = path.join(tmpRoot, "Territory");
+    fs.mkdirSync(projectDir);
+    fs.mkdirSync(path.join(tmpRoot, ".codex"));
+
+    const codex = detectMcpClients(projectDir).find((client) => client.name === "Codex");
+    expect(codex).toBeDefined();
+
+    writeMcpConfig(codex!, "M:\\PerforceWorkspace\\Territory\\Territory.uproject");
+
+    const result = fs.readFileSync(path.join(tmpRoot, ".codex", "config.toml"), "utf-8");
+    expect(result).toContain("[mcp_servers.ue-mcp]");
+    expect(result).toContain('command = "npx"');
+    expect(result).toContain('args = ["ue-mcp", "M:/PerforceWorkspace/Territory/Territory.uproject"]');
+    expect(result).toContain('cwd = "M:/PerforceWorkspace/Territory"');
+    expect(result).toContain("enabled = true");
   });
 });


### PR DESCRIPTION
## Summary
- detect Codex installs during `ue-mcp init` via `~/.codex/config.toml`
- write/update Codex TOML while preserving unrelated config and replacing stale `ue-mcp` entries
- move MCP client config helpers out of `init.ts` and document the Codex config shape

## Tests
- `npx vitest run tests/unit/mcp-client-config.test.ts`
- `npx tsc --noEmit`
- `npm run test:unit`

Closes #496