### PR TITLE
Fix UE 5.8 bridge compile errors

### DIFF
--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/HandlerJsonProperty.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/HandlerJsonProperty.h
@@ -141,20 +141,21 @@ namespace MCPJsonProperty
 				H.EmptyValues();
 				for (const auto& Pair : (*Obj)->Values)
 				{
+					const FString Key(*Pair.Key);
 					const int32 Idx = H.AddDefaultValue_Invalid_NeedsRehash();
 					FString E;
-					if (!SetJsonOnProperty(MapProp->KeyProp, H.GetKeyPtr(Idx), MakeShared<FJsonValueString>(Pair.Key), E))
+					if (!SetJsonOnProperty(MapProp->KeyProp, H.GetKeyPtr(Idx), MakeShared<FJsonValueString>(Key), E))
 					{
 						H.EmptyValues();
 						H.Rehash();
-						OutError = FString::Printf(TEXT("map key '%s': %s"), *Pair.Key, *E);
+						OutError = FString::Printf(TEXT("map key '%s': %s"), *Key, *E);
 						return false;
 					}
 					if (!SetJsonOnProperty(MapProp->ValueProp, H.GetValuePtr(Idx), Pair.Value, E))
 					{
 						H.EmptyValues();
 						H.Rehash();
-						OutError = FString::Printf(TEXT("map value '%s': %s"), *Pair.Key, *E);
+						OutError = FString::Printf(TEXT("map value '%s': %s"), *Key, *E);
 						return false;
 					}
 				}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AnimationHandlers_StateMachine.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AnimationHandlers_StateMachine.cpp
@@ -37,7 +37,7 @@
 #include "Animation/AnimComposite.h"
 #include "Animation/BlendSpace.h"
 #include "Animation/Skeleton.h"
