### PR TITLE
Check validity of enum iterator before use

### DIFF
--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/ReflectionHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/ReflectionHandlers.cpp
@@ -818,7 +818,7 @@ static TArray<FString> SuggestEnumNames(const FString& EnumName, int32 MaxSugges
 	const FString Needle = EnumName.ToLower();
 	for (TObjectIterator<UEnum> It; It && Suggestions.Num() < MaxSuggestions; ++It)
 	{
-		if (!*It) continue;
+		if (!IsValid(*It)) continue;
 		const FString Name = It->GetName();
 		if (Name.ToLower().Contains(Needle))
 		{


### PR DESCRIPTION
I made a fix to Reflection Handlers.cpp, and removed a null pointer check. This fixed a build error, and now the build compiles cleanly on Mac.