### PR TITLE
Guard UE-MCP test engine builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,9 @@ Edit only under `plugin/ue_mcp_bridge/`. The deployer syncs to `tests/ue_mcp/Plu
 ### Building the plugin
 
 - TS: `npx tsc --noEmit` for type-checking, `npx tsc` for emit. Build output goes to `dist/`.
-- UE C++: `npm run build`. Set `UE_MCP_TEST_ENGINE_ROOT` to a dedicated test engine containing a root-level `.ue-mcp-test-engine` marker, and list daily-development or production roots in `UE_MCP_PROTECTED_ENGINE_ROOTS` first. The build and run scripts derive their executables from that one root.
-- Test builds add `-NoEngineChanges` by default. Set `UE_MCP_ALLOW_TEST_ENGINE_CHANGES=true` only to bootstrap engine outputs in an isolated test root. Protected roots are always rejected.
-- Do not invoke Build.bat or UnrealBuildTool directly, add `-NoLiveCoding`, or pass alternate targets for the test project. The `ue_mcpEditor` target enforces the engine-root policy as a second guard.
+- UE C++: `npm run build`. This calls `scripts/build.js`, which always builds the `ue_mcpEditor` target against `tests/ue_mcp/ue_mcp.uproject` and nothing else.
+- Test builds pass `-NoEngineChanges`, so Unreal aborts with the offending file list if the build would overwrite anything already in the engine tree. Set `UE_MCP_ALLOW_TEST_ENGINE_CHANGES=true` only to bootstrap engine outputs in an engine you are willing to have written to.
+- Optional: `UE_MCP_TEST_ENGINE_ROOT` pins the engine to build and run with, and `UE_MCP_PROTECTED_ENGINE_ROOTS` is a deny list of roots the scripts refuse to touch at all. The deny list outranks every other setting, including the opt-in above.
 - `npm run up:build` stops the editor, builds, and relaunches. Use when iterating live.
 - The deployer (`scripts/deploy.mjs`, also called implicitly by `npm run up`) syncs `plugin/` → `tests/ue_mcp/Plugins/UE_MCP_Bridge/`. Run it after plugin source edits before building.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,9 @@ Edit only under `plugin/ue_mcp_bridge/`. The deployer syncs to `tests/ue_mcp/Plu
 ### Building the plugin
 
 - TS: `npx tsc --noEmit` for type-checking, `npx tsc` for emit. Build output goes to `dist/`.
-- UE C++: `npm run build`. This calls `scripts/build.js` which invokes Unreal's Build.bat against `tests/ue_mcp/ue_mcp.uproject`.
+- UE C++: `npm run build`. Set `UE_MCP_TEST_ENGINE_ROOT` to a dedicated test engine containing a root-level `.ue-mcp-test-engine` marker, and list daily-development or production roots in `UE_MCP_PROTECTED_ENGINE_ROOTS` first. The build and run scripts derive their executables from that one root.
+- Test builds add `-NoEngineChanges` by default. Set `UE_MCP_ALLOW_TEST_ENGINE_CHANGES=true` only to bootstrap engine outputs in an isolated test root. Protected roots are always rejected.
+- Do not invoke Build.bat or UnrealBuildTool directly, add `-NoLiveCoding`, or pass alternate targets for the test project. The `ue_mcpEditor` target enforces the engine-root policy as a second guard.
 - `npm run up:build` stops the editor, builds, and relaunches. Use when iterating live.
 - The deployer (`scripts/deploy.mjs`, also called implicitly by `npm run up`) syncs `plugin/` → `tests/ue_mcp/Plugins/UE_MCP_Bridge/`. Run it after plugin source edits before building.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,18 +41,25 @@ npm run build          # UE C++ plugin build (requires editor closed)
 
 `npx tsc` emits the TypeScript server into `dist/`. `npm run build` is the C++ plugin build that runs Unreal's build tool against the test project and requires the editor to be closed first.
 
-UE-MCP test builds require a dedicated engine root. They do not auto-discover an installed engine and must not use a daily-development or production engine tree. Configure the test lane before building:
+The build script only ever builds the `ue_mcpEditor` target against the bundled `tests/ue_mcp/ue_mcp.uproject`, and it refuses to start if that resolves anywhere else. It also passes `-NoEngineChanges`, so Unreal itself aborts the build and prints the offending file list if the build would overwrite a file that already exists under the engine tree. That is what keeps a test build from invalidating the outputs of a shared source engine you use for other work.
+
+Engine selection order is `UE_MCP_TEST_ENGINE_ROOT`, then `UE_BUILD_TOOL_PATH`, then the default install locations. A pinned root that has no build tool is an error rather than a silent fallback to an engine you did not ask for.
+
+Two optional environment variables tune the guard:
 
 ```powershell
-$null = New-Item -ItemType File 'D:\UE-Test\.ue-mcp-test-engine'
-$env:UE_MCP_TEST_ENGINE_ROOT = 'D:\UE-Test'
+# Roots the build and run scripts must never touch, whatever else is set.
 $env:UE_MCP_PROTECTED_ENGINE_ROOTS = 'D:\UE-Primary;D:\UE-Release'
+
+# Pin the engine used for test builds and editor launches.
+$env:UE_MCP_TEST_ENGINE_ROOT = 'D:\UE-Test'
+
 npm run build
 ```
 
-The `.ue-mcp-test-engine` marker must exist at the selected engine root. Create it only in an engine tree dedicated to UE-MCP testing. `UE_MCP_PROTECTED_ENGINE_ROOTS` uses the platform path-list delimiter (`;` on Windows, `:` on macOS and Linux). The selected test engine cannot be equal to or nested under a protected root, even if it has a marker. The build script derives both Unreal's build tool and editor executable from `UE_MCP_TEST_ENGINE_ROOT`, fixes the target to `ue_mcpEditor`, and adds `-NoEngineChanges` by default. The target rules enforce the same policy when UnrealBuildTool is called directly.
+`UE_MCP_PROTECTED_ENGINE_ROOTS` uses the platform path-list delimiter (`;` on Windows, `:` on macOS and Linux). A selected engine equal to or nested under a protected root is rejected, including when it arrives through `UE_BUILD_TOOL_PATH` or `UE_EDITOR_PATH`.
 
