### PR TITLE
Add native SaveGame slot inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you prefer to configure manually, add to your MCP client config:
 | **Networking** | Replication, dormancy, relevancy, net priority |
 | **UI** | UMG widgets, editor utility widgets and blueprints, runtime delegate inspection |
 | **Editor** | Console, Python, PIE, viewport, sequencer, build pipeline, logs |
-| **Reflection** | Class/struct/enum introspection, gameplay tags |
+| **Reflection** | Class/struct/enum introspection, gameplay tags, SaveGame inspection |
 
 ## Supported Platforms
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Start with **[Getting Started](getting-started.md)**. It assumes zero knowledge 
 | **GAS** | Gameplay Ability System - attributes, abilities, effects, cues |
 | **Networking** | Replication, dormancy, relevancy, net priority |
 | **Editor** | Console commands, Python escape hatch, PIE, viewport, sequencer, build pipeline, logs |
-| **Reflection** | Class/struct/enum introspection, gameplay tags |
+| **Reflection** | Class/struct/enum introspection, gameplay tags, SaveGame inspection |
 | **Project** | Status, INI config, C++ source/header parsing, build |
 | **Demo** | Built-in 19-step Neon Shrine procedural scene |
 | **Feedback** | Submit tool-gap reports as GitHub issues |

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -712,7 +712,7 @@ UE-MCP exposes **<!-- count:tools -->24<!-- /count --> category tools** covering
 
 ## reflection
 
-*UE reflection: classes, structs, enums, gameplay tags.*
+*UE reflection: classes, structs, enums, gameplay tags, and SaveGame instances.*
 
 | Action | Description |
 |--------|-------------|
@@ -727,6 +727,7 @@ UE-MCP exposes **<!-- count:tools -->24<!-- /count --> category tools** covering
 | `is_class_loaded` | Report whether a UClass is currently loaded in the editor (loaded), whether it exists/is loadable (exists), and its owning module + that module's load state. Distinguishes 'not loaded yet' from 'does not exist'. Params: `className (short name, /Script/<Module>.<Class>, or BP class path) (#689)` |
 | `is_module_loaded` | Report whether a named module is currently loaded. Params: `moduleName (#689)` |
 | `list_loaded_modules` | Enumerate modules with runtime load state. Params: `filter? (case-insensitive substring), loadedOnly? (default false)` |
+| `inspect_save_game` | Load a SaveGame slot read-only and return its reflected `UPROPERTY(SaveGame)` values. Params: `slotName, userIndex? (default 0)` |
 
 ---
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/ReflectionHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/ReflectionHandlers.cpp
@@ -20,6 +20,9 @@
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
 #include "JsonSerializer.h"
+#include "JsonObjectConverter.h"
+#include "GameFramework/SaveGame.h"
+#include "Kismet/GameplayStatics.h"
 #include "HAL/PlatformFileManager.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
@@ -39,6 +42,7 @@ void FReflectionHandlers::RegisterHandlers(FMCPHandlerRegistry& Registry)
 	Registry.RegisterHandler(TEXT("is_class_loaded"), &IsClassLoaded);
 	Registry.RegisterHandler(TEXT("is_module_loaded"), &IsModuleLoaded);
 	Registry.RegisterHandler(TEXT("list_loaded_modules"), &ListLoadedModules);
+	Registry.RegisterHandler(TEXT("inspect_save_game"), &InspectSaveGame);
 }
 
 // #689: report whether a UClass is currently loaded, and (separately) whether
