### PR TITLE
Add StringTable asset tools

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -87,6 +87,13 @@ UE-MCP exposes **<!-- count:tools -->21<!-- /count --> category tools** covering
 | `list_textures` | List textures. Params: `directory?, recursive?` |
 | `get_texture_info` | Get texture details. Params: `assetPath` |
 | `set_texture_settings` | Set texture settings. Params: `assetPath, settings (object with compressionSettings?, lodGroup?, sRGB?, neverStream?)` |
+| `create_stringtable` | Create a StringTable asset. Params: `name, packagePath?, namespace?, onConflict?` |
+| `read_stringtable` | Read StringTable entries and keys. Params: `assetPath, keyFilter?` |
+| `list_stringtable_keys` | List StringTable keys. Params: `assetPath, keyFilter?` |
+| `get_stringtable_entry` | Read one StringTable entry. Params: `assetPath, key` |
+| `set_stringtable_entry` | Create or update one StringTable entry. Params: `assetPath, key, sourceString (or value)` |
+| `remove_stringtable_entry` | Remove one StringTable entry. Idempotent (alreadyDeleted=true if missing). Params: `assetPath, key` |
+| `import_stringtable` | Import StringTable entries from CSV. Params: `assetPath, filePath (or csvPath)` |
 | `add_input_mapping` | Append an Enhanced Input key mapping to an InputMappingContext (InputAction + key by name string e.g. 'Mouse2D','LeftMouseButton'). Idempotent on (action,key). For modifiers/triggers use gameplay(set_mapping_modifiers). Same as gameplay(add_imc_mapping) (#525). Params: `mappingContext (IMC path), inputAction (IA path), key` |
 | `remove_input_mapping` | Remove an IMC key mapping. Same as gameplay(remove_imc_mapping) (#525). Params: `mappingContext (IMC path), mappingIndex? \\| (inputAction? + key?)` |
 | `list_input_mappings` | List an IMC's key->action bindings with triggers/modifiers. Same as gameplay(read_imc) (#525). Params: `mappingContext (IMC path)` |

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers.cpp
@@ -215,6 +215,15 @@ void FAssetHandlers::RegisterHandlers(FMCPHandlerRegistry& Registry)
 	Registry.RegisterHandler(TEXT("reimport_asset"), &ReimportAsset);
 	Registry.RegisterHandler(TEXT("export_asset"), &ExportAsset);
 
+	// StringTable handlers
+	Registry.RegisterHandler(TEXT("create_stringtable"), &CreateStringTable);
+	Registry.RegisterHandler(TEXT("read_stringtable"), &ReadStringTable);
+	Registry.RegisterHandler(TEXT("list_stringtable_keys"), &ListStringTableKeys);
+	Registry.RegisterHandler(TEXT("get_stringtable_entry"), &GetStringTableEntry);
+	Registry.RegisterHandler(TEXT("set_stringtable_entry"), &SetStringTableEntry);
+	Registry.RegisterHandler(TEXT("remove_stringtable_entry"), &RemoveStringTableEntry);
+	Registry.RegisterHandler(TEXT("import_stringtable"), &ImportStringTable);
+
 	// v0.7.8 stubs — FTS5-backed asset search
 	Registry.RegisterHandler(TEXT("search_assets_fts"), &SearchAssetsFTS);
 	Registry.RegisterHandler(TEXT("reindex_assets_fts"), &ReindexAssetsFTS);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers.h
@@ -58,6 +58,15 @@ private:
 	// #430: one-call batch of texture imports - loops AssetImportTasks inside the editor.
 	static TSharedPtr<FJsonValue> ImportTextureBatch(const TSharedPtr<FJsonObject>& Params);
 
+	// StringTable handlers
+	static TSharedPtr<FJsonValue> CreateStringTable(const TSharedPtr<FJsonObject>& Params);
+	static TSharedPtr<FJsonValue> ReadStringTable(const TSharedPtr<FJsonObject>& Params);
+	static TSharedPtr<FJsonValue> ListStringTableKeys(const TSharedPtr<FJsonObject>& Params);
+	static TSharedPtr<FJsonValue> GetStringTableEntry(const TSharedPtr<FJsonObject>& Params);
+	static TSharedPtr<FJsonValue> SetStringTableEntry(const TSharedPtr<FJsonObject>& Params);
+	static TSharedPtr<FJsonValue> RemoveStringTableEntry(const TSharedPtr<FJsonObject>& Params);
+	static TSharedPtr<FJsonValue> ImportStringTable(const TSharedPtr<FJsonObject>& Params);
+
 	// Export
 	static TSharedPtr<FJsonValue> ExportAsset(const TSharedPtr<FJsonObject>& Params);
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_Import.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_Import.cpp
@@ -42,6 +42,9 @@
 #include "Editor.h"
 #include "EditorScriptingUtilities/Public/EditorAssetLibrary.h"
 #include "Factories/DataTableFactory.h"
+#include "Internationalization/StringTable.h"
+#include "Internationalization/StringTableCore.h"
+#include "Internationalization/TextKey.h"
 #include "Exporters/Exporter.h"
 #include "AssetExportTask.h"
 
@@ -1428,6 +1431,355 @@ TSharedPtr<FJsonValue> FAssetHandlers::FillDataTableFromJson(const TSharedPtr<FJ
 	Result->SetStringField(TEXT("assetPath"), AssetPath);
 	Result->SetNumberField(TEXT("rowsUpserted"), Upserted);
 	Result->SetNumberField(TEXT("rowCount"), DataTable->GetRowMap().Num());
+	return MCPResult(Result);
+}
+
+// ============================================================================
+// StringTable handlers
+// ============================================================================
+
+namespace
+{
+	TSharedPtr<FJsonValue> LoadStringTableAsset(const TSharedPtr<FJsonObject>& Params, FString& OutAssetPath, UStringTable*& OutStringTable)
+	{
+		if (auto Err = RequireStringAlt(Params, TEXT("path"), TEXT("assetPath"), OutAssetPath)) return Err;
+
+		UObject* Asset = UEditorAssetLibrary::LoadAsset(OutAssetPath);
+		if (!Asset)
+		{
+			return MCPError(FString::Printf(TEXT("Asset not found: %s"), *OutAssetPath));
+		}
+
+		OutStringTable = Cast<UStringTable>(Asset);
+		if (!OutStringTable)
+		{
+			return MCPError(FString::Printf(TEXT("Asset is not a StringTable: %s"), *OutAssetPath));
+		}
+		return nullptr;
+	}
+
+	int32 AppendStringTableEntries(
+		const UStringTable* StringTable,
+		const FString& KeyFilter,
+		TArray<TSharedPtr<FJsonValue>>& OutEntries,
+		TArray<TSharedPtr<FJsonValue>>& OutKeys,
+		const bool bIncludeEntries = true)
+	{
+		if (!StringTable)
+		{
+			return 0;
+		}
+
+		const FString FilterLower = KeyFilter.ToLower();
+		int32 TotalEntryCount = 0;
+		StringTable->GetStringTable()->EnumerateKeysAndSourceStrings(
+			[&](const FTextKey& Key, const FString& SourceString)
+			{
+				++TotalEntryCount;
+				const FString KeyString = Key.ToString();
+				if (!FilterLower.IsEmpty() && !KeyString.ToLower().Contains(FilterLower))
+				{
+					return true;
+				}
+
+				OutKeys.Add(MakeShared<FJsonValueString>(KeyString));
+
+				if (bIncludeEntries)
+				{
+					TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+					Entry->SetStringField(TEXT("key"), KeyString);
+					Entry->SetStringField(TEXT("sourceString"), SourceString);
+					OutEntries.Add(MakeShared<FJsonValueObject>(Entry));
+				}
+				return true;
+			});
+
+		return TotalEntryCount;
+	}
+
+	void SetStringTableInfoFields(TSharedPtr<FJsonObject> Result, UStringTable* StringTable)
+	{
+		if (!Result.IsValid() || !StringTable)
+		{
+			return;
+		}
+
+		TArray<TSharedPtr<FJsonValue>> Entries;
+		TArray<TSharedPtr<FJsonValue>> Keys;
+		const int32 EntryCount = AppendStringTableEntries(StringTable, TEXT(""), Entries, Keys, false);
+
+		Result->SetStringField(TEXT("assetPath"), StringTable->GetPathName());
+		Result->SetStringField(TEXT("tableId"), StringTable->GetStringTableId().ToString());
+		Result->SetStringField(TEXT("namespace"), StringTable->GetStringTable()->GetNamespace());
+		Result->SetNumberField(TEXT("entryCount"), EntryCount);
+	}
+}
+
+TSharedPtr<FJsonValue> FAssetHandlers::CreateStringTable(const TSharedPtr<FJsonObject>& Params)
+{
+	FString Name;
+	if (auto Err = RequireString(Params, TEXT("name"), Name)) return Err;
+
+	const FString PackagePath = OptionalString(Params, TEXT("packagePath"), TEXT("/Game/StringTables"));
+	const FString OnConflict = OptionalString(Params, TEXT("onConflict"), TEXT("skip"));
+	const FString TableNamespace = OptionalString(Params, TEXT("namespace"));
+
+	auto Created = MCPCreateAssetIdempotentNewObject<UStringTable>(Name, PackagePath, OnConflict, TEXT("StringTable"));
+	if (Created.EarlyReturn)
+	{
+		if (TSharedPtr<FJsonObject> ExistingObj = Created.EarlyReturn->AsObject())
+		{
+			bool bExisted = false;
+			if (ExistingObj->TryGetBoolField(TEXT("existed"), bExisted) && bExisted)
+			{
+				FString ExistingAssetPath;
+				ExistingObj->TryGetStringField(TEXT("path"), ExistingAssetPath);
+				if (UStringTable* Existing = LoadObject<UStringTable>(nullptr, *ExistingAssetPath))
+				{
+					SetStringTableInfoFields(ExistingObj, Existing);
+				}
+			}
+		}
+		return Created.EarlyReturn;
+	}
+
+	UStringTable* StringTable = Created.Asset;
+	if (!StringTable)
+	{
+		return MCPError(TEXT("Failed to create StringTable"));
+	}
+
+	if (!TableNamespace.IsEmpty())
+	{
+		StringTable->Modify(true);
+		StringTable->GetMutableStringTable()->SetNamespace(FTextKey(TableNamespace));
+	}
+	SaveAssetPackage(StringTable);
+
+	auto Result = MCPSuccess();
+	MCPSetCreated(Result);
+	Result->SetStringField(TEXT("name"), Name);
+	Result->SetStringField(TEXT("packagePath"), PackagePath);
+	SetStringTableInfoFields(Result, StringTable);
+
+	TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+	Payload->SetStringField(TEXT("assetPath"), StringTable->GetPathName());
+	MCPSetRollback(Result, TEXT("delete_asset"), Payload);
+
+	return MCPResult(Result);
+}
+
+TSharedPtr<FJsonValue> FAssetHandlers::ReadStringTable(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath;
+	UStringTable* StringTable = nullptr;
+	if (auto Err = LoadStringTableAsset(Params, AssetPath, StringTable)) return Err;
+
+	const FString KeyFilter = OptionalString(Params, TEXT("keyFilter"));
+	TArray<TSharedPtr<FJsonValue>> Entries;
+	TArray<TSharedPtr<FJsonValue>> Keys;
+	const int32 TotalEntryCount = AppendStringTableEntries(StringTable, KeyFilter, Entries, Keys);
+
+	auto Result = MCPSuccess();
+	SetStringTableInfoFields(Result, StringTable);
+	Result->SetStringField(TEXT("assetPath"), AssetPath);
+	Result->SetArrayField(TEXT("entries"), Entries);
+	Result->SetArrayField(TEXT("keys"), Keys);
+	Result->SetNumberField(TEXT("totalEntryCount"), TotalEntryCount);
+	Result->SetNumberField(TEXT("filteredCount"), Entries.Num());
+	if (!KeyFilter.IsEmpty())
+	{
+		Result->SetStringField(TEXT("keyFilter"), KeyFilter);
+	}
+
+	return MCPResult(Result);
+}
+
+TSharedPtr<FJsonValue> FAssetHandlers::ListStringTableKeys(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath;
+	UStringTable* StringTable = nullptr;
+	if (auto Err = LoadStringTableAsset(Params, AssetPath, StringTable)) return Err;
+
+	const FString KeyFilter = OptionalString(Params, TEXT("keyFilter"));
+	TArray<TSharedPtr<FJsonValue>> Entries;
+	TArray<TSharedPtr<FJsonValue>> Keys;
+	const int32 TotalEntryCount = AppendStringTableEntries(StringTable, KeyFilter, Entries, Keys, false);
+
+	auto Result = MCPSuccess();
+	SetStringTableInfoFields(Result, StringTable);
+	Result->SetStringField(TEXT("assetPath"), AssetPath);
+	Result->SetArrayField(TEXT("keys"), Keys);
+	Result->SetNumberField(TEXT("totalEntryCount"), TotalEntryCount);
+	Result->SetNumberField(TEXT("filteredCount"), Keys.Num());
+	if (!KeyFilter.IsEmpty())
+	{
+		Result->SetStringField(TEXT("keyFilter"), KeyFilter);
+	}
+
+	return MCPResult(Result);
+}
+
+TSharedPtr<FJsonValue> FAssetHandlers::GetStringTableEntry(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath;
+	UStringTable* StringTable = nullptr;
+	if (auto Err = LoadStringTableAsset(Params, AssetPath, StringTable)) return Err;
+
+	FString Key;
+	if (auto Err = RequireString(Params, TEXT("key"), Key)) return Err;
+
+	FString SourceString;
+	if (!StringTable->GetStringTable()->GetSourceString(FTextKey(Key), SourceString))
+	{
+		return MCPError(FString::Printf(TEXT("StringTable entry not found: %s"), *Key));
+	}
+
+	auto Result = MCPSuccess();
+	SetStringTableInfoFields(Result, StringTable);
+	Result->SetStringField(TEXT("assetPath"), AssetPath);
+	Result->SetStringField(TEXT("key"), Key);
+	Result->SetStringField(TEXT("sourceString"), SourceString);
+	return MCPResult(Result);
+}
+
+TSharedPtr<FJsonValue> FAssetHandlers::SetStringTableEntry(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath;
+	UStringTable* StringTable = nullptr;
+	if (auto Err = LoadStringTableAsset(Params, AssetPath, StringTable)) return Err;
+
+	FString Key;
+	if (auto Err = RequireString(Params, TEXT("key"), Key)) return Err;
+
+	FString SourceString;
+	bool bHasSourceString = Params->TryGetStringField(TEXT("sourceString"), SourceString);
+	if (!bHasSourceString)
+	{
+		bHasSourceString = Params->TryGetStringField(TEXT("value"), SourceString);
+	}
+	if (!bHasSourceString)
+	{
+		return MCPError(TEXT("Missing 'sourceString' parameter"));
+	}
+
+	const FTextKey EntryKey(Key);
+	FString PreviousSourceString;
+	const bool bExisted = StringTable->GetStringTable()->GetSourceString(EntryKey, PreviousSourceString);
+
+	StringTable->Modify(true);
+	StringTable->GetMutableStringTable()->SetSourceString(EntryKey, SourceString);
+	SaveAssetPackage(StringTable);
+
+	auto Result = MCPSuccess();
+	if (bExisted) MCPSetUpdated(Result); else MCPSetCreated(Result);
+	SetStringTableInfoFields(Result, StringTable);
+	Result->SetStringField(TEXT("assetPath"), AssetPath);
+	Result->SetStringField(TEXT("key"), Key);
+	Result->SetStringField(TEXT("sourceString"), SourceString);
+
+	TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+	Payload->SetStringField(TEXT("assetPath"), AssetPath);
+	Payload->SetStringField(TEXT("key"), Key);
+	if (bExisted)
+	{
+		Payload->SetStringField(TEXT("sourceString"), PreviousSourceString);
+		MCPSetRollback(Result, TEXT("set_stringtable_entry"), Payload);
+	}
+	else
+	{
+		MCPSetRollback(Result, TEXT("remove_stringtable_entry"), Payload);
+	}
+
+	return MCPResult(Result);
+}
+
+TSharedPtr<FJsonValue> FAssetHandlers::RemoveStringTableEntry(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath;
+	UStringTable* StringTable = nullptr;
+	if (auto Err = LoadStringTableAsset(Params, AssetPath, StringTable)) return Err;
+
+	FString Key;
+	if (auto Err = RequireString(Params, TEXT("key"), Key)) return Err;
+
+	const FTextKey EntryKey(Key);
+	FString PreviousSourceString;
+	if (!StringTable->GetStringTable()->GetSourceString(EntryKey, PreviousSourceString))
+	{
+		auto Noop = MCPSuccess();
+		Noop->SetBoolField(TEXT("alreadyDeleted"), true);
+		Noop->SetStringField(TEXT("assetPath"), AssetPath);
+		Noop->SetStringField(TEXT("key"), Key);
+		return MCPResult(Noop);
+	}
+
+	StringTable->Modify(true);
+	StringTable->GetMutableStringTable()->RemoveSourceString(EntryKey);
+	SaveAssetPackage(StringTable);
+
+	auto Result = MCPSuccess();
+	MCPSetUpdated(Result);
+	SetStringTableInfoFields(Result, StringTable);
+	Result->SetStringField(TEXT("assetPath"), AssetPath);
+	Result->SetStringField(TEXT("key"), Key);
+
+	TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+	Payload->SetStringField(TEXT("assetPath"), AssetPath);
+	Payload->SetStringField(TEXT("key"), Key);
+	Payload->SetStringField(TEXT("sourceString"), PreviousSourceString);
+	MCPSetRollback(Result, TEXT("set_stringtable_entry"), Payload);
+
+	return MCPResult(Result);
+}
+
+TSharedPtr<FJsonValue> FAssetHandlers::ImportStringTable(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath;
+	UStringTable* StringTable = nullptr;
+	if (auto Err = LoadStringTableAsset(Params, AssetPath, StringTable)) return Err;
+
+	FString FilePath;
+	if (!Params->TryGetStringField(TEXT("filePath"), FilePath) || FilePath.IsEmpty())
+	{
+		if (!Params->TryGetStringField(TEXT("filename"), FilePath) || FilePath.IsEmpty())
+		{
+			Params->TryGetStringField(TEXT("csvPath"), FilePath);
+		}
+	}
+	if (FilePath.IsEmpty())
+	{
+		return MCPError(TEXT("Missing 'filePath' parameter"));
+	}
+	if (!FPaths::FileExists(FilePath))
+	{
+		return MCPError(FString::Printf(TEXT("StringTable import file not found: %s"), *FilePath));
+	}
+
+	TArray<TSharedPtr<FJsonValue>> BeforeEntries;
+	TArray<TSharedPtr<FJsonValue>> BeforeKeys;
+	const int32 BeforeCount = AppendStringTableEntries(StringTable, TEXT(""), BeforeEntries, BeforeKeys, false);
+
+	StringTable->Modify(true);
+	const bool bImported = StringTable->GetMutableStringTable()->ImportStrings(FilePath);
+	if (!bImported)
+	{
+		return MCPError(FString::Printf(TEXT("Failed to import StringTable from: %s"), *FilePath));
+	}
+	SaveAssetPackage(StringTable);
+
+	TArray<TSharedPtr<FJsonValue>> Entries;
+	TArray<TSharedPtr<FJsonValue>> Keys;
+	const int32 AfterCount = AppendStringTableEntries(StringTable, TEXT(""), Entries, Keys, false);
+
+	auto Result = MCPSuccess();
+	MCPSetUpdated(Result);
+	SetStringTableInfoFields(Result, StringTable);
+	Result->SetStringField(TEXT("assetPath"), AssetPath);
+	Result->SetStringField(TEXT("filePath"), FilePath);
+	Result->SetNumberField(TEXT("entryCountBefore"), BeforeCount);
+	Result->SetNumberField(TEXT("entryCountAfter"), AfterCount);
+	Result->SetArrayField(TEXT("keys"), Keys);
 	return MCPResult(Result);
 }
 

--- a/src/tools/asset.ts
+++ b/src/tools/asset.ts
@@ -4,7 +4,7 @@ import { Vec3, Rotator } from "../schemas.js";
 
 export const assetTool: ToolDef = categoryTool(
   "asset",
-  "Asset management: list, search, read, CRUD, import meshes/textures, datatables.",
+  "Asset management: list, search, read, CRUD, import meshes/textures, datatables, stringtables.",
   {
     list: bp(
       "List assets via the AssetRegistry (sees /Game and every mounted plugin root). Params: directory? (default /Game), classFilter?, recursive? (default true), maxResults? (default 2000)",
@@ -82,6 +82,13 @@ export const assetTool: ToolDef = categoryTool(
       ...(p.sRGB !== undefined ? { sRGB: p.sRGB } : {}),
       ...(p.neverStream !== undefined ? { neverStream: p.neverStream } : {}),
     })),
+    create_stringtable:   bp("Create a StringTable asset. Params: name, packagePath?, namespace?, onConflict?", "create_stringtable"),
+    read_stringtable:     bp("Read StringTable entries and keys. Params: assetPath, keyFilter?", "read_stringtable", (p) => ({ assetPath: p.assetPath, path: p.path, keyFilter: p.keyFilter })),
+    list_stringtable_keys: bp("List StringTable keys. Params: assetPath, keyFilter?", "list_stringtable_keys", (p) => ({ assetPath: p.assetPath, path: p.path, keyFilter: p.keyFilter })),
+    get_stringtable_entry: bp("Read one StringTable entry. Params: assetPath, key", "get_stringtable_entry", (p) => ({ assetPath: p.assetPath, path: p.path, key: p.key })),
+    set_stringtable_entry: bp("Create or update one StringTable entry. Params: assetPath, key, sourceString (or value)", "set_stringtable_entry", (p) => ({ assetPath: p.assetPath, path: p.path, key: p.key, sourceString: p.sourceString, value: p.value })),
+    remove_stringtable_entry: bp("Remove one StringTable entry. Idempotent (alreadyDeleted=true if missing). Params: assetPath, key", "remove_stringtable_entry", (p) => ({ assetPath: p.assetPath, path: p.path, key: p.key })),
+    import_stringtable:   bp("Import StringTable entries from CSV. Params: assetPath, filePath (or csvPath)", "import_stringtable", (p) => ({ assetPath: p.assetPath, path: p.path, filePath: p.filePath ?? p.csvPath })),
     add_input_mapping:    bp("Append an Enhanced Input key mapping to an InputMappingContext (InputAction + key by name string e.g. 'Mouse2D','LeftMouseButton'). Idempotent on (action,key). For modifiers/triggers use gameplay(set_mapping_modifiers). Same as gameplay(add_imc_mapping) (#525). Params: mappingContext (IMC path), inputAction (IA path), key", "add_imc_mapping", (p) => ({ imcPath: p.mappingContext ?? p.imcPath ?? p.assetPath, inputActionPath: p.inputAction ?? p.inputActionPath, key: p.key })),
     remove_input_mapping: bp("Remove an IMC key mapping. Same as gameplay(remove_imc_mapping) (#525). Params: mappingContext (IMC path), mappingIndex? | (inputAction? + key?)", "remove_imc_mapping", (p) => ({ imcPath: p.mappingContext ?? p.imcPath ?? p.assetPath, mappingIndex: p.mappingIndex, inputActionPath: p.inputAction ?? p.inputActionPath, key: p.key })),
     list_input_mappings:  bp("List an IMC's key->action bindings with triggers/modifiers. Same as gameplay(read_imc) (#525). Params: mappingContext (IMC path)", "read_imc", (p) => ({ imcPath: p.mappingContext ?? p.imcPath ?? p.assetPath })),
@@ -135,6 +142,7 @@ export const assetTool: ToolDef = categoryTool(
     filePath: z.string().optional().describe("Absolute file path for imports"),
     name: z.string().optional().describe("Asset name (defaults to filename)"),
     packagePath: z.string().optional().describe("Destination package path (e.g. /Game/Meshes)"),
+    onConflict: z.string().optional().describe("Asset-creation conflict policy: skip (default) | error | overwrite"),
     groups: z.record(z.array(z.string())).optional().describe("set_texture_settings_by_type: { normal?: [...], grayscale?: [...], baseColor?: [...], hdr?: [...] }"),
     meshType: z.string().optional().describe("create_interchange_pipeline: 'skeletal' (default) or 'static'"),
     options: z.record(z.unknown()).optional().describe("create_interchange_pipeline: dotted-path overrides"),
@@ -151,7 +159,11 @@ export const assetTool: ToolDef = categoryTool(
     inputAction: z.string().optional().describe("InputAction asset path for add_input_mapping (#525)"),
     imcPath: z.string().optional(),
     inputActionPath: z.string().optional(),
-    key: z.string().optional().describe("Key name for add_input_mapping (e.g. 'Mouse2D', 'LeftMouseButton') (#525)"),
+    key: z.string().optional().describe("Key name for add_input_mapping or StringTable entry key (e.g. 'Mouse2D', 'LeftMouseButton') (#525)"),
+    sourceString: z.string().optional().describe("StringTable entry source string"),
+    namespace: z.string().optional().describe("StringTable namespace for create_stringtable"),
+    keyFilter: z.string().optional().describe("Filter StringTable keys by substring"),
+    csvPath: z.string().optional().describe("StringTable CSV import path"),
     mappingIndex: z.number().optional().describe("Index of an IMC mapping for remove_input_mapping (#525)"),
     fieldName: z.string().optional().describe("DataTable field/column name for set_datatable_cell (#535)"),
     oldName: z.string().optional().describe("Existing row key for rename_datatable_row (#535)"),


### PR DESCRIPTION
## Summary
- add StringTable asset creation, entry, key-listing, and import handlers
- expose the new StringTable actions through the asset tool schema
- document the StringTable actions in the tool reference

## Validation
- `npx tsc --noEmit`
- `npm run audit:docs` (passes action coverage; existing `project.write_source_file` / `project.read_source_file` param drift warnings remain)
- `npm run audit:handlers` (passes with the existing orphan-handler warnings)
- `git diff --check` (only existing CRLF normalization warnings)