-A new dedicated test engine may need to create its engine-side outputs once. For that isolated bootstrap only, set `UE_MCP_ALLOW_TEST_ENGINE_CHANGES=true`. Protected roots remain forbidden even with this opt-in. Do not add `-NoLiveCoding` or pass alternate build flags directly; use `npm run build` so the guard remains active. Use `npm run up:build` to chain stop-build-start during plugin iteration.
+A fresh engine may need to create its engine-side outputs once. For that bootstrap only, set `UE_MCP_ALLOW_TEST_ENGINE_CHANGES=true` to drop `-NoEngineChanges`. Protected roots stay forbidden even with this opt-in, and the build prints a warning naming the variable so an opt-in left in your environment is visible. Use `npm run up:build` to chain stop-build-start during plugin iteration.
 
 ## Running
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,7 +39,20 @@ npx tsc                # TypeScript -> dist/ (what the server ships as)
 npm run build          # UE C++ plugin build (requires editor closed)
 ```
 
-`npx tsc` emits the TypeScript server into `dist/`. `npm run build` is the C++ plugin build that runs Unreal's `Build.bat` against the test project and requires the editor to be closed first. Use `npm run up:build` to chain stop-build-start during plugin iteration.
+`npx tsc` emits the TypeScript server into `dist/`. `npm run build` is the C++ plugin build that runs Unreal's build tool against the test project and requires the editor to be closed first.
+
+UE-MCP test builds require a dedicated engine root. They do not auto-discover an installed engine and must not use a daily-development or production engine tree. Configure the test lane before building:
+
+```powershell
+$null = New-Item -ItemType File 'D:\UE-Test\.ue-mcp-test-engine'
+$env:UE_MCP_TEST_ENGINE_ROOT = 'D:\UE-Test'
+$env:UE_MCP_PROTECTED_ENGINE_ROOTS = 'D:\UE-Primary;D:\UE-Release'
+npm run build
+```
+
+The `.ue-mcp-test-engine` marker must exist at the selected engine root. Create it only in an engine tree dedicated to UE-MCP testing. `UE_MCP_PROTECTED_ENGINE_ROOTS` uses the platform path-list delimiter (`;` on Windows, `:` on macOS and Linux). The selected test engine cannot be equal to or nested under a protected root, even if it has a marker. The build script derives both Unreal's build tool and editor executable from `UE_MCP_TEST_ENGINE_ROOT`, fixes the target to `ue_mcpEditor`, and adds `-NoEngineChanges` by default. The target rules enforce the same policy when UnrealBuildTool is called directly.
+
+A new dedicated test engine may need to create its engine-side outputs once. For that isolated bootstrap only, set `UE_MCP_ALLOW_TEST_ENGINE_CHANGES=true`. Protected roots remain forbidden even with this opt-in. Do not add `-NoLiveCoding` or pass alternate build flags directly; use `npm run build` so the guard remains active. Use `npm run up:build` to chain stop-build-start during plugin iteration.
 
 ## Running
 

--- a/scripts/build-utils.js
+++ b/scripts/build-utils.js
@@ -5,7 +5,6 @@ import { dirname } from 'path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const TEST_ENGINE_MARKER = '.ue-mcp-test-engine';
 
 // ANSI color codes for better output
 const colors = {
@@ -39,48 +38,52 @@ function envFlag(env, name) {
   return /^(1|true|yes|on)$/i.test(env[name] || '');
 }
 
-function canonicalDirectory(directoryPath, variableName) {
-  if (!path.isAbsolute(directoryPath)) {
-    throw new Error(`${variableName} must be an absolute path.`);
-  }
-
-  try {
-    return fs.realpathSync.native(directoryPath);
-  } catch {
-    throw new Error(`${variableName} does not identify an existing directory: ${directoryPath}`);
-  }
+function pathImpl(platform) {
+  return platform === 'win32' ? path.win32 : path.posix;
 }
 
+/**
+ * Normalize a path for comparison on the target platform. Windows paths are
+ * case-insensitive, so they are lowercased; separators are normalized and a
+ * trailing separator is dropped so `D:\Engine` and `D:\Engine\` compare equal.
+ */
 function comparisonPath(value, platform = process.platform) {
-  const normalized = path.normalize(value).replace(/[\\/]+$/, '');
+  const normalized = pathImpl(platform).normalize(value).replace(/[\\/]+$/, '');
   return platform === 'win32' ? normalized.toLowerCase() : normalized;
 }
 
+/**
+ * True when `candidate` is `parent` itself or lives beneath it. The trailing
+ * separator on the parent is what stops `/ue/engine-test` from being treated
+ * as a child of `/ue/engine`.
+ */
 function isSameOrUnder(candidate, parent, platform = process.platform) {
   const normalizedCandidate = comparisonPath(candidate, platform);
   const normalizedParent = comparisonPath(parent, platform);
   return normalizedCandidate === normalizedParent ||
-    normalizedCandidate.startsWith(`${normalizedParent}${path.sep}`);
+    normalizedCandidate.startsWith(`${normalizedParent}${pathImpl(platform).sep}`);
 }
 
 function engineExecutables(engineRoot, platform = process.platform) {
+  const impl = pathImpl(platform);
+
   if (platform === 'win32') {
     return {
-      buildTool: path.join(engineRoot, 'Engine', 'Build', 'BatchFiles', 'Build.bat'),
-      editorExecutable: path.join(engineRoot, 'Engine', 'Binaries', 'Win64', 'UnrealEditor.exe'),
+      buildTool: impl.join(engineRoot, 'Engine', 'Build', 'BatchFiles', 'Build.bat'),
+      editorExecutable: impl.join(engineRoot, 'Engine', 'Binaries', 'Win64', 'UnrealEditor.exe'),
     };
   }
 
   if (platform === 'darwin') {
     return {
-      buildTool: path.join(engineRoot, 'Engine', 'Build', 'BatchFiles', 'Mac', 'Build.sh'),
-      editorExecutable: path.join(engineRoot, 'Engine', 'Binaries', 'Mac', 'UnrealEditor.app', 'Contents', 'MacOS', 'UnrealEditor'),
+      buildTool: impl.join(engineRoot, 'Engine', 'Build', 'BatchFiles', 'Mac', 'Build.sh'),
+      editorExecutable: impl.join(engineRoot, 'Engine', 'Binaries', 'Mac', 'UnrealEditor.app', 'Contents', 'MacOS', 'UnrealEditor'),
     };
   }
 
   return {
-    buildTool: path.join(engineRoot, 'Engine', 'Build', 'BatchFiles', 'Linux', 'Build.sh'),
-    editorExecutable: path.join(engineRoot, 'Engine', 'Binaries', 'Linux', 'UnrealEditor'),
+    buildTool: impl.join(engineRoot, 'Engine', 'Build', 'BatchFiles', 'Linux', 'Build.sh'),
+    editorExecutable: impl.join(engineRoot, 'Engine', 'Binaries', 'Linux', 'UnrealEditor'),
   };
 }
 
@@ -90,41 +93,160 @@ function unrealTargetPlatform(platform = process.platform) {
   return 'Linux';
 }
 
-function resolveTestEngine(env = process.env, platform = process.platform) {
-  const configuredRoot = env.UE_MCP_TEST_ENGINE_ROOT;
-  if (!configuredRoot) {
-    throw new Error('UE_MCP_TEST_ENGINE_ROOT is required. Use a dedicated engine root for UE-MCP tests.');
+/**
+ * Walk up from a path inside an engine tree to the engine root (the directory
+ * that contains `Engine`). Covers the Windows build tool layout
+ * (Engine/Build/BatchFiles/Build.bat), the Mac and Linux layouts
+ * (Engine/Build/BatchFiles/<Platform>/Build.sh), and editor binaries.
+ */
+function engineRootFromEnginePath(enginePath, platform = process.platform) {
+  const impl = pathImpl(platform);
+  let directory = impl.dirname(enginePath);
+
+  while (directory && directory !== impl.dirname(directory)) {
+    if (impl.basename(directory).toLowerCase() === 'engine') {
+      return impl.dirname(directory);
+    }
+    directory = impl.dirname(directory);
   }
 
-  const engineRoot = canonicalDirectory(configuredRoot, 'UE_MCP_TEST_ENGINE_ROOT');
-  const markerPath = path.join(engineRoot, TEST_ENGINE_MARKER);
-  if (!fs.existsSync(markerPath)) {
-    throw new Error(`UE_MCP_TEST_ENGINE_ROOT is not marked as a dedicated test engine. Missing: ${markerPath}`);
-  }
-
-  const protectedRoots = (env.UE_MCP_PROTECTED_ENGINE_ROOTS || '')
-    .split(path.delimiter)
-    .filter(Boolean)
-    .map((protectedRoot) => canonicalDirectory(protectedRoot, 'UE_MCP_PROTECTED_ENGINE_ROOTS'));
-
-  const protectedRoot = protectedRoots.find((root) => isSameOrUnder(engineRoot, root, platform));
-  if (protectedRoot) {
-    throw new Error(`UE-MCP test builds are forbidden under protected engine root: ${protectedRoot}`);
-  }
-
-  const executables = engineExecutables(engineRoot, platform);
-  if (!fs.existsSync(executables.buildTool)) {
-    throw new Error(`Unreal build tool not found in UE_MCP_TEST_ENGINE_ROOT: ${executables.buildTool}`);
-  }
-
-  return {
-    engineRoot,
-    protectedRoots,
-    allowEngineChanges: envFlag(env, 'UE_MCP_ALLOW_TEST_ENGINE_CHANGES'),
-    ...executables,
-  };
+  return null;
 }
 
+function defaultEngineRoots(platform = process.platform) {
+  const versions = ['5.8', '5.7', '5.6', '5.5', '5.4', '5.3'];
+
+  if (platform === 'win32') {
+    return versions.map((version) => path.win32.join('C:/Program Files/Epic Games', `UE_${version}`));
+  }
+
+  if (platform === 'darwin') {
+    return versions.map((version) => path.posix.join('/Users/Shared/Epic Games', `UE_${version}`));
+  }
+
+  return [];
+}
+
+/**
+ * Ordered list of candidate engine roots, most explicit first. Each entry
+ * carries the name of the thing that produced it so failures can name the
+ * setting the caller has to correct.
+ */
+function engineRootCandidates(env = process.env, platform = process.platform) {
+  const candidates = [];
+
+  if (env.UE_MCP_TEST_ENGINE_ROOT) {
+    candidates.push({ source: 'UE_MCP_TEST_ENGINE_ROOT', engineRoot: env.UE_MCP_TEST_ENGINE_ROOT });
+  }
+
+  if (env.UE_BUILD_TOOL_PATH) {
+    const derived = engineRootFromEnginePath(env.UE_BUILD_TOOL_PATH, platform);
+    if (derived) {
+      candidates.push({ source: 'UE_BUILD_TOOL_PATH', engineRoot: derived });
+    }
+  }
+
+  for (const engineRoot of defaultEngineRoots(platform)) {
+    candidates.push({ source: 'default engine install', engineRoot });
+  }
+
+  return candidates;
+}
+
+function canonicalDirectory(directoryPath) {
+  try {
+    return fs.realpathSync.native(directoryPath);
+  } catch {
+    return path.resolve(directoryPath);
+  }
+}
+
+/**
+ * Roots the build must never touch. Listing a root here is a hard deny: it wins
+ * over every other setting, including UE_MCP_ALLOW_TEST_ENGINE_CHANGES.
+ *
+ * A relative entry is rejected rather than resolved against the current working
+ * directory. Silently turning a mistyped deny entry into a path that can never
+ * match would leave the caller believing an engine is protected when it is not.
+ */
+function protectedEngineRoots(env = process.env) {
+  return (env.UE_MCP_PROTECTED_ENGINE_ROOTS || '')
+    .split(path.delimiter)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      if (!path.isAbsolute(entry)) {
+        throw new Error(
+          `UE_MCP_PROTECTED_ENGINE_ROOTS entry '${entry}' is not an absolute path, so it would protect nothing.`
+        );
+      }
+      return canonicalDirectory(entry);
+    });
+}
+
+function assertNotProtected(engineRoot, roots, platform = process.platform) {
+  const match = roots.find((root) => isSameOrUnder(engineRoot, root, platform));
+  if (match) {
+    throw new Error(
+      `Engine root '${engineRoot}' is listed in UE_MCP_PROTECTED_ENGINE_ROOTS ('${match}'). ` +
+      'UE-MCP test builds refuse to run against a protected engine.'
+    );
+  }
+}
+
+/**
+ * Pick the engine the test project builds and runs against.
+ *
+ * Resolution never silently falls back to "no engine": if nothing usable is
+ * found the caller gets an error naming every location that was tried.
+ */
+function resolveTestEngine(env = process.env, platform = process.platform) {
+  const roots = protectedEngineRoots(env);
+  const candidates = engineRootCandidates(env, platform);
+  const tried = [];
+
+  for (const candidate of candidates) {
+    const engineRoot = canonicalDirectory(candidate.engineRoot);
+    const executables = engineExecutables(engineRoot, platform);
+
+    if (!fs.existsSync(executables.buildTool)) {
+      tried.push(`${executables.buildTool} (from ${candidate.source})`);
+
+      // An explicitly configured root that does not exist is a mistake worth
+      // reporting on its own rather than quietly falling through to a default
+      // install the caller did not ask for.
+      if (candidate.source !== 'default engine install') {
+        throw new Error(
+          `${candidate.source} does not point at a usable Unreal engine: ${executables.buildTool} is missing.`
+        );
+      }
+      continue;
+    }
+
+    assertNotProtected(engineRoot, roots, platform);
+
+    return {
+      engineRoot,
+      engineRootSource: candidate.source,
+      protectedRoots: roots,
+      allowEngineChanges: envFlag(env, 'UE_MCP_ALLOW_TEST_ENGINE_CHANGES'),
+      ...executables,
+    };
+  }
+
+  throw new Error(
+    'Unreal Engine build tool not found. Set UE_MCP_TEST_ENGINE_ROOT to a dedicated engine root ' +
+    '(or UE_BUILD_TOOL_PATH to a Build.bat / Build.sh), or install UE 5.3+ to a default location. Tried:\n  ' +
+    (tried.join('\n  ') || '(no candidate locations)')
+  );
+}
+
+/**
+ * Everything scripts/build.js needs to spawn Unreal, with the safety rails
+ * already applied: a fixed target, the repo's own test project, and
+ * `-NoEngineChanges` so Unreal itself aborts the build if it would overwrite
+ * an existing file under the engine tree.
+ */
 function createTestBuildPlan(env = process.env, platform = process.platform) {
   const engine = resolveTestEngine(env, platform);
   const { projectRoot, projectFile } = getProjectPaths();
@@ -150,17 +272,37 @@ function getProjectPaths() {
   return { projectRoot, projectFile };
 }
 
+/**
+ * The build scripts must only ever drive the bundled test project. This asserts
+ * that the path they resolved is still the one inside this repository, so a
+ * future refactor cannot quietly retarget them at somebody's real game.
+ */
+function assertTestProject(projectFile) {
+  const expected = getProjectPaths().projectFile;
+  if (comparisonPath(projectFile) !== comparisonPath(expected)) {
+    throw new Error(
+      `Refusing to build '${projectFile}'. UE-MCP build scripts only build the bundled test project at '${expected}'.`
+    );
+  }
+  if (!fs.existsSync(expected)) {
+    throw new Error(`Test project not found: ${expected}`);
+  }
+}
+
 export {
   colors,
-  TEST_ENGINE_MARKER,
   log,
   logSection,
   fileExists,
   envFlag,
+  comparisonPath,
   engineExecutables,
+  engineRootFromEnginePath,
   unrealTargetPlatform,
   isSameOrUnder,
+  protectedEngineRoots,
   resolveTestEngine,
   createTestBuildPlan,
   getProjectPaths,
+  assertTestProject,
 };

--- a/scripts/build-utils.js
+++ b/scripts/build-utils.js
@@ -5,6 +5,7 @@ import { dirname } from 'path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const TEST_ENGINE_MARKER = '.ue-mcp-test-engine';
 
 // ANSI color codes for better output
 const colors = {
@@ -34,25 +35,113 @@ async function fileExists(filePath) {
   }
 }
 
-function findUEBuildTool() {
-  // Check for environment variable override first
-  const envPath = process.env.UE_BUILD_TOOL_PATH;
-  if (envPath) {
-    return envPath;
+function envFlag(env, name) {
+  return /^(1|true|yes|on)$/i.test(env[name] || '');
+}
+
+function canonicalDirectory(directoryPath, variableName) {
+  if (!path.isAbsolute(directoryPath)) {
+    throw new Error(`${variableName} must be an absolute path.`);
   }
 
-  // Check default UE5 installation paths
-  const versions = ['5.8', '5.7', '5.6', '5.5', '5.4', '5.3'];
-  const basePath = 'C:/Program Files/Epic Games';
-  
-  for (const version of versions) {
-    const buildToolPath = path.join(basePath, `UE_${version}`, 'Engine', 'Build', 'BatchFiles', 'Build.bat');
-    if (fs.existsSync(buildToolPath)) {
-      return buildToolPath;
-    }
+  try {
+    return fs.realpathSync.native(directoryPath);
+  } catch {
+    throw new Error(`${variableName} does not identify an existing directory: ${directoryPath}`);
+  }
+}
+
+function comparisonPath(value, platform = process.platform) {
+  const normalized = path.normalize(value).replace(/[\\/]+$/, '');
+  return platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
+function isSameOrUnder(candidate, parent, platform = process.platform) {
+  const normalizedCandidate = comparisonPath(candidate, platform);
+  const normalizedParent = comparisonPath(parent, platform);
+  return normalizedCandidate === normalizedParent ||
+    normalizedCandidate.startsWith(`${normalizedParent}${path.sep}`);
+}
+
+function engineExecutables(engineRoot, platform = process.platform) {
+  if (platform === 'win32') {
+    return {
+      buildTool: path.join(engineRoot, 'Engine', 'Build', 'BatchFiles', 'Build.bat'),
+      editorExecutable: path.join(engineRoot, 'Engine', 'Binaries', 'Win64', 'UnrealEditor.exe'),
+    };
   }
 
-  return null;
+  if (platform === 'darwin') {
+    return {
+      buildTool: path.join(engineRoot, 'Engine', 'Build', 'BatchFiles', 'Mac', 'Build.sh'),
+      editorExecutable: path.join(engineRoot, 'Engine', 'Binaries', 'Mac', 'UnrealEditor.app', 'Contents', 'MacOS', 'UnrealEditor'),
+    };
+  }
+
+  return {
+    buildTool: path.join(engineRoot, 'Engine', 'Build', 'BatchFiles', 'Linux', 'Build.sh'),
+    editorExecutable: path.join(engineRoot, 'Engine', 'Binaries', 'Linux', 'UnrealEditor'),
+  };
+}
+
+function unrealTargetPlatform(platform = process.platform) {
+  if (platform === 'win32') return 'Win64';
+  if (platform === 'darwin') return 'Mac';
+  return 'Linux';
+}
+
+function resolveTestEngine(env = process.env, platform = process.platform) {
+  const configuredRoot = env.UE_MCP_TEST_ENGINE_ROOT;
+  if (!configuredRoot) {
+    throw new Error('UE_MCP_TEST_ENGINE_ROOT is required. Use a dedicated engine root for UE-MCP tests.');
+  }
+
+  const engineRoot = canonicalDirectory(configuredRoot, 'UE_MCP_TEST_ENGINE_ROOT');
+  const markerPath = path.join(engineRoot, TEST_ENGINE_MARKER);
+  if (!fs.existsSync(markerPath)) {
+    throw new Error(`UE_MCP_TEST_ENGINE_ROOT is not marked as a dedicated test engine. Missing: ${markerPath}`);
+  }
+
+  const protectedRoots = (env.UE_MCP_PROTECTED_ENGINE_ROOTS || '')
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map((protectedRoot) => canonicalDirectory(protectedRoot, 'UE_MCP_PROTECTED_ENGINE_ROOTS'));
+
+  const protectedRoot = protectedRoots.find((root) => isSameOrUnder(engineRoot, root, platform));
+  if (protectedRoot) {
+    throw new Error(`UE-MCP test builds are forbidden under protected engine root: ${protectedRoot}`);
+  }
+
+  const executables = engineExecutables(engineRoot, platform);
+  if (!fs.existsSync(executables.buildTool)) {
+    throw new Error(`Unreal build tool not found in UE_MCP_TEST_ENGINE_ROOT: ${executables.buildTool}`);
+  }
+
+  return {
+    engineRoot,
+    protectedRoots,
+    allowEngineChanges: envFlag(env, 'UE_MCP_ALLOW_TEST_ENGINE_CHANGES'),
+    ...executables,
+  };
+}
+
+function createTestBuildPlan(env = process.env, platform = process.platform) {
+  const engine = resolveTestEngine(env, platform);
+  const { projectRoot, projectFile } = getProjectPaths();
+  const buildArgs = [
+    'ue_mcpEditor',
+    unrealTargetPlatform(platform),
+    'Development',
+    `-Project="${projectFile}"`,
+    '-WaitMutex',
+    '-FromMsBuild',
+  ];
+
+  if (!engine.allowEngineChanges) {
+    buildArgs.push('-NoEngineChanges');
+  }
+
+  return { ...engine, projectRoot, projectFile, buildArgs };
 }
 
 function getProjectPaths() {
@@ -63,9 +152,15 @@ function getProjectPaths() {
 
 export {
   colors,
+  TEST_ENGINE_MARKER,
   log,
   logSection,
   fileExists,
-  findUEBuildTool,
+  envFlag,
+  engineExecutables,
+  unrealTargetPlatform,
+  isSameOrUnder,
+  resolveTestEngine,
+  createTestBuildPlan,
   getProjectPaths,
 };

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn, exec } from 'child_process';
-import { log, logSection, fileExists, createTestBuildPlan } from './build-utils.js';
+import { log, logSection, assertTestProject, createTestBuildPlan } from './build-utils.js';
 
 function runCommand(command, args, options = {}) {
   return new Promise((resolve, reject) => {
@@ -62,24 +62,35 @@ async function main() {
   let plan;
   try {
     plan = createTestBuildPlan();
+    assertTestProject(plan.projectFile);
   } catch (error) {
     log(`ERROR: ${error.message}`, 'red');
     process.exit(1);
   }
 
-  const { projectRoot, projectFile, engineRoot, buildTool, buildArgs, allowEngineChanges } = plan;
-
-  // Check if project file exists
-  if (!(await fileExists(projectFile))) {
-    log(`ERROR: Project file not found at ${projectFile}`, 'red');
-    process.exit(1);
-  }
+  const {
+    projectRoot,
+    projectFile,
+    engineRoot,
+    engineRootSource,
+    buildTool,
+    buildArgs,
+    allowEngineChanges,
+    protectedRoots,
+  } = plan;
 
   log(`Project Root: ${projectRoot}`);
   log(`Project File: ${projectFile}`);
-  log(`Test Engine Root: ${engineRoot}`);
+  log(`Engine Root: ${engineRoot} (from ${engineRootSource})`);
   log(`Build Tool: ${buildTool}`);
-  log(`Engine changes: ${allowEngineChanges ? 'explicitly allowed' : 'blocked'}`);
+  if (protectedRoots.length > 0) {
+    log(`Protected roots: ${protectedRoots.join(', ')}`);
+  }
+  if (allowEngineChanges) {
+    log('Engine changes: ALLOWED via UE_MCP_ALLOW_TEST_ENGINE_CHANGES. This build may write into the engine tree.', 'yellow');
+  } else {
+    log('Engine changes: blocked (-NoEngineChanges)');
+  }
   log('');
 
   log('Starting build...');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,16 +1,7 @@
 #!/usr/bin/env node
 
-import path from 'path';
 import { spawn, exec } from 'child_process';
-import { promisify } from 'util';
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
-import { log, logSection, fileExists, findUEBuildTool, getProjectPaths } from './build-utils.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const execPromise = promisify(exec);
+import { log, logSection, fileExists, createTestBuildPlan } from './build-utils.js';
 
 function runCommand(command, args, options = {}) {
   return new Promise((resolve, reject) => {
@@ -68,7 +59,15 @@ function runCommand(command, args, options = {}) {
 async function main() {
   logSection('UE-MCP Build');
 
-  const { projectRoot, projectFile } = getProjectPaths();
+  let plan;
+  try {
+    plan = createTestBuildPlan();
+  } catch (error) {
+    log(`ERROR: ${error.message}`, 'red');
+    process.exit(1);
+  }
+
+  const { projectRoot, projectFile, engineRoot, buildTool, buildArgs, allowEngineChanges } = plan;
 
   // Check if project file exists
   if (!(await fileExists(projectFile))) {
@@ -76,34 +75,12 @@ async function main() {
     process.exit(1);
   }
 
-  // Find UE5 build tool
-  const buildTool = findUEBuildTool();
-  
-  if (!buildTool) {
-    log('ERROR: Unreal Engine build tool not found!', 'red');
-    log('');
-    log('Please either:');
-    log('  1. Install UE5.3+ to default location, OR');
-    log('  2. Set UE_BUILD_TOOL_PATH environment variable to your Build.bat path');
-    log('');
-    log('Example: set UE_BUILD_TOOL_PATH=C:\\Program Files\\Epic Games\\UE_5.8\\Engine\\Build\\BatchFiles\\Build.bat');
-    process.exit(1);
-  }
-
   log(`Project Root: ${projectRoot}`);
   log(`Project File: ${projectFile}`);
+  log(`Test Engine Root: ${engineRoot}`);
   log(`Build Tool: ${buildTool}`);
+  log(`Engine changes: ${allowEngineChanges ? 'explicitly allowed' : 'blocked'}`);
   log('');
-
-  // Build command arguments
-  const buildArgs = [
-    'ue_mcpEditor',
-    'Win64',
-    'Development',
-    `-Project="${projectFile}"`,
-    '-WaitMutex',
-    '-FromMsBuild',
-  ];
 
   log('Starting build...');
   log(`Command: ${buildTool} ${buildArgs.join(' ')}`);

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -2,34 +2,68 @@
 
 import { spawn } from 'child_process';
 import fs from 'fs';
-import { log, logSection, getProjectPaths, resolveTestEngine } from './build-utils.js';
+import path from 'path';
+import {
+  log,
+  logSection,
+  assertTestProject,
+  engineRootFromEnginePath,
+  getProjectPaths,
+  protectedEngineRoots,
+  isSameOrUnder,
+  resolveTestEngine,
+} from './build-utils.js';
+
+/**
+ * UE_EDITOR_PATH stays supported so an existing setup keeps working, but it
+ * goes through the same protected-root deny list as a discovered engine.
+ * Otherwise a stale override would be the one way around the guard.
+ */
+function editorFromOverride(overridePath) {
+  const editorExecutable = path.resolve(overridePath);
+  const engineRoot = engineRootFromEnginePath(editorExecutable) ?? path.dirname(editorExecutable);
+  const roots = protectedEngineRoots();
+  const match = roots.find((root) => isSameOrUnder(engineRoot, root));
+
+  if (match) {
+    throw new Error(
+      `UE_EDITOR_PATH resolves under protected engine root '${match}'. Refusing to launch the test project from it.`
+    );
+  }
+
+  return { editorExecutable, engineRoot, engineRootSource: 'UE_EDITOR_PATH' };
+}
 
 async function main() {
   logSection('UE-MCP Run');
 
   const { projectFile } = getProjectPaths();
-  let testEngine;
+  let engine;
   try {
-    testEngine = resolveTestEngine();
+    assertTestProject(projectFile);
+    engine = process.env.UE_EDITOR_PATH
+      ? editorFromOverride(process.env.UE_EDITOR_PATH)
+      : resolveTestEngine();
   } catch (error) {
     log(`ERROR: ${error.message}`, 'red');
     process.exit(1);
   }
 
-  const editorExe = testEngine.editorExecutable;
+  const editorExe = engine.editorExecutable;
 
   if (!fs.existsSync(editorExe)) {
-    log(`ERROR: Unreal Editor executable not found in UE_MCP_TEST_ENGINE_ROOT: ${editorExe}`, 'red');
+    log(`ERROR: Unreal Editor executable not found: ${editorExe}`, 'red');
+    log(`Resolved from ${engine.engineRootSource}. Set UE_MCP_TEST_ENGINE_ROOT or UE_EDITOR_PATH to correct it.`);
     process.exit(1);
   }
 
   log(`Project File: ${projectFile}`);
-  log(`Test Engine Root: ${testEngine.engineRoot}`);
+  log(`Engine Root: ${engine.engineRoot} (from ${engine.engineRootSource})`);
   log(`Editor: ${editorExe}`);
   log('');
 
   log('Launching Unreal Editor...', 'green');
-  
+
   // Launch editor with project file
   const proc = spawn(editorExe, [projectFile], {
     stdio: 'inherit',

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -1,59 +1,30 @@
 #!/usr/bin/env node
 
 import { spawn } from 'child_process';
-import path from 'path';
 import fs from 'fs';
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
-import { log, logSection, getProjectPaths, findUEBuildTool } from './build-utils.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-function findEditorExecutable() {
-  // Check for environment variable override first
-  const envPath = process.env.UE_EDITOR_PATH;
-  if (envPath) {
-    return envPath;
-  }
-
-  // Find build tool to get engine root
-  const buildTool = findUEBuildTool();
-  if (!buildTool) {
-    return null;
-  }
-
-  // Extract engine root from build tool path
-  // Build.bat is at Engine/Build/BatchFiles/Build.bat
-  // Go up 4 levels to get to UE_X.X root, then Engine/Binaries/Win64/UnrealEditor.exe
-  const engineRoot = path.resolve(buildTool, '..', '..', '..', '..');
-  const editorExe = path.join(engineRoot, 'Engine', 'Binaries', 'Win64', 'UnrealEditor.exe');
-  
-  if (fs.existsSync(editorExe)) {
-    return editorExe;
-  }
-
-  return null;
-}
+import { log, logSection, getProjectPaths, resolveTestEngine } from './build-utils.js';
 
 async function main() {
   logSection('UE-MCP Run');
 
   const { projectFile } = getProjectPaths();
-  const editorExe = findEditorExecutable();
+  let testEngine;
+  try {
+    testEngine = resolveTestEngine();
+  } catch (error) {
+    log(`ERROR: ${error.message}`, 'red');
+    process.exit(1);
+  }
 
-  if (!editorExe) {
-    log('ERROR: Unreal Editor executable not found!', 'red');
-    log('');
-    log('Please either:');
-    log('  1. Install UE5.3+ to default location, OR');
-    log('  2. Set UE_EDITOR_PATH environment variable to your UnrealEditor.exe path');
-    log('');
-    log('Example: set UE_EDITOR_PATH=C:\\Program Files\\Epic Games\\UE_5.8\\Engine\\Binaries\\Win64\\UnrealEditor.exe');
+  const editorExe = testEngine.editorExecutable;
+
+  if (!fs.existsSync(editorExe)) {
+    log(`ERROR: Unreal Editor executable not found in UE_MCP_TEST_ENGINE_ROOT: ${editorExe}`, 'red');
     process.exit(1);
   }
 
   log(`Project File: ${projectFile}`);
+  log(`Test Engine Root: ${testEngine.engineRoot}`);
   log(`Editor: ${editorExe}`);
   log('');
 

--- a/tests/ue_mcp/Source/ue_mcpEditor.Target.cs
+++ b/tests/ue_mcp/Source/ue_mcpEditor.Target.cs
@@ -1,93 +1,13 @@
 using UnrealBuildTool;
-using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 
 public class ue_mcpEditorTarget : TargetRules
 {
 	public ue_mcpEditorTarget(TargetInfo Target) : base(Target)
 	{
-		EnforceTestEnginePolicy();
-
 		Type = TargetType.Editor;
 		DefaultBuildSettings = BuildSettingsVersion.V7;
 		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_8;
 		ExtraModuleNames.Add("ue_mcp");
 	}
-
-	private static void EnforceTestEnginePolicy()
-	{
-		string? ConfiguredRoot = Environment.GetEnvironmentVariable("UE_MCP_TEST_ENGINE_ROOT");
-		if (String.IsNullOrWhiteSpace(ConfiguredRoot) || !Path.IsPathRooted(ConfiguredRoot))
-		{
-			throw new BuildException("UE_MCP_TEST_ENGINE_ROOT must name an absolute, dedicated engine root.");
-		}
-
-		string SelectedRoot = Canonicalize(ConfiguredRoot);
-		string ActualRoot = Canonicalize(Path.Combine(Unreal.EngineDirectory.FullName, ".."));
-		string MarkerPath = Path.Combine(ActualRoot, ".ue-mcp-test-engine");
-		if (!File.Exists(MarkerPath))
-		{
-			throw new BuildException($"UE_MCP_TEST_ENGINE_ROOT is not marked as a dedicated test engine. Missing '{MarkerPath}'.");
-		}
-
-		if (!String.Equals(SelectedRoot, ActualRoot, PathComparison))
-		{
-			throw new BuildException(
-				$"ue_mcpEditor must be built by UE_MCP_TEST_ENGINE_ROOT. Selected '{SelectedRoot}', but UBT is running from '{ActualRoot}'.");
-		}
-
-		string ProtectedValue = Environment.GetEnvironmentVariable("UE_MCP_PROTECTED_ENGINE_ROOTS") ?? String.Empty;
-		foreach (string ProtectedEntry in ProtectedValue.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries))
-		{
-			string ProtectedRoot = Canonicalize(ProtectedEntry);
-			if (IsSameOrUnder(ActualRoot, ProtectedRoot))
-			{
-				throw new BuildException($"UE-MCP test builds are forbidden under protected engine root '{ProtectedRoot}'.");
-			}
-		}
-
-		if (!EnvironmentFlag("UE_MCP_ALLOW_TEST_ENGINE_CHANGES") && !HasCommandLineSwitch("-NoEngineChanges"))
-		{
-			throw new BuildException(
-				"ue_mcpEditor requires -NoEngineChanges. Set UE_MCP_ALLOW_TEST_ENGINE_CHANGES=true only while bootstrapping a dedicated test engine.");
-		}
-	}
-
-	private static StringComparison PathComparison =>
-		OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-
-	private static string Canonicalize(string Value)
-	{
-		string FullPath = Path.GetFullPath(Value).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-		DirectoryInfo Directory = new DirectoryInfo(FullPath);
-		if (Directory.Exists)
-		{
-			FileSystemInfo? Resolved = Directory.ResolveLinkTarget(true);
-			if (Resolved != null)
-			{
-				FullPath = Resolved.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-			}
-		}
-		return FullPath;
-	}
-
-	private static bool IsSameOrUnder(string Candidate, string Parent) =>
-		String.Equals(Candidate, Parent, PathComparison) ||
-		Candidate.StartsWith(Parent + Path.DirectorySeparatorChar, PathComparison);
-
-	private static bool EnvironmentFlag(string Name)
-	{
-		string Value = Environment.GetEnvironmentVariable(Name) ?? String.Empty;
-		return Value.Equals("1", StringComparison.OrdinalIgnoreCase) ||
-			Value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
-			Value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
-			Value.Equals("on", StringComparison.OrdinalIgnoreCase);
-	}
-
-	private static bool HasCommandLineSwitch(string Switch) =>
-		Environment.GetCommandLineArgs().Any(Argument =>
-			Argument.Split(new[] { ' ', '\t', '"' }, StringSplitOptions.RemoveEmptyEntries)
-				.Any(Token => Token.Equals(Switch, StringComparison.OrdinalIgnoreCase)));
 }

--- a/tests/ue_mcp/Source/ue_mcpEditor.Target.cs
+++ b/tests/ue_mcp/Source/ue_mcpEditor.Target.cs
@@ -1,13 +1,93 @@
 using UnrealBuildTool;
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 public class ue_mcpEditorTarget : TargetRules
 {
 	public ue_mcpEditorTarget(TargetInfo Target) : base(Target)
 	{
+		EnforceTestEnginePolicy();
+
 		Type = TargetType.Editor;
 		DefaultBuildSettings = BuildSettingsVersion.V7;
 		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_8;
 		ExtraModuleNames.Add("ue_mcp");
 	}
+
+	private static void EnforceTestEnginePolicy()
+	{
+		string? ConfiguredRoot = Environment.GetEnvironmentVariable("UE_MCP_TEST_ENGINE_ROOT");
+		if (String.IsNullOrWhiteSpace(ConfiguredRoot) || !Path.IsPathRooted(ConfiguredRoot))
+		{
+			throw new BuildException("UE_MCP_TEST_ENGINE_ROOT must name an absolute, dedicated engine root.");
+		}
+
+		string SelectedRoot = Canonicalize(ConfiguredRoot);
+		string ActualRoot = Canonicalize(Path.Combine(Unreal.EngineDirectory.FullName, ".."));
+		string MarkerPath = Path.Combine(ActualRoot, ".ue-mcp-test-engine");
+		if (!File.Exists(MarkerPath))
+		{
+			throw new BuildException($"UE_MCP_TEST_ENGINE_ROOT is not marked as a dedicated test engine. Missing '{MarkerPath}'.");
+		}
+
+		if (!String.Equals(SelectedRoot, ActualRoot, PathComparison))
+		{
+			throw new BuildException(
+				$"ue_mcpEditor must be built by UE_MCP_TEST_ENGINE_ROOT. Selected '{SelectedRoot}', but UBT is running from '{ActualRoot}'.");
+		}
+
+		string ProtectedValue = Environment.GetEnvironmentVariable("UE_MCP_PROTECTED_ENGINE_ROOTS") ?? String.Empty;
+		foreach (string ProtectedEntry in ProtectedValue.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries))
+		{
+			string ProtectedRoot = Canonicalize(ProtectedEntry);
+			if (IsSameOrUnder(ActualRoot, ProtectedRoot))
+			{
+				throw new BuildException($"UE-MCP test builds are forbidden under protected engine root '{ProtectedRoot}'.");
+			}
+		}
+
+		if (!EnvironmentFlag("UE_MCP_ALLOW_TEST_ENGINE_CHANGES") && !HasCommandLineSwitch("-NoEngineChanges"))
+		{
+			throw new BuildException(
+				"ue_mcpEditor requires -NoEngineChanges. Set UE_MCP_ALLOW_TEST_ENGINE_CHANGES=true only while bootstrapping a dedicated test engine.");
+		}
+	}
+
+	private static StringComparison PathComparison =>
+		OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+	private static string Canonicalize(string Value)
+	{
+		string FullPath = Path.GetFullPath(Value).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		DirectoryInfo Directory = new DirectoryInfo(FullPath);
+		if (Directory.Exists)
+		{
+			FileSystemInfo? Resolved = Directory.ResolveLinkTarget(true);
+			if (Resolved != null)
+			{
+				FullPath = Resolved.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+			}
+		}
+		return FullPath;
+	}
+
+	private static bool IsSameOrUnder(string Candidate, string Parent) =>
+		String.Equals(Candidate, Parent, PathComparison) ||
+		Candidate.StartsWith(Parent + Path.DirectorySeparatorChar, PathComparison);
+
+	private static bool EnvironmentFlag(string Name)
+	{
+		string Value = Environment.GetEnvironmentVariable(Name) ?? String.Empty;
+		return Value.Equals("1", StringComparison.OrdinalIgnoreCase) ||
+			Value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+			Value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
+			Value.Equals("on", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static bool HasCommandLineSwitch(string Switch) =>
+		Environment.GetCommandLineArgs().Any(Argument =>
+			Argument.Split(new[] { ' ', '\t', '"' }, StringSplitOptions.RemoveEmptyEntries)
+				.Any(Token => Token.Equals(Switch, StringComparison.OrdinalIgnoreCase)));
 }

--- a/tests/unit/test-build-guard.test.ts
+++ b/tests/unit/test-build-guard.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  createTestBuildPlan,
+  engineExecutables,
+  isSameOrUnder,
+  resolveTestEngine,
+  TEST_ENGINE_MARKER,
+  unrealTargetPlatform,
+} from "../../scripts/build-utils.js";
+
+let temporaryRoot: string;
+
+beforeEach(() => {
+  temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-test-engine-"));
+});
+
+afterEach(() => {
+  fs.rmSync(temporaryRoot, { recursive: true, force: true });
+});
+
+function createFakeEngine(name: string): string {
+  const engineRoot = path.join(temporaryRoot, name);
+  const { buildTool } = engineExecutables(engineRoot);
+  fs.mkdirSync(path.dirname(buildTool), { recursive: true });
+  fs.writeFileSync(buildTool, "test build tool");
+  fs.writeFileSync(path.join(engineRoot, TEST_ENGINE_MARKER), "Dedicated UE-MCP test engine.\n");
+  return engineRoot;
+}
+
+describe("UE-MCP test engine build guard", () => {
+  it("requires an explicit test engine root", () => {
+    expect(() => resolveTestEngine({})).toThrow("UE_MCP_TEST_ENGINE_ROOT is required");
+  });
+
+  it("rejects an unmarked engine root", () => {
+    const engineRoot = createFakeEngine("unmarked");
+    fs.rmSync(path.join(engineRoot, TEST_ENGINE_MARKER));
+
+    expect(() => resolveTestEngine({ UE_MCP_TEST_ENGINE_ROOT: engineRoot }))
+      .toThrow("not marked as a dedicated test engine");
+  });
+
+  it("builds only the fixed test target with engine changes blocked", () => {
+    const engineRoot = createFakeEngine("dedicated");
+    const plan = createTestBuildPlan({ UE_MCP_TEST_ENGINE_ROOT: engineRoot });
+
+    expect(plan.buildArgs).toEqual([
+      "ue_mcpEditor",
+      unrealTargetPlatform(),
+      "Development",
+      `-Project="${plan.projectFile}"`,
+      "-WaitMutex",
+      "-FromMsBuild",
+      "-NoEngineChanges",
+    ]);
+    expect(plan.buildArgs.filter((argument: string) => argument === "-NoEngineChanges")).toHaveLength(1);
+  });
+
+  it.each([
+    ["win32", "Win64"],
+    ["darwin", "Mac"],
+    ["linux", "Linux"],
+  ])("maps %s to Unreal target platform %s", (platform, expected) => {
+    expect(unrealTargetPlatform(platform)).toBe(expected);
+  });
+
+  it("compares protected Windows paths without case sensitivity", () => {
+    expect(isSameOrUnder("D:\\UE-PRIMARY\\Engine", "d:\\ue-primary", "win32")).toBe(true);
+  });
+
+  it("rejects a selected engine inside a protected root", () => {
+    const protectedRoot = path.join(temporaryRoot, "protected");
+    fs.mkdirSync(protectedRoot);
+    const engineRoot = createFakeEngine(path.join("protected", "engine"));
+
+    expect(() => resolveTestEngine({
+      UE_MCP_TEST_ENGINE_ROOT: engineRoot,
+      UE_MCP_PROTECTED_ENGINE_ROOTS: protectedRoot,
+      UE_MCP_ALLOW_TEST_ENGINE_CHANGES: "true",
+    })).toThrow("forbidden under protected engine root");
+  });
+
+  it("does not confuse a sibling path prefix with a protected child", () => {
+    const protectedRoot = path.join(temporaryRoot, "engine");
+    fs.mkdirSync(protectedRoot);
+    const engineRoot = createFakeEngine("engine-test");
+
+    expect(resolveTestEngine({
+      UE_MCP_TEST_ENGINE_ROOT: engineRoot,
+      UE_MCP_PROTECTED_ENGINE_ROOTS: protectedRoot,
+    }).engineRoot).toBe(fs.realpathSync.native(engineRoot));
+  });
+
+  it("allows engine output creation only through an explicit bootstrap opt-in", () => {
+    const engineRoot = createFakeEngine("bootstrap");
+    const plan = createTestBuildPlan({
+      UE_MCP_TEST_ENGINE_ROOT: engineRoot,
+      UE_MCP_ALLOW_TEST_ENGINE_CHANGES: "yes",
+    });
+
+    expect(plan.allowEngineChanges).toBe(true);
+    expect(plan.buildArgs).not.toContain("-NoEngineChanges");
+  });
+});

--- a/tests/unit/test-build-guard.test.ts
+++ b/tests/unit/test-build-guard.test.ts
@@ -3,18 +3,21 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+  assertTestProject,
   createTestBuildPlan,
   engineExecutables,
+  engineRootFromEnginePath,
+  getProjectPaths,
   isSameOrUnder,
+  protectedEngineRoots,
   resolveTestEngine,
-  TEST_ENGINE_MARKER,
   unrealTargetPlatform,
 } from "../../scripts/build-utils.js";
 
 let temporaryRoot: string;
 
 beforeEach(() => {
-  temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-test-engine-"));
+  temporaryRoot = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-test-engine-")));
 });
 
 afterEach(() => {
@@ -26,24 +29,11 @@ function createFakeEngine(name: string): string {
   const { buildTool } = engineExecutables(engineRoot);
   fs.mkdirSync(path.dirname(buildTool), { recursive: true });
   fs.writeFileSync(buildTool, "test build tool");
-  fs.writeFileSync(path.join(engineRoot, TEST_ENGINE_MARKER), "Dedicated UE-MCP test engine.\n");
   return engineRoot;
 }
 
 describe("UE-MCP test engine build guard", () => {
-  it("requires an explicit test engine root", () => {
-    expect(() => resolveTestEngine({})).toThrow("UE_MCP_TEST_ENGINE_ROOT is required");
-  });
-
-  it("rejects an unmarked engine root", () => {
-    const engineRoot = createFakeEngine("unmarked");
-    fs.rmSync(path.join(engineRoot, TEST_ENGINE_MARKER));
-
-    expect(() => resolveTestEngine({ UE_MCP_TEST_ENGINE_ROOT: engineRoot }))
-      .toThrow("not marked as a dedicated test engine");
-  });
-
-  it("builds only the fixed test target with engine changes blocked", () => {
+  it("blocks engine writes by default on the fixed test target", () => {
     const engineRoot = createFakeEngine("dedicated");
     const plan = createTestBuildPlan({ UE_MCP_TEST_ENGINE_ROOT: engineRoot });
 
@@ -59,6 +49,39 @@ describe("UE-MCP test engine build guard", () => {
     expect(plan.buildArgs.filter((argument: string) => argument === "-NoEngineChanges")).toHaveLength(1);
   });
 
+  it("blocks engine writes even when no engine settings are configured at all", () => {
+    // A missing config must not soften the guard. Discovery may fail, but if it
+    // succeeds the build still carries -NoEngineChanges.
+    const engineRoot = createFakeEngine("discovered");
+    const plan = createTestBuildPlan({ UE_BUILD_TOOL_PATH: engineExecutables(engineRoot).buildTool });
+
+    expect(plan.engineRootSource).toBe("UE_BUILD_TOOL_PATH");
+    expect(plan.allowEngineChanges).toBe(false);
+    expect(plan.buildArgs).toContain("-NoEngineChanges");
+  });
+
+  it("always builds the bundled test project", () => {
+    const engineRoot = createFakeEngine("project-pin");
+    const plan = createTestBuildPlan({ UE_MCP_TEST_ENGINE_ROOT: engineRoot });
+
+    expect(plan.projectFile).toBe(getProjectPaths().projectFile);
+    expect(() => assertTestProject(plan.projectFile)).not.toThrow();
+  });
+
+  it("refuses to build any project other than the bundled test project", () => {
+    expect(() => assertTestProject(path.join(temporaryRoot, "Vale", "Vale.uproject")))
+      .toThrow("only build the bundled test project");
+  });
+
+  it("fails loudly when an explicitly configured engine root has no build tool", () => {
+    expect(() => resolveTestEngine({ UE_MCP_TEST_ENGINE_ROOT: path.join(temporaryRoot, "missing") }))
+      .toThrow("UE_MCP_TEST_ENGINE_ROOT does not point at a usable Unreal engine");
+  });
+
+  it("fails loudly rather than silently skipping the build when nothing is found", () => {
+    expect(() => resolveTestEngine({}, "linux")).toThrow("Unreal Engine build tool not found");
+  });
+
   it.each([
     ["win32", "Win64"],
     ["darwin", "Mac"],
@@ -67,8 +90,21 @@ describe("UE-MCP test engine build guard", () => {
     expect(unrealTargetPlatform(platform)).toBe(expected);
   });
 
-  it("compares protected Windows paths without case sensitivity", () => {
+  it("compares protected Windows paths without case sensitivity, from any host", () => {
     expect(isSameOrUnder("D:\\UE-PRIMARY\\Engine", "d:\\ue-primary", "win32")).toBe(true);
+    expect(isSameOrUnder("D:\\UE-PRIMARY-TEST", "d:\\ue-primary", "win32")).toBe(false);
+  });
+
+  it("compares protected POSIX paths case sensitively", () => {
+    expect(isSameOrUnder("/opt/ue/Engine", "/opt/ue", "linux")).toBe(true);
+    expect(isSameOrUnder("/opt/UE/Engine", "/opt/ue", "linux")).toBe(false);
+  });
+
+  it("derives the engine root from a build tool path on every layout", () => {
+    expect(engineRootFromEnginePath("D:\\UE\\Engine\\Build\\BatchFiles\\Build.bat", "win32")).toBe("D:\\UE");
+    expect(engineRootFromEnginePath("/opt/ue/Engine/Build/BatchFiles/Linux/Build.sh", "linux")).toBe("/opt/ue");
+    expect(engineRootFromEnginePath("/opt/ue/Engine/Binaries/Linux/UnrealEditor", "linux")).toBe("/opt/ue");
+    expect(engineRootFromEnginePath("/somewhere/else/tool.sh", "linux")).toBeNull();
   });
 
   it("rejects a selected engine inside a protected root", () => {
@@ -79,8 +115,19 @@ describe("UE-MCP test engine build guard", () => {
     expect(() => resolveTestEngine({
       UE_MCP_TEST_ENGINE_ROOT: engineRoot,
       UE_MCP_PROTECTED_ENGINE_ROOTS: protectedRoot,
+    })).toThrow("UE_MCP_PROTECTED_ENGINE_ROOTS");
+  });
+
+  it("rejects a protected root even when engine changes are explicitly allowed", () => {
+    const protectedRoot = path.join(temporaryRoot, "protected-optin");
+    fs.mkdirSync(protectedRoot);
+    const engineRoot = createFakeEngine(path.join("protected-optin", "engine"));
+
+    expect(() => createTestBuildPlan({
+      UE_MCP_TEST_ENGINE_ROOT: engineRoot,
+      UE_MCP_PROTECTED_ENGINE_ROOTS: protectedRoot,
       UE_MCP_ALLOW_TEST_ENGINE_CHANGES: "true",
-    })).toThrow("forbidden under protected engine root");
+    })).toThrow("refuse to run against a protected engine");
   });
 
   it("does not confuse a sibling path prefix with a protected child", () => {
@@ -91,7 +138,23 @@ describe("UE-MCP test engine build guard", () => {
     expect(resolveTestEngine({
       UE_MCP_TEST_ENGINE_ROOT: engineRoot,
       UE_MCP_PROTECTED_ENGINE_ROOTS: protectedRoot,
-    }).engineRoot).toBe(fs.realpathSync.native(engineRoot));
+    }).engineRoot).toBe(engineRoot);
+  });
+
+  it("rejects a relative protected root instead of protecting nothing", () => {
+    expect(() => protectedEngineRoots({ UE_MCP_PROTECTED_ENGINE_ROOTS: "Epic Games" }))
+      .toThrow("is not an absolute path");
+  });
+
+  it("parses the protected root list with the platform delimiter", () => {
+    const first = path.join(temporaryRoot, "one");
+    const second = path.join(temporaryRoot, "two");
+    fs.mkdirSync(first);
+    fs.mkdirSync(second);
+
+    expect(protectedEngineRoots({
+      UE_MCP_PROTECTED_ENGINE_ROOTS: ` ${first} ${path.delimiter}${second}${path.delimiter}`,
+    })).toEqual([first, second]);
   });
 
   it("allows engine output creation only through an explicit bootstrap opt-in", () => {
@@ -103,5 +166,16 @@ describe("UE-MCP test engine build guard", () => {
 
     expect(plan.allowEngineChanges).toBe(true);
     expect(plan.buildArgs).not.toContain("-NoEngineChanges");
+  });
+
+  it("treats an unrecognised opt-in value as no opt-in", () => {
+    const engineRoot = createFakeEngine("garbage-optin");
+    const plan = createTestBuildPlan({
+      UE_MCP_TEST_ENGINE_ROOT: engineRoot,
+      UE_MCP_ALLOW_TEST_ENGINE_CHANGES: "maybe",
+    });
+
+    expect(plan.allowEngineChanges).toBe(false);
+    expect(plan.buildArgs).toContain("-NoEngineChanges");
   });
 });


### PR DESCRIPTION
## What

- pass `-NoEngineChanges` on every UE-MCP test build, so Unreal aborts and names the files if the build would overwrite anything that already exists under the engine tree
- keep engine discovery working: `UE_MCP_TEST_ENGINE_ROOT`, then `UE_BUILD_TOOL_PATH`, then the default install locations, with a pinned root that has no build tool reported as an error instead of a silent fallback
- `UE_MCP_PROTECTED_ENGINE_ROOTS` is a deny list that outranks every other setting, including the bootstrap opt-in, and now also covers the `UE_EDITOR_PATH` override
- reject a relative deny-list entry rather than resolving it against the working directory, where it would protect nothing
- pin both scripts to the bundled `tests/ue_mcp/ue_mcp.uproject` with an explicit assertion
- derive the build tool and editor executable for Windows, macOS, and Linux from one engine root

## Why

A test build can invalidate outputs that a shared source engine already has on disk, and the next ordinary build then reschedules engine modules. UnrealBuildTool already has the exact check for this in `-NoEngineChanges`, so the guard is a flag the build always carries rather than a policy the scripts reimplement. Because it does not depend on any file or variable being present, a missing or stale configuration cannot soften it.

## Changed from the first revision

The first revision required a duplicate engine install carrying a `.ue-mcp-test-engine` marker before any build could run, and removed the `UE_BUILD_TOOL_PATH` and `UE_EDITOR_PATH` overrides. That blocked every existing setup on a first `npm run build`.

It also enforced the policy a second time inside `ue_mcpEditor.Target.cs`. That constructor runs for project file generation, IDE builds, and the editor's own compile path, none of which carry the environment variables or the command line switch, so the test project became buildable only through one script. That copy is gone.

## Validation

- `npx tsc --noEmit` clean
- `npm run test:unit`: 32 files, 325 tests passed, including the guard suite that previously failed on the Linux runner
- real build: `node scripts/build.js` against UE 5.8 with the bridge plugin deployed, confirming `-NoEngineChanges` is accepted and does not block an ordinary test build
- behaviour probed against the live install: a protected parent root, a protected exact root combined with a stale allow flag, a stale `UE_BUILD_TOOL_PATH` aimed at a protected engine, a pin to a nonexistent root, and a relative deny entry all fail loud with the reason named