@@ -129,6 +133,77 @@ TSharedPtr<FJsonValue> FReflectionHandlers::ListLoadedModules(const TSharedPtr<F
 	Result->SetNumberField(TEXT("count"), Out.Num());
 	Result->SetNumberField(TEXT("totalLoaded"), LoadedCount);
 	Result->SetNumberField(TEXT("totalModules"), Statuses.Num());
+	return MCPResult(Result);
+}
+
+TSharedPtr<FJsonValue> FReflectionHandlers::InspectSaveGame(const TSharedPtr<FJsonObject>& Params)
+{
+	MCP_CHECK_GAME_THREAD();
+
+	FString SlotName;
+	if (auto Err = RequireString(Params, TEXT("slotName"), SlotName)) return Err;
+	int32 UserIndex = 0;
+	if (Params->HasField(TEXT("userIndex")))
+	{
+		double RawUserIndex = 0.0;
+		if (!Params->TryGetNumberField(TEXT("userIndex"), RawUserIndex) ||
+			!FMath::IsFinite(RawUserIndex) || RawUserIndex < 0.0 ||
+			RawUserIndex > static_cast<double>(MAX_int32) || FMath::TruncToDouble(RawUserIndex) != RawUserIndex)
+		{
+			return MCPError(TEXT("userIndex must be a non-negative integer"));
+		}
+		UserIndex = static_cast<int32>(RawUserIndex);
+	}
+
+	if (SlotName.Len() > 128 || SlotName != SlotName.TrimStartAndEnd() ||
+		SlotName == TEXT(".") || SlotName == TEXT("..") || SlotName.Contains(TEXT("..")) ||
+		SlotName != FPaths::MakeValidFileName(SlotName))
+	{
+		return MCPError(TEXT("Invalid slotName: use a plain filename without path separators, traversal, or surrounding whitespace"));
+	}
+	if (!UGameplayStatics::DoesSaveGameExist(SlotName, UserIndex))
+	{
+		return MCPError(FString::Printf(TEXT("Save game slot does not exist: %s (userIndex %d)"), *SlotName, UserIndex));
+	}
+
+	USaveGame* SaveGame = UGameplayStatics::LoadGameFromSlot(SlotName, UserIndex);
+	if (!SaveGame)
+	{
+		return MCPError(FString::Printf(TEXT("Failed to load save game slot: %s (userIndex %d)"), *SlotName, UserIndex));
+	}
+
+	TSharedPtr<FJsonObject> Properties = MakeShared<FJsonObject>();
+	int32 PropertyCount = 0;
+	for (TFieldIterator<FProperty> It(SaveGame->GetClass(), EFieldIteratorFlags::IncludeSuper); It; ++It)
+	{
+		FProperty* Property = *It;
+		if (!Property || !Property->HasAnyPropertyFlags(CPF_SaveGame) ||
+			Property->HasAnyPropertyFlags(CPF_Transient | CPF_DuplicateTransient))
+		{
+			continue;
+		}
+
+		const void* Value = Property->ContainerPtrToValuePtr<void>(SaveGame);
+		TSharedPtr<FJsonValue> JsonValue = FJsonObjectConverter::UPropertyToJsonValue(
+			Property, Value, 0, CPF_Transient | CPF_DuplicateTransient);
+		if (!JsonValue.IsValid())
+		{
+			return MCPError(FString::Printf(
+				TEXT("Failed to serialize SaveGame property '%s' on class '%s'"),
+				*Property->GetName(), *SaveGame->GetClass()->GetPathName()));
+		}
+
+		Properties->SetField(Property->GetName(), JsonValue);
+		++PropertyCount;
+	}
+
+	auto Result = MCPSuccess();
+	Result->SetStringField(TEXT("slotName"), SlotName);
+	Result->SetNumberField(TEXT("userIndex"), UserIndex);
+	Result->SetStringField(TEXT("className"), SaveGame->GetClass()->GetName());
+	Result->SetStringField(TEXT("classPath"), SaveGame->GetClass()->GetPathName());
+	Result->SetNumberField(TEXT("propertyCount"), PropertyCount);
+	Result->SetObjectField(TEXT("properties"), Properties);
 	return MCPResult(Result);
 }
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/ReflectionHandlers.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/ReflectionHandlers.h
@@ -24,6 +24,7 @@ private:
 	static TSharedPtr<FJsonValue> IsClassLoaded(const TSharedPtr<FJsonObject>& Params);
 	static TSharedPtr<FJsonValue> IsModuleLoaded(const TSharedPtr<FJsonObject>& Params);
 	static TSharedPtr<FJsonValue> ListLoadedModules(const TSharedPtr<FJsonObject>& Params);
+	static TSharedPtr<FJsonValue> InspectSaveGame(const TSharedPtr<FJsonObject>& Params);
 
 	// Helper functions
 	static UClass* FindClass(const FString& ClassName);