-#include "InstancedStruct.h"
+#include "StructUtils/InstancedStruct.h"
 #include "UObject/Package.h"
 #include "Misc/PackageName.h"
 #include "Runtime/Launch/Resources/Version.h"

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers.cpp
@@ -2611,7 +2611,7 @@ TSharedPtr<FJsonValue> FAssetHandlers::SetTextureSettingsByType(const TSharedPtr
 
 	for (const auto& Pair : (*GroupsObj)->Values)
 	{
-		const FString& Group = Pair.Key;
+		const FString Group(*Pair.Key);
 		const FProfile* Profile = Profiles.Find(Group);
 		if (!Profile)
 		{
@@ -2763,7 +2763,7 @@ TSharedPtr<FJsonValue> FAssetHandlers::CreateInterchangePipeline(const TSharedPt
 		for (const auto& Pair : (*OptionsObj)->Values)
 		{
 			// Caller key is a dotted path: "MeshPipeline.bImportSkeletalMeshes" etc.
-			const FString& Key = Pair.Key;
+			const FString Key(*Pair.Key);
 			int32 Dot = INDEX_NONE;
 			Key.FindLastChar('.', Dot);
 			if (Dot == INDEX_NONE)

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_Import.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_Import.cpp
@@ -1749,10 +1749,11 @@ TSharedPtr<FJsonValue> FAssetHandlers::SetDataTableRow(const TSharedPtr<FJsonObj
 	bool bOk = true;
 	for (const auto& Pair : (*RowObj)->Values)
 	{
+		const FString FieldName(*Pair.Key);
 		FProperty* FieldProp = nullptr;
 		for (TFieldIterator<FProperty> It(RowStruct); It; ++It)
 		{
-			if (It->GetName() == Pair.Key || It->GetAuthoredName() == Pair.Key)
+			if (It->GetName() == FieldName || It->GetAuthoredName() == FieldName)
 			{
 				FieldProp = *It;
 				break;
@@ -1760,7 +1761,7 @@ TSharedPtr<FJsonValue> FAssetHandlers::SetDataTableRow(const TSharedPtr<FJsonObj
 		}
 		if (!FieldProp)
 		{
-			SetErr = FString::Printf(TEXT("row struct '%s' has no field '%s'"), *RowStruct->GetName(), *Pair.Key);
+			SetErr = FString::Printf(TEXT("row struct '%s' has no field '%s'"), *RowStruct->GetName(), *FieldName);
 			bOk = false;
 			break;
 		}
@@ -1768,7 +1769,7 @@ TSharedPtr<FJsonValue> FAssetHandlers::SetDataTableRow(const TSharedPtr<FJsonObj
 		FString E;
 		if (!MCPJsonProperty::SetJsonOnProperty(FieldProp, FieldAddr, Pair.Value, E))
 		{
-			SetErr = FString::Printf(TEXT("%s: %s"), *Pair.Key, *E);
+			SetErr = FString::Printf(TEXT("%s: %s"), *FieldName, *E);
 			bOk = false;
 			break;
 		}
@@ -2277,7 +2278,11 @@ TSharedPtr<FJsonValue> FAssetHandlers::SetStringTableEntry(const TSharedPtr<FJso
 	const bool bExisted = StringTable->GetStringTable()->GetSourceString(EntryKey, PreviousSourceString);
 
 	StringTable->Modify(true);
+#if WITH_EDITORONLY_DATA
+	StringTable->GetMutableStringTable()->SetSourceString(EntryKey, SourceString, FString());
+#else
 	StringTable->GetMutableStringTable()->SetSourceString(EntryKey, SourceString);
+#endif
 	SaveAssetPackage(StringTable);
 
 	auto Result = MCPSuccess();

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EditorHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EditorHandlers.cpp
@@ -1556,17 +1556,18 @@ TSharedPtr<FJsonValue> FEditorHandlers::SetCVars(const TSharedPtr<FJsonObject>& 
 	{
 		for (const auto& Pair : (*CVarObj)->Values)
 		{
+			const FString CVarName(*Pair.Key);
 			FString ValStr;
 			if (Pair.Value.IsValid() && Pair.Value->TryGetString(ValStr))
 			{
-				Requests.Add({ Pair.Key, ValStr });
+				Requests.Add({ CVarName, ValStr });
 			}
 			else if (Pair.Value.IsValid())
 			{
 				// numbers/bools arrive as non-string JSON; stringify them.
 				double Num = 0.0; bool bBool = false;
-				if (Pair.Value->TryGetNumber(Num)) Requests.Add({ Pair.Key, FString::SanitizeFloat(Num) });
-				else if (Pair.Value->TryGetBool(bBool)) Requests.Add({ Pair.Key, bBool ? TEXT("1") : TEXT("0") });
+				if (Pair.Value->TryGetNumber(Num)) Requests.Add({ CVarName, FString::SanitizeFloat(Num) });
+				else if (Pair.Value->TryGetBool(bBool)) Requests.Add({ CVarName, bBool ? TEXT("1") : TEXT("0") });
 			}
 		}
 	}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/FoliageHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/FoliageHandlers.cpp
@@ -275,7 +275,7 @@ TSharedPtr<FJsonValue> FFoliageHandlers::SetFoliageTypeSettings(const TSharedPtr
 
 	for (const auto& KV : (*SettingsObj)->Values)
 	{
-		FString PropertyName = KV.Key;
+		FString PropertyName(*KV.Key);
 		FString PropertyValue;
 
 		// Convert the JSON value to a string for ImportText
@@ -402,7 +402,7 @@ TSharedPtr<FJsonValue> FFoliageHandlers::CreateFoliageType(const TSharedPtr<FJso
 	{
 		for (const auto& KV : (*SettingsObj)->Values)
 		{
-			FString PropertyName = KV.Key;
+			FString PropertyName(*KV.Key);
 			FString PropertyValue;
 
 			if (KV.Value->Type == EJson::String)

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/GameplayHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/GameplayHandlers.cpp
@@ -1675,7 +1675,7 @@ TSharedPtr<FJsonValue> FGameplayHandlers::ConfigureAiPerceptionSense(const TShar
 			FString PErr;
 			if (MCPJsonProperty::SetJsonOnProperty(P, P->ContainerPtrToValuePtr<void>(Cfg), KV.Value, PErr))
 			{
-				AppliedProps.Add(KV.Key);
+				AppliedProps.Add(FString(*KV.Key));
 			}
 		}
 	}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/GasHandlers_Runtime.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/GasHandlers_Runtime.cpp
@@ -183,7 +183,7 @@ TSharedPtr<FJsonValue> FGasHandlers::ApplyEffect(const TSharedPtr<FJsonObject>& 
 			{
 				SpecHandle.Data->SetSetByCallerMagnitude(FName(*KV.Key), static_cast<float>(Mag));
 			}
-			AppliedKeys.Add(KV.Key);
+			AppliedKeys.Add(FString(*KV.Key));
 		}
 	}
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Volumes.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Volumes.cpp
@@ -225,14 +225,14 @@ TSharedPtr<FJsonValue> FLevelHandlers::SetVolumeProperties(const TSharedPtr<FJso
 	{
 		if (Pair.Key == TEXT("actorLabel") || Pair.Key == TEXT("action") || Pair.Key == TEXT("properties"))
 			continue;
-		Pairs.Emplace(Pair.Key, Pair.Value);
+		Pairs.Emplace(FString(*Pair.Key), Pair.Value);
 	}
 	const TSharedPtr<FJsonObject>* PropsObj = nullptr;
 	if (Params->TryGetObjectField(TEXT("properties"), PropsObj) && PropsObj && (*PropsObj).IsValid())
 	{
 		for (auto& Pair : (*PropsObj)->Values)
 		{
-			Pairs.Emplace(Pair.Key, Pair.Value);
+			Pairs.Emplace(FString(*Pair.Key), Pair.Value);
 		}
 	}
 	for (auto& Pair : Pairs)

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/PCGHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/PCGHandlers.cpp
@@ -997,7 +997,7 @@ TSharedPtr<FJsonValue> FPCGHandlers::SetPCGNodeSettings(const TSharedPtr<FJsonOb
 	{
 		for (const auto& Pair : (*SettingsObj)->Values)
 		{
-			PropertiesToSet.Add(TPair<FString, TSharedPtr<FJsonValue>>(Pair.Key, Pair.Value));
+			PropertiesToSet.Add(TPair<FString, TSharedPtr<FJsonValue>>(FString(*Pair.Key), Pair.Value));
 		}
 	}
 	else
@@ -1756,14 +1756,15 @@ TSharedPtr<FJsonValue> FPCGHandlers::ImportGraph(const TSharedPtr<FJsonObject>& 
 			DefaultSettings->Modify();
 			for (const auto& Pair : (*SettingsObj)->Values)
 			{
+				const FString SettingName(*Pair.Key);
 				FString SubErr;
-				if (SetDottedPropertyFromJson(DefaultSettings, Pair.Key, Pair.Value, SubErr))
+				if (SetDottedPropertyFromJson(DefaultSettings, SettingName, Pair.Value, SubErr))
 				{
 					++SettingsApplied;
 				}
 				else
 				{
-					Warnings.Add(MakeShared<FJsonValueString>(FString::Printf(TEXT("node '%s' setting '%s': %s"), *LocalName, *Pair.Key, *SubErr)));
+					Warnings.Add(MakeShared<FJsonValueString>(FString::Printf(TEXT("node '%s' setting '%s': %s"), *LocalName, *SettingName, *SubErr)));
 				}
 			}
 			DefaultSettings->PostEditChange();

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/PhysicsHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/PhysicsHandlers.cpp
@@ -407,17 +407,18 @@ TSharedPtr<FJsonValue> FPhysicsHandlers::SetCollision(const TSharedPtr<FJsonObje
 	{
 		for (const auto& Pair : (*ResponsesObj)->Values)
 		{
+			const FString ChannelName(*Pair.Key);
 			ECollisionChannel Ch;
-			if (!ResolveCollisionChannel(Pair.Key, Ch))
+			if (!ResolveCollisionChannel(ChannelName, Ch))
 			{
-				return MCPError(FString::Printf(TEXT("Unknown response channel '%s'"), *Pair.Key));
+				return MCPError(FString::Printf(TEXT("Unknown response channel '%s'"), *ChannelName));
 			}
 			FString RespStr;
 			Pair.Value->TryGetString(RespStr);
 			ECollisionResponse Resp;
 			if (!ResolveCollisionResponse(RespStr, Resp))
 			{
-				return MCPError(FString::Printf(TEXT("Unknown response '%s' for channel '%s'. Use Block, Overlap, Ignore."), *RespStr, *Pair.Key));
+				return MCPError(FString::Printf(TEXT("Unknown response '%s' for channel '%s'. Use Block, Overlap, Ignore."), *RespStr, *ChannelName));
 			}
 			ChannelResponses.Emplace(Ch, Resp);
 		}


### PR DESCRIPTION
## Summary

Fixes UE_MCP_Bridge compile failures against Unreal Engine 5.8 by updating the plugin for small UE API changes:

- Convert `FJsonObject::Values` keys before passing them to APIs that require `FString`.
- Include `StructUtils/InstancedStruct.h` after the UE 5.8 header move.
- Call the editor-only `FStringTable::SetSourceString` overload with dev notes.

## Root Cause

UE 5.8 changed `FJsonObject::Values` key storage from plain `FString` to `UE::FSharedString`, so several call sites no longer compile when binding JSON keys as `FString`, constructing `FJsonValueString`, or passing keys to helpers that require `const FString&`.

## Validation

Built the plugin locally against Unreal Engine 5.8 Win64 using `RunUAT BuildPlugin`:

```powershell
& '<UE_5.8>\Engine\Build\BatchFiles\RunUAT.bat' BuildPlugin -Plugin='<ue-mcp>\plugin\ue_mcp_bridge\UE_MCP_Bridge.uplugin' -Package='<temp-output>\BuildPlugin_UE58' -TargetPlatforms=Win64
```

Result: `BUILD SUCCESSFUL`.