### PR TITLE
Fix add_node crash on SpawnActor/AssignDelegate + bind support for delegate nodes (#627)

### DIFF
--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/BlueprintHandlers_Graph.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/BlueprintHandlers_Graph.cpp
@@ -30,6 +30,7 @@
 #include "K2Node_ComponentBoundEvent.h"
 #include "K2Node_CustomEvent.h"
 #include "K2Node_CallDelegate.h"
+#include "K2Node_BaseMCDelegate.h"
 #include "K2Node_ConstructObjectFromClass.h"
 #include "UObject/UnrealType.h"
 #include "UObject/Package.h"
@@ -517,6 +518,73 @@ TSharedPtr<FJsonValue> FBlueprintHandlers::AddNode(const TSharedPtr<FJsonObject>
 				{
 					// Self member — delegate belongs to the Blueprint's own class
 					DelegateNode->DelegateReference.SetSelfMember(FName(*DelegateName));
+				}
+			}
+		}
+	}
+
+	// #627: bind-style multicast-delegate nodes (K2Node_AddDelegate and its child
+	// K2Node_AssignDelegate, plus Remove/ClearDelegate). CallDelegate is matched by the
+	// earlier else-if, so this branch only catches the bind family. Setting the
+	// DelegateReference BEFORE AllocateDefaultPins makes the "Delegate" pin resolve to
+	// the dispatcher's signature; combined with the corrected
+	// AllocateDefaultPins-before-PostPlacedNewNode order, AssignDelegate's
+	// PostPlacedNewNode then auto-creates and wires the paired Custom Event — a fully
+	// bound "Bind Event to <Dispatcher>" in one add_node call. Without these params the
+	// node still places (unbound) and does not crash.
+	if (UK2Node_BaseMCDelegate* MCDelegateNode = Cast<UK2Node_BaseMCDelegate>(NewNode))
+	{
+		if (NodeParams && !MCDelegateNode->IsA<UK2Node_CallDelegate>())
+		{
+			FString DelegateName;
+			FString OwnerClass;
+
+			if (!(*NodeParams)->TryGetStringField(TEXT("delegateName"), DelegateName))
+			{
+				if (!(*NodeParams)->TryGetStringField(TEXT("functionName"), DelegateName))
+					(*NodeParams)->TryGetStringField(TEXT("memberName"), DelegateName);
+			}
+			if (!(*NodeParams)->TryGetStringField(TEXT("ownerClass"), OwnerClass))
+			{
+				if (!(*NodeParams)->TryGetStringField(TEXT("targetClass"), OwnerClass))
+					(*NodeParams)->TryGetStringField(TEXT("memberParent"), OwnerClass);
+			}
+
+			if (DelegateName.IsEmpty())
+			{
+				const TSharedPtr<FJsonObject>* DelRef = nullptr;
+				if ((*NodeParams)->TryGetObjectField(TEXT("DelegateReference"), DelRef))
+				{
+					(*DelRef)->TryGetStringField(TEXT("MemberName"), DelegateName);
+					if (OwnerClass.IsEmpty())
+						(*DelRef)->TryGetStringField(TEXT("MemberParent"), OwnerClass);
+				}
+			}
+
+			if (!DelegateName.IsEmpty())
+			{
+				if (!OwnerClass.IsEmpty())
+				{
+					UClass* Owner = LoadObject<UClass>(nullptr, *OwnerClass);
+					if (!Owner && !OwnerClass.EndsWith(TEXT("_C")))
+						Owner = LoadObject<UClass>(nullptr, *(OwnerClass + TEXT("_C")));
+					if (!Owner) Owner = FindClassByShortName(OwnerClass);
+					if (Owner)
+					{
+						FProperty* Prop = Owner->FindPropertyByName(FName(*DelegateName));
+						bool bIsSelf = Blueprint->ParentClass && Blueprint->ParentClass->IsChildOf(Owner);
+						if (Prop)
+							MCDelegateNode->SetFromProperty(Prop, bIsSelf, Owner);
+						else if (bIsSelf)
+							MCDelegateNode->DelegateReference.SetSelfMember(FName(*DelegateName));
+						else
+							MCDelegateNode->DelegateReference.SetExternalMember(FName(*DelegateName), Owner);
+					}
+				}
+				else
+				{
+					// Self member — dispatcher belongs to the Blueprint's own class
+					MCDelegateNode->DelegateReference.SetSelfMember(FName(*DelegateName));
 				}
 			}
 		}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/BlueprintHandlers_Graph.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/BlueprintHandlers_Graph.cpp
@@ -622,8 +622,22 @@ TSharedPtr<FJsonValue> FBlueprintHandlers::AddNode(const TSharedPtr<FJsonObject>
 	TargetGraph->Modify();
 	TargetGraph->AddNode(NewNode, false, false);
 	NewNode->CreateNewGuid();
-	NewNode->PostPlacedNewNode();
+
+	// #627: AllocateDefaultPins MUST run BEFORE PostPlacedNewNode. The engine's own
+	// spawner (UBlueprintNodeSpawner::SpawnEdGraphNode) allocates pins first and only
+	// then calls PostPlacedNewNode. Several node types dereference their own pins inside
+	// PostPlacedNewNode, so if the pins have not been allocated yet the lookup crashes
+	// the editor:
+	//   - K2Node_ConstructObjectFromClass (incl. K2Node_SpawnActorFromClass) reaches
+	//     GetResultPin() -> FindPinChecked(PN_ReturnValue), which asserts at
+	//     EdGraphNode.h:586 (check(Result) in FindPinChecked) when the result pin is absent.
+	//   - K2Node_AssignDelegate dereferences GetDelegatePin()->LinkedTo, a null-deref when
+	//     the "Delegate" pin has not been created yet.
+	// Allocating first matches the engine order and fixes both node families. (The
+	// AddDelegate base unconditionally creates the "Delegate" pin in AllocateDefaultPins,
+	// so AssignDelegate is safe even when its delegate reference is unbound.)
 	NewNode->AllocateDefaultPins();
+	NewNode->PostPlacedNewNode();
 
 	// #101/#118: after AllocateDefaultPins, force ReconstructNode so typed output pin
 	// ("As ClassName") appears for DynamicCast and typed pins appear for VariableGet.


### PR DESCRIPTION
Fixes #627.

Two commits: (1) the crash fix, (2) a follow-on enhancement that makes `K2Node_AssignDelegate` actually bindable from `add_node`.

## 1. Crash fix — allocate pins before PostPlacedNewNode

`FBlueprintHandlers::AddNode` calls `PostPlacedNewNode()` **before** `AllocateDefaultPins()`:

```cpp
NewNode->CreateNewGuid();
NewNode->PostPlacedNewNode();    // runs before pins exist
NewNode->AllocateDefaultPins();
```

Several node types dereference their own pins inside `PostPlacedNewNode`, so with pins not yet allocated the lookup crashes:

- **`K2Node_ConstructObjectFromClass`** (incl. `K2Node_SpawnActorFromClass`): `PostPlacedNewNode` → `GetResultPin()` → `FindPinChecked(PN_ReturnValue)`, hitting `check(Result)` at `EdGraphNode.h:586` when the result pin is absent — the exact assertion reported.
- **`K2Node_AssignDelegate`**: `PostPlacedNewNode` → `GetDelegatePin()->LinkedTo`, a null-deref when the `"Delegate"` pin hasn't been created yet.

The engine's own spawner does the opposite order — `UBlueprintNodeSpawner::SpawnEdGraphNode`:

```cpp
NewNode->AllocateDefaultPins();
NewNode->PostPlacedNewNode();
```

Fix: swap the two calls to match the engine. `UK2Node_AddDelegate::AllocateDefaultPins` creates the `"Delegate"` pin unconditionally, so `AssignDelegate` is safe even when unbound. The pre-existing `#201/#231` `Modify()` and the `ReconstructNode` skip for `ConstructObjectFromClass` are untouched.

## 2. Enhancement — bind delegate nodes from add_node

The crash fix alone leaves `AssignDelegate` placed **unbound** (`"Bind Event to None"`) because there was no special-case to set its target. Added a block (mirroring the existing `K2Node_CallDelegate` handling) that sets the `DelegateReference` for the bind family (`K2Node_AddDelegate`/`AssignDelegate`/`Remove`/`Clear`) from `delegateName` (+ optional `ownerClass`, or a nested `DelegateReference`). `CallDelegate` is matched by the earlier else-if and explicitly excluded.

Because the reference is set before `AllocateDefaultPins`, the `Delegate` pin resolves to the dispatcher signature, and — thanks to the corrected order — `AssignDelegate::PostPlacedNewNode` then auto-creates and wires the paired Custom Event. One call produces a fully bound binding, matching the palette. Omitting the params still places the node unbound (no crash).

## Testing (UE 5.7, live via the bridge)

| Case | Result |
|---|---|
| `add_node K2Node_SpawnActorFromClass` | places with full pins (`Class`, `ReturnValue`, `SpawnTransform`, `CollisionHandlingOverride`, `TransformScaleMethod`, `Owner`); no crash |
| `add_node K2Node_AssignDelegate` (no params) | places `"Bind Event to None"`; no crash |
| `add_node K2Node_AssignDelegate {"delegateName":"OnTestFired"}` | places `"Assign On Test Fired"` **+** auto-creates `OnTestFired_Event` custom event wired into the `Delegate` pin |

Editor stayed connected and healthy throughout (no delayed crash); test Blueprints deleted afterward.

Scope note: only the canonical source under `plugin/ue_mcp_bridge/...` is changed; the divergent fixture copy under `tests/` was left as-is.