--- a/src/tools/reflection.ts
+++ b/src/tools/reflection.ts
@@ -3,7 +3,7 @@ import { categoryTool, bp, type ToolDef } from "../types.js";
 
 export const reflectionTool: ToolDef = categoryTool(
   "reflection",
-  "UE reflection: classes, structs, enums, gameplay tags.",
+  "UE reflection: classes, structs, enums, gameplay tags, and SaveGame instances.",
   {
     reflect_class:  bp("Reflect UClass. Params: className, includeInherited?", "reflect_class"),
     reflect_struct: bp("Reflect UScriptStruct. Params: structName", "reflect_struct"),
@@ -16,12 +16,15 @@ export const reflectionTool: ToolDef = categoryTool(
     is_class_loaded: bp("Report whether a UClass is currently loaded in the editor (loaded), whether it exists/is loadable (exists), and its owning module + that module's load state. Distinguishes 'not loaded yet' from 'does not exist'. Params: className (short name, /Script/<Module>.<Class>, or BP class path) (#689)", "is_class_loaded", (p) => ({ className: p.className })),
     is_module_loaded: bp("Report whether a named module is currently loaded. Params: moduleName (#689)", "is_module_loaded", (p) => ({ moduleName: p.moduleName })),
     list_loaded_modules: bp("Enumerate modules with runtime load state. Params: filter? (case-insensitive substring), loadedOnly? (default false). Returns modules[{name, loaded, gameModule}] + totalLoaded/totalModules (#689)", "list_loaded_modules", (p) => ({ filter: p.filter, loadedOnly: p.loadedOnly })),
+    inspect_save_game: bp("Load a SaveGame slot read-only and return its reflected UPROPERTY(SaveGame) values. Params: slotName, userIndex? (default 0)", "inspect_save_game", (p) => ({ slotName: p.slotName, userIndex: p.userIndex })),
   },
   undefined,
   {
     className: z.string().optional(),
     moduleName: z.string().optional().describe("is_module_loaded: module name (#689)"),
     loadedOnly: z.boolean().optional().describe("list_loaded_modules: only loaded modules (#689)"),
+    slotName: z.string().min(1).max(128).optional().describe("inspect_save_game: logical save slot name without a path"),
+    userIndex: z.number().int().nonnegative().optional().describe("inspect_save_game: platform user index (default 0)"),
     includeInherited: z.boolean().optional(),
     structName: z.string().optional(),
     enumName: z.string().optional(),

--- a/tests/unit/reflection-savegame.test.ts
+++ b/tests/unit/reflection-savegame.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { reflectionTool } from "../../src/tools/reflection.js";
+import type { ToolContext } from "../../src/types.js";
+
+describe("reflection.inspect_save_game", () => {
+  it("maps the validated slot selector to the native handler", async () => {
+    const call = vi.fn().mockResolvedValue({ success: true });
+    const ctx = { bridge: { call } } as unknown as ToolContext;
+
+    await reflectionTool.handler(ctx, {
+      action: "inspect_save_game",
+      slotName: "UserSettings",
+      userIndex: 2,
+      className: "ignored",
+    });
+
+    expect(call).toHaveBeenCalledWith(
+      "inspect_save_game",
+      { slotName: "UserSettings", userIndex: 2 },
+      undefined,
+    );
+  });
+
+  it("rejects negative and fractional user indexes in the public schema", () => {
+    expect(reflectionTool.schema.userIndex.safeParse(-1).success).toBe(false);
+    expect(reflectionTool.schema.userIndex.safeParse(0.5).success).toBe(false);
+    expect(reflectionTool.schema.userIndex.safeParse(0).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- add the read-only `reflection.inspect_save_game` action
- validate logical slot names and user indexes at both TypeScript and C++ boundaries
- return class metadata and reflected values for properties marked `UPROPERTY(SaveGame)`

## Why

Existing reflection actions can inspect types but cannot inspect a serialized SaveGame instance. This adds a narrow native path for loading and examining a selected slot without modifying or deleting save data.

## User impact

MCP clients can inspect SaveGame state without using the Python escape hatch. The response includes the loaded class, slot selector, property count, and JSON-compatible saved property values.

## Validation

- `npm run test:unit` (270 passed)
- `npx tsc --noEmit`
- `npm run audit`
- UE 5.8 plugin build via `npm run build` with `UE_BUILD_TOOL_PATH`

## Follow-up

Live handler smoke testing still needs a dedicated editor session running the upgraded bridge. The native bridge compiled successfully and the typed action and drift tests pass.