### PR TITLE
fix: remove unreachable loop increment in GetNavmeshDetails (UE 5.8 -Werror)

### DIFF
--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/GameplayHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/GameplayHandlers.cpp
@@ -2060,13 +2060,13 @@ TSharedPtr<FJsonValue> FGameplayHandlers::GetNavmeshDetails(const TSharedPtr<FJs
 		if (RecastNav) break;
 	}
 
-	// Fallback: iterate world actors
+	// Fallback: grab the first ARecastNavMesh in the world
 	if (!RecastNav)
 	{
-		for (TActorIterator<ARecastNavMesh> It(World); It; ++It)
+		TActorIterator<ARecastNavMesh> It(World);
+		if (It)
 		{
 			RecastNav = *It;
-			break;
 		}
 	}
 


### PR DESCRIPTION
Fixes #705

Replace the single-iteration for-loop with a direct TActorIterator + if check. Clang 5.8 -Werror flags the never-reached ++It as unreachable-code-loop-increment.