### PR TITLE
Smoke harness: discover the bridge port, and prove the target is the test project

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -144,11 +144,29 @@ npm run test:smoke
 ```
 
 !!! warning "Smoke tests require the test project"
-    The smoke runner targets `tests/ue_mcp/ue_mcp.uproject` only. Real mutations execute against the connected editor (creating blueprints, deleting assets, modifying the level). **Never run smoke tests against a real project.** The runner aborts if it detects a connection to anything else.
+    The smoke runner targets `tests/ue_mcp/ue_mcp.uproject` only. Real mutations execute against the connected editor (creating blueprints, deleting assets, modifying the level). **Never run smoke tests against a real project.** After connecting, the runner asks the editor which project it has open and aborts before sending anything if the answer is not `tests/ue_mcp`. Non-loopback hosts are refused outright.
 
 !!! note "Prerequisites"
     - Editor running with the test project
     - Bridge connected (`project(action="get_status")` returns `editorConnected: true`)
+
+#### How the harness finds the bridge
+
+The editor binds a per-project port, not a fixed one, and publishes the port it
+actually bound to `tests/ue_mcp/Saved/UE_MCP_Bridge/port.json`. Both harnesses
+(`scripts/smoke-test.js` and the Vitest suites) resolve the endpoint through
+`scripts/bridge-target.mjs`, which probes in this order:
+
+1. The port recorded in that lockfile.
+2. The port derived from the project path, which is what the bridge binds when
+   nothing is in its way.
+3. The legacy fixed port `9877`, for older bridges.
+
+Start the editor and run the tests; no environment variable is needed. When
+nothing answers, the failure names the lockfile path it read, the state that
+file was in (missing, malformed, or stale with a dead pid), and every port it
+tried. `--port` on the runner and `UE_MCP_TEST_PORT` for the Vitest suites still
+pin the port for unusual setups, and neither weakens the project check above.
 
 ### Test Suites
 

--- a/scripts/bridge-target.mjs
+++ b/scripts/bridge-target.mjs
@@ -1,0 +1,177 @@
+/**
+ * Shared bridge discovery for the test harnesses (scripts/smoke-test.js and
+ * everything under tests/).
+ *
+ * The editor no longer binds a fixed port: it derives a per-project port from
+ * the project root path and publishes the port it actually bound to
+ * <Project>/Saved/UE_MCP_Bridge/port.json. Harnesses that hardcode 9877 cannot
+ * connect. Discovery order here is lockfile, then the derived port, then the
+ * legacy fixed port, so a running editor is found with no environment variables
+ * and no flags.
+ *
+ * The project itself is hardcoded to tests/ue_mcp/ue_mcp.uproject relative to
+ * this file: smoke runs perform real mutations, so they only ever address the
+ * dedicated test project.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/** Repository root (the checkout this harness belongs to). */
+export const REPO_ROOT = path.resolve(HERE, "..");
+
+/** The one project any test harness in this repo is allowed to touch. */
+export const TEST_PROJECT_DIR = path.join(REPO_ROOT, "tests", "ue_mcp");
+export const TEST_PROJECT_UPROJECT = path.join(TEST_PROJECT_DIR, "ue_mcp.uproject");
+
+/** Where the running bridge publishes the port it bound for that project. */
+export const TEST_PORT_LOCKFILE = path.join(
+  TEST_PROJECT_DIR, "Saved", "UE_MCP_Bridge", "port.json",
+);
+
+/** Pre-derived-port bridges bound this. Kept as the last candidate. */
+export const LEGACY_BRIDGE_PORT = 9877;
+
+// Ephemeral range used by the derived-port scheme. Must match src/port.ts and
+// FMCPBridgeServer::DeriveProjectPort; tests/unit/bridge-target.test.ts pins
+// this implementation against src/port.ts so the two cannot drift apart.
+const EPHEMERAL_BASE = 49152;
+const EPHEMERAL_SPAN = 65535 - EPHEMERAL_BASE + 1;
+
+/** Canonical form of a project root for hashing and for identity comparison. */
+export function normalizeProjectRoot(dir) {
+  return String(dir).replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}
+
+/** Port the bridge would bind for a project root when nothing is in its way. */
+export function deriveProjectPort(projectRootDir) {
+  const h = crypto.createHash("sha1")
+    .update(normalizeProjectRoot(projectRootDir), "utf8")
+    .digest();
+  const v = ((h[0] << 24) | (h[1] << 16) | (h[2] << 8) | h[3]) >>> 0;
+  return EPHEMERAL_BASE + (v % EPHEMERAL_SPAN);
+}
+
+/**
+ * Read the port lockfile for the test project.
+ *
+ * Never throws: a missing, empty, or malformed lockfile is an ordinary state
+ * (editor not started yet, editor shut down cleanly) and the reason is carried
+ * in the returned record so the failure message can quote it.
+ */
+export function readPortLockfile(lockfilePath = TEST_PORT_LOCKFILE) {
+  const record = {
+    path: lockfilePath,
+    exists: false,
+    port: null,
+    pid: null,
+    startedAt: null,
+    error: null,
+    pidAlive: null,
+  };
+
+  let raw;
+  try {
+    raw = fs.readFileSync(lockfilePath, "utf8");
+    record.exists = true;
+  } catch (err) {
+    record.error = err.code === "ENOENT" ? "not found" : `unreadable (${err.code ?? err.message})`;
+    return record;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    record.error = "present but not valid JSON";
+    return record;
+  }
+
+  const port = Number(parsed?.port);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    record.error = `present but has no usable "port" field (got ${JSON.stringify(parsed?.port)})`;
+    return record;
+  }
+
+  record.port = port;
+  record.pid = Number.isInteger(Number(parsed?.pid)) ? Number(parsed.pid) : null;
+  record.startedAt = typeof parsed?.startedAt === "string" ? parsed.startedAt : null;
+  record.pidAlive = record.pid === null ? null : isProcessAlive(record.pid);
+  return record;
+}
+
+/** Best-effort liveness probe, used only to make failure messages specific. */
+export function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === "EPERM";
+  }
+}
+
+/**
+ * Ordered list of ports worth trying for the test project bridge.
+ *
+ * An explicit port (CLI flag or environment variable) short-circuits discovery
+ * so a developer can pin an unusual setup.
+ */
+export function bridgePortCandidates(options = {}) {
+  const { explicitPort = null, lockfile = readPortLockfile() } = options;
+
+  const candidates = [];
+  const add = (port, source) => {
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) return;
+    if (candidates.some((c) => c.port === port)) return;
+    candidates.push({ port, source });
+  };
+
+  if (Number.isInteger(explicitPort) && explicitPort > 0) {
+    add(explicitPort, "explicit");
+    return { candidates, lockfile };
+  }
+
+  add(lockfile.port, "lockfile");
+  add(deriveProjectPort(TEST_PROJECT_DIR), "derived from project path");
+  add(LEGACY_BRIDGE_PORT, "legacy fixed port");
+  return { candidates, lockfile };
+}
+
+/**
+ * The failure message for "no bridge answered". Names every port that was
+ * tried, where each came from, and the exact lockfile path that was read, so
+ * the next step is obvious without reading harness source.
+ */
+export function describeMissingBridge(options) {
+  const { host, candidates, lockfile, lastError = null } = options;
+
+  const lines = [];
+  lines.push("Could not reach the UE MCP bridge for the smoke test project.");
+  lines.push(`  Project  : ${TEST_PROJECT_UPROJECT}${fs.existsSync(TEST_PROJECT_UPROJECT) ? "" : "  (MISSING)"}`);
+
+  let lockNote;
+  if (lockfile.port !== null) {
+    const pidNote = lockfile.pid === null
+      ? ""
+      : `, pid ${lockfile.pid}${lockfile.pidAlive === false ? " (not running, stale lockfile)" : ""}`;
+    lockNote = `port ${lockfile.port}${pidNote}`;
+  } else {
+    lockNote = lockfile.error ?? "no port recorded";
+  }
+  lines.push(`  Lockfile : ${lockfile.path}  (${lockNote})`);
+
+  for (const [i, c] of candidates.entries()) {
+    const label = i === 0 ? "  Tried    : " : "             ";
+    lines.push(`${label}ws://${host}:${c.port}  (${c.source})`);
+  }
+  if (lastError) lines.push(`  Last error: ${lastError}`);
+  lines.push("");
+  lines.push("Start the editor on the test project (npm run up), wait for \"Bridge listening\" in the editor log,");
+  lines.push(`then retry. The bridge writes its bound port to the lockfile path above.`);
+  return lines.join("\n");
+}
+

--- a/scripts/bridge-target.mjs
+++ b/scripts/bridge-target.mjs
@@ -1,17 +1,23 @@
 /**
- * Shared bridge discovery for the test harnesses (scripts/smoke-test.js and
+ * Shared target resolution for the test harnesses (scripts/smoke-test.js and
  * everything under tests/).
  *
- * The editor no longer binds a fixed port: it derives a per-project port from
- * the project root path and publishes the port it actually bound to
- * <Project>/Saved/UE_MCP_Bridge/port.json. Harnesses that hardcode 9877 cannot
- * connect. Discovery order here is lockfile, then the derived port, then the
- * legacy fixed port, so a running editor is found with no environment variables
- * and no flags.
+ * Two jobs:
  *
- * The project itself is hardcoded to tests/ue_mcp/ue_mcp.uproject relative to
- * this file: smoke runs perform real mutations, so they only ever address the
- * dedicated test project.
+ *  1. Find the bridge. The editor no longer binds a fixed port: it derives a
+ *     per-project port from the project root path and publishes the port it
+ *     actually bound to <Project>/Saved/UE_MCP_Bridge/port.json. Harnesses that
+ *     hardcode 9877 cannot connect. Discovery order here is lockfile, then the
+ *     derived port, then the legacy fixed port, so a running editor is found
+ *     with no environment variables and no flags.
+ *
+ *  2. Refuse anything that is not the dedicated test project. Smoke runs
+ *     perform real mutations (create blueprints, delete assets, rewrite the
+ *     level), so pointing them at a working project can destroy someone's work.
+ *     The project is hardcoded to tests/ue_mcp/ue_mcp.uproject relative to this
+ *     file. Host and port remain overridable for odd local setups, so the guard
+ *     is enforced after connecting by asking the editor which project it has
+ *     open and aborting on any mismatch.
  */
 
 import crypto from "node:crypto";
@@ -118,7 +124,8 @@ export function isProcessAlive(pid) {
  * Ordered list of ports worth trying for the test project bridge.
  *
  * An explicit port (CLI flag or environment variable) short-circuits discovery
- * so a developer can pin an unusual setup.
+ * so a developer can pin an unusual setup. It does not weaken the project
+ * guard, which runs after the connection is up.
  */
 export function bridgePortCandidates(options = {}) {
   const { explicitPort = null, lockfile = readPortLockfile() } = options;
@@ -139,6 +146,20 @@ export function bridgePortCandidates(options = {}) {
   add(deriveProjectPort(TEST_PROJECT_DIR), "derived from project path");
   add(LEGACY_BRIDGE_PORT, "legacy fixed port");
   return { candidates, lockfile };
+}
+
+/** Loopback-only: a smoke run must never reach an editor on another machine. */
+export function isLoopbackHost(host) {
+  const h = String(host).trim().toLowerCase().replace(/^\[|\]$/g, "");
+  return h === "localhost" || h === "127.0.0.1" || h === "::1" || h.startsWith("127.");
+}
+
+export function assertLoopbackHost(host) {
+  if (isLoopbackHost(host)) return;
+  throw new Error(
+    `Refusing to run the smoke harness against host "${host}". ` +
+    `It is hardcoded to the local test project (${TEST_PROJECT_UPROJECT}) and only loopback hosts can serve it.`,
+  );
 }
 
 /**
@@ -175,3 +196,74 @@ export function describeMissingBridge(options) {
   return lines.join("\n");
 }
 
+// ---------------------------------------------------------------------------
+// Project identity guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Python the harness runs on the connected editor to learn which project is
+ * open. Printed with a marker so it survives whatever shape the bridge wraps
+ * python output in.
+ */
+export const PROJECT_IDENTITY_PYTHON =
+  'import unreal\nprint("MCP_PROJECT_DIR:" + unreal.Paths.convert_relative_path_to_full(unreal.Paths.project_dir()))';
+
+/**
+ * Pull the reported project directory out of an execute_python result. The
+ * result is stringified first, so the marker is found whatever key the python
+ * output landed under; JSON escaping is then undone so a Windows path survives
+ * the round trip intact.
+ */
+export function extractReportedProjectDir(result) {
+  const text = typeof result === "string" ? result : JSON.stringify(result ?? "");
+  const match = /MCP_PROJECT_DIR:((?:\\.|[^"\r\n])*)/.exec(text);
+  if (!match) return null;
+  const unescaped = match[1].replace(/\\(.)/g, (_, ch) =>
+    ch === "n" ? "\n" : ch === "r" ? "\r" : ch === "t" ? "\t" : ch,
+  );
+  const dir = unescaped.split(/[\r\n]/, 1)[0].trim();
+  return dir.length > 0 ? dir : null;
+}
+
+/** True when the editor's open project is this checkout's test project. */
+export function isTestProjectDir(reportedDir) {
+  if (!reportedDir) return false;
+  return normalizeProjectRoot(reportedDir) === normalizeProjectRoot(TEST_PROJECT_DIR);
+}
+
+/**
+ * Hard guard. Throws unless the connected editor has the test project open.
+ * Called before the harness issues a single mutating request.
+ */
+export function assertTestProjectDir(reportedDir) {
+  if (isTestProjectDir(reportedDir)) return reportedDir;
+  const what = reportedDir
+    ? `it reported "${reportedDir}"`
+    : "the editor did not report a project directory (is the Python plugin enabled?)";
+  throw new Error(
+    "Aborting: the connected editor is not the smoke test project.\n" +
+    `  Expected : ${TEST_PROJECT_DIR}\n` +
+    `  Reported : ${reportedDir ?? "(unknown)"}\n` +
+    `Smoke runs perform destructive mutations, so the harness only ever talks to its own test project. ` +
+    `Because ${what}, nothing was sent.`,
+  );
+}
+
+/**
+ * Run the guard over any RPC caller. `call` takes (method, params) and resolves
+ * to the raw handler result (or anything containing it); the identity marker is
+ * matched out of the stringified value.
+ */
+export async function verifyTestProjectTarget(call) {
+  let result;
+  try {
+    result = await call("execute_python", { code: PROJECT_IDENTITY_PYTHON });
+  } catch (err) {
+    throw new Error(
+      "Aborting: could not confirm which project the connected editor has open " +
+      `(execute_python failed: ${err instanceof Error ? err.message : String(err)}).\n` +
+      `The smoke harness only runs against ${TEST_PROJECT_UPROJECT}, so it will not send mutations it cannot vouch for.`,
+    );
+  }
+  return assertTestProjectDir(extractReportedProjectDir(result));
+}

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -9,13 +9,20 @@
  *
  * Exit code 0 when no FAILURES, 1 otherwise.
  *
- * Usage:  node scripts/smoke-test.js [--host 127.0.0.1] [--port 9877] [--timeout 5000]
+ * The bridge port is discovered, not assumed: see scripts/bridge-target.mjs.
+ *
+ * Usage:  node scripts/smoke-test.js [--host 127.0.0.1] [--port <port>] [--timeout 5000]
  */
 
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import WebSocket from "ws";
+import {
+  bridgePortCandidates,
+  describeMissingBridge,
+  TEST_PROJECT_UPROJECT,
+} from "./bridge-target.mjs";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -30,26 +37,8 @@ function flag(name, fallback) {
 }
 
 const HOST = flag("host", "127.0.0.1");
-
-// The bridge derives a per-worktree port (see src/port.ts) and publishes the
-// actual bound port to a lockfile. Prefer that over the legacy fixed default so
-// a derived-port editor is reachable without passing --port by hand. Precedence:
-// explicit --port > lockfile > legacy 9877.
-function lockfilePort() {
-  const lock = path.resolve(
-    __dirname, "..", "tests", "ue_mcp", "Saved", "UE_MCP_Bridge", "port.json",
-  );
-  try {
-    const { port } = JSON.parse(fs.readFileSync(lock, "utf8"));
-    return Number.isInteger(port) ? String(port) : null;
-  } catch {
-    return null;
-  }
-}
-
-const PORT = flag("port", lockfilePort() ?? "9877");
+const EXPLICIT_PORT = Number.parseInt(flag("port", ""), 10);
 const TIMEOUT_MS = Number(flag("timeout", "5000"));
-const WS_URL = `ws://${HOST}:${PORT}`;
 
 // ---------------------------------------------------------------------------
 // ANSI helpers
@@ -105,13 +94,13 @@ function discoverHandlers() {
 // ---------------------------------------------------------------------------
 // 2. WebSocket helpers
 // ---------------------------------------------------------------------------
-function connect(url) {
+function connect(url, timeoutMs = TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(url);
     const timer = setTimeout(() => {
       ws.terminate();
-      reject(new Error(`Connection to ${url} timed out after ${TIMEOUT_MS}ms`));
-    }, TIMEOUT_MS);
+      reject(new Error(`Connection to ${url} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
 
     ws.on("open", () => {
       clearTimeout(timer);
@@ -191,6 +180,34 @@ function rpcRaw(ws, method, params, id) {
     ws.on("message", onMessage);
     ws.send(payload);
   });
+}
+
+// Endpoint of the bridge that answered, filled in by connectToTestBridge().
+let WS_URL = null;
+
+// Walk the candidate ports for the test project until one answers. Probing is
+// cheap (a refused TCP connect returns immediately) and it means a developer
+// never has to look up which port this worktree's editor bound.
+async function connectToTestBridge() {
+  const { candidates, lockfile } = bridgePortCandidates({
+    explicitPort: Number.isInteger(EXPLICIT_PORT) ? EXPLICIT_PORT : null,
+  });
+
+  let lastError = null;
+  for (const c of candidates) {
+    const url = `ws://${HOST}:${c.port}`;
+    try {
+      const ws = await connect(url, Math.min(TIMEOUT_MS, 3000));
+      WS_URL = url;
+      console.log(`${GREEN}Connected to ${url}${RESET} ${DIM}(${c.source})${RESET}`);
+      return ws;
+    } catch (err) {
+      lastError = err.message;
+      console.log(`${DIM}  no bridge on ${url} (${c.source})${RESET}`);
+    }
+  }
+
+  throw new Error(describeMissingBridge({ host: HOST, candidates, lockfile, lastError }));
 }
 
 const SCRATCH_LEVEL = "/Game/MCP_SmokeScratch";
@@ -282,27 +299,23 @@ async function main() {
     process.exit(1);
   }
 
-  console.log(`\n${BOLD}UE MCP Bridge — Smoke Test${RESET}`);
-  console.log(`${DIM}Endpoint : ${WS_URL}${RESET}`);
+  console.log(`\n${BOLD}UE MCP Bridge - Smoke Test${RESET}`);
+  console.log(`${DIM}Project  : ${TEST_PROJECT_UPROJECT}${RESET}`);
   console.log(`${DIM}Handlers : ${handlers.length}${RESET}`);
   console.log(`${DIM}Timeout  : ${TIMEOUT_MS}ms per call${RESET}\n`);
 
   // Connect
   let ws;
   try {
-    ws = await connect(WS_URL);
+    ws = await connectToTestBridge();
   } catch (err) {
-    console.error(
-      `${RED}${BOLD}Could not connect to the UE MCP bridge at ${WS_URL}${RESET}`
-    );
-    console.error(`${RED}${err.message}${RESET}`);
-    console.error(
-      `\n${DIM}Make sure Unreal Editor is running with the UE_MCP_Bridge plugin enabled.${RESET}\n`
-    );
+    console.error(`${RED}${BOLD}${err.message}${RESET}\n`);
     process.exit(1);
   }
 
-  console.log(`${GREEN}Connected to ${WS_URL}${RESET}\n`);
+  let nextId = 1;
+  const idGen = () => nextId++;
+  console.log("");
 
   // Run calls sequentially to avoid flooding the bridge.
   //
@@ -312,8 +325,6 @@ async function main() {
   // otherwise one slow handler cascades into 50+ false-FAILUREs as everything
   // queues behind it and also hits the per-call timeout.
   const results = [];
-  let nextId = 1;
-  const idGen = () => nextId++;
 
   // Pre-flight: anchor every spawn into a throwaway scratch level so the
   // anchor (MCP_Home) and any other map the user was on stays untouched.

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -19,8 +19,12 @@ import path from "path";
 import { fileURLToPath } from "url";
 import WebSocket from "ws";
 import {
+  assertLoopbackHost,
   bridgePortCandidates,
   describeMissingBridge,
+  assertTestProjectDir,
+  extractReportedProjectDir,
+  PROJECT_IDENTITY_PYTHON,
   TEST_PROJECT_UPROJECT,
 } from "./bridge-target.mjs";
 
@@ -189,6 +193,7 @@ let WS_URL = null;
 // cheap (a refused TCP connect returns immediately) and it means a developer
 // never has to look up which port this worktree's editor bound.
 async function connectToTestBridge() {
+  assertLoopbackHost(HOST);
   const { candidates, lockfile } = bridgePortCandidates({
     explicitPort: Number.isInteger(EXPLICIT_PORT) ? EXPLICIT_PORT : null,
   });
@@ -208,6 +213,22 @@ async function connectToTestBridge() {
   }
 
   throw new Error(describeMissingBridge({ host: HOST, candidates, lockfile, lastError }));
+}
+
+// The harness is hardcoded to tests/ue_mcp and every call below mutates the
+// connected editor. Confirm the editor really has that project open before
+// sending anything: a stale lockfile or a hand-passed --port must not be able
+// to point a destructive sweep at someone's working project.
+async function assertConnectedToTestProject(ws, idGen) {
+  const msg = await rpcRaw(ws, "execute_python", { code: PROJECT_IDENTITY_PYTHON }, idGen());
+  if (msg.error) {
+    throw new Error(
+      `Aborting: could not confirm which project the connected editor has open (${msg.error.message}).\n` +
+      `The smoke harness only runs against ${TEST_PROJECT_UPROJECT}, so nothing was sent.`,
+    );
+  }
+  const reported = assertTestProjectDir(extractReportedProjectDir(msg.result));
+  console.log(`${DIM}  target confirmed: ${reported}${RESET}`);
 }
 
 const SCRATCH_LEVEL = "/Game/MCP_SmokeScratch";
@@ -315,6 +336,15 @@ async function main() {
 
   let nextId = 1;
   const idGen = () => nextId++;
+
+  // Guard before any mutation: prove this editor is the test project.
+  try {
+    await assertConnectedToTestProject(ws, idGen);
+  } catch (err) {
+    console.error(`\n${RED}${BOLD}${err.message}${RESET}\n`);
+    ws.close();
+    process.exit(1);
+  }
   console.log("");
 
   // Run calls sequentially to avoid flooding the bridge.

--- a/tests/reload-bridge.ts
+++ b/tests/reload-bridge.ts
@@ -1,8 +1,9 @@
-import { EditorBridge } from "../src/bridge.js";
+import { getBridge, disconnectBridge } from "./setup.js";
 
 async function main() {
-  const bridge = new EditorBridge("localhost", 9877);
-  await bridge.connect(5000);
+  // Same discovery and same test-project guard as the rest of the harness: the
+  // bridge port is per-project and published in the project's port lockfile.
+  const bridge = await getBridge();
 
   const reloadCode = `
 import importlib
@@ -54,7 +55,7 @@ print(f"Reloaded modules: {len(reloaded)}")
     console.log("Reload error:", message);
   }
 
-  bridge.disconnect();
+  disconnectBridge();
 }
 
 main().catch(console.error);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,15 +1,46 @@
 import { EditorBridge } from "../src/bridge.js";
+import {
+  bridgePortCandidates,
+  describeMissingBridge,
+} from "../scripts/bridge-target.mjs";
 
 let _bridge: EditorBridge | null = null;
 
-const TEST_BRIDGE_HOST = process.env.UE_MCP_TEST_HOST ?? "localhost";
-const TEST_BRIDGE_PORT = Number(process.env.UE_MCP_TEST_PORT ?? 9877);
+// 127.0.0.1 rather than "localhost": on hosts where the IPv6 stack wins DNS,
+// "localhost" resolves to ::1 and the client waits on an empty socket while the
+// bridge owns the IPv4 loopback.
+const TEST_BRIDGE_HOST = process.env.UE_MCP_TEST_HOST ?? "127.0.0.1";
+const ENV_PORT = Number.parseInt(process.env.UE_MCP_TEST_PORT ?? "", 10);
 
+/**
+ * Connect to the bridge for tests/ue_mcp. The bridge binds a per-project port
+ * and publishes it to that project's Saved/UE_MCP_Bridge/port.json, so the port
+ * is discovered rather than assumed; UE_MCP_TEST_PORT still pins it when set.
+ */
 export async function getBridge(): Promise<EditorBridge> {
   if (_bridge?.isConnected) return _bridge;
-  _bridge = new EditorBridge(TEST_BRIDGE_HOST, TEST_BRIDGE_PORT);
-  await _bridge.connect(5000);
-  return _bridge;
+
+  const { candidates, lockfile } = bridgePortCandidates({
+    explicitPort: Number.isInteger(ENV_PORT) ? ENV_PORT : null,
+  });
+
+  let lastError: string | null = null;
+  for (const candidate of candidates) {
+    const bridge = new EditorBridge(TEST_BRIDGE_HOST, candidate.port);
+    try {
+      await bridge.connect(5000);
+    } catch (e: unknown) {
+      lastError = e instanceof Error ? e.message : String(e);
+      bridge.disconnect();
+      continue;
+    }
+    _bridge = bridge;
+    return bridge;
+  }
+
+  throw new Error(
+    describeMissingBridge({ host: TEST_BRIDGE_HOST, candidates, lockfile, lastError }),
+  );
 }
 
 export function disconnectBridge(): void {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,10 +1,13 @@
 import { EditorBridge } from "../src/bridge.js";
 import {
+  assertLoopbackHost,
   bridgePortCandidates,
   describeMissingBridge,
+  verifyTestProjectTarget,
 } from "../scripts/bridge-target.mjs";
 
 let _bridge: EditorBridge | null = null;
+let _targetVerified = false;
 
 // 127.0.0.1 rather than "localhost": on hosts where the IPv6 stack wins DNS,
 // "localhost" resolves to ::1 and the client waits on an empty socket while the
@@ -16,10 +19,13 @@ const ENV_PORT = Number.parseInt(process.env.UE_MCP_TEST_PORT ?? "", 10);
  * Connect to the bridge for tests/ue_mcp. The bridge binds a per-project port
  * and publishes it to that project's Saved/UE_MCP_Bridge/port.json, so the port
  * is discovered rather than assumed; UE_MCP_TEST_PORT still pins it when set.
+ * The connected editor is then challenged for its project directory, and any
+ * project other than tests/ue_mcp aborts the run before a single mutation.
  */
 export async function getBridge(): Promise<EditorBridge> {
   if (_bridge?.isConnected) return _bridge;
 
+  assertLoopbackHost(TEST_BRIDGE_HOST);
   const { candidates, lockfile } = bridgePortCandidates({
     explicitPort: Number.isInteger(ENV_PORT) ? ENV_PORT : null,
   });
@@ -35,6 +41,10 @@ export async function getBridge(): Promise<EditorBridge> {
       continue;
     }
     _bridge = bridge;
+    if (!_targetVerified) {
+      await verifyTestProjectTarget((method, params) => bridge.call(method, params));
+      _targetVerified = true;
+    }
     return bridge;
   }
 

--- a/tests/unit/bridge-target.test.ts
+++ b/tests/unit/bridge-target.test.ts
@@ -3,14 +3,20 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  assertLoopbackHost,
+  assertTestProjectDir,
   bridgePortCandidates,
   describeMissingBridge,
   deriveProjectPort,
+  extractReportedProjectDir,
+  isLoopbackHost,
+  isTestProjectDir,
   LEGACY_BRIDGE_PORT,
   readPortLockfile,
   TEST_PORT_LOCKFILE,
   TEST_PROJECT_DIR,
   TEST_PROJECT_UPROJECT,
+  verifyTestProjectTarget,
 } from "../../scripts/bridge-target.mjs";
 import { deriveProjectPort as srcDeriveProjectPort } from "../../src/port.js";
 
@@ -118,3 +124,65 @@ describe("describeMissingBridge", () => {
   });
 });
 
+describe("host guard", () => {
+  it("accepts loopback only", () => {
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackHost("localhost")).toBe(true);
+    expect(isLoopbackHost("::1")).toBe(true);
+    expect(isLoopbackHost("192.168.1.20")).toBe(false);
+    expect(isLoopbackHost("build-box.local")).toBe(false);
+  });
+
+  it("refuses to point the harness at another machine", () => {
+    expect(() => assertLoopbackHost("192.168.1.20")).toThrow(/Refusing/);
+    expect(() => assertLoopbackHost("127.0.0.1")).not.toThrow();
+  });
+});
+
+describe("test-project guard", () => {
+  it("accepts the repo test project in any path spelling", () => {
+    expect(isTestProjectDir(TEST_PROJECT_DIR)).toBe(true);
+    expect(isTestProjectDir(`${TEST_PROJECT_DIR}/`)).toBe(true);
+    expect(isTestProjectDir(TEST_PROJECT_DIR.replace(/\\/g, "/").toUpperCase())).toBe(true);
+  });
+
+  it("refuses any other project", () => {
+    expect(isTestProjectDir("C:/Users/dev/RealGame/")).toBe(false);
+    expect(isTestProjectDir(`${TEST_PROJECT_DIR}_other`)).toBe(false);
+    expect(isTestProjectDir(null)).toBe(false);
+    expect(() => assertTestProjectDir("C:/Users/dev/RealGame/")).toThrow(/not the smoke test project/);
+    expect(() => assertTestProjectDir("C:/Users/dev/RealGame/")).toThrow(/RealGame/);
+  });
+
+  it("extracts the reported project directory from a python result", () => {
+    expect(extractReportedProjectDir({ output: "MCP_PROJECT_DIR:C:/x/y/\n" })).toBe("C:/x/y/");
+    expect(extractReportedProjectDir("MCP_PROJECT_DIR:/home/dev/proj/")).toBe("/home/dev/proj/");
+    expect(extractReportedProjectDir({ logs: ["noise", "MCP_PROJECT_DIR:/a/b/"] })).toBe("/a/b/");
+    expect(extractReportedProjectDir({ output: "nothing here" })).toBeNull();
+    // A backslashed Windows path survives JSON escaping.
+    expect(extractReportedProjectDir({ output: "MCP_PROJECT_DIR:C:\\work\\proj\\" })).toBe("C:\\work\\proj\\");
+  });
+
+  it("passes when the editor reports the test project", async () => {
+    await expect(
+      verifyTestProjectTarget(async () => ({ output: `MCP_PROJECT_DIR:${TEST_PROJECT_DIR}/` })),
+    ).resolves.toBeTruthy();
+  });
+
+  it("aborts when the editor has a different project open", async () => {
+    await expect(
+      verifyTestProjectTarget(async () => ({ output: "MCP_PROJECT_DIR:C:/Users/dev/RealGame/" })),
+    ).rejects.toThrow(/not the smoke test project/);
+  });
+
+  it("aborts when the project cannot be identified at all", async () => {
+    await expect(
+      verifyTestProjectTarget(async () => {
+        throw new Error("Unknown method: execute_python");
+      }),
+    ).rejects.toThrow(/could not confirm which project/);
+    await expect(
+      verifyTestProjectTarget(async () => ({ output: "" })),
+    ).rejects.toThrow(/not the smoke test project/);
+  });
+});

--- a/tests/unit/bridge-target.test.ts
+++ b/tests/unit/bridge-target.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  bridgePortCandidates,
+  describeMissingBridge,
+  deriveProjectPort,
+  LEGACY_BRIDGE_PORT,
+  readPortLockfile,
+  TEST_PORT_LOCKFILE,
+  TEST_PROJECT_DIR,
+  TEST_PROJECT_UPROJECT,
+} from "../../scripts/bridge-target.mjs";
+import { deriveProjectPort as srcDeriveProjectPort } from "../../src/port.js";
+
+function withTempLockfile(contents: string | null): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-lock-"));
+  const file = path.join(dir, "port.json");
+  if (contents !== null) fs.writeFileSync(file, contents, "utf8");
+  return file;
+}
+
+describe("port derivation parity", () => {
+  it("matches src/port.ts, which matches the C++ bridge", () => {
+    for (const p of [
+      TEST_PROJECT_DIR,
+      "C:/Users/dev/GameA",
+      "C:\\Users\\Dev\\GameA\\",
+      "/home/dev/projects/thing",
+    ]) {
+      expect(deriveProjectPort(p)).toBe(srcDeriveProjectPort(p));
+    }
+  });
+});
+
+describe("readPortLockfile", () => {
+  it("reports a missing lockfile without throwing, keeping the path", () => {
+    const file = path.join(os.tmpdir(), "ue-mcp-lock-does-not-exist", "port.json");
+    const lock = readPortLockfile(file);
+    expect(lock.exists).toBe(false);
+    expect(lock.port).toBeNull();
+    expect(lock.error).toBe("not found");
+    expect(lock.path).toBe(file);
+  });
+
+  it("reads the bound port the bridge published", () => {
+    const file = withTempLockfile(
+      JSON.stringify({ port: 63300, pid: 4242, startedAt: "2026-01-01T00:00:00Z", apiVersion: 1 }),
+    );
+    const lock = readPortLockfile(file);
+    expect(lock.port).toBe(63300);
+    expect(lock.pid).toBe(4242);
+    expect(lock.exists).toBe(true);
+    expect(lock.error).toBeNull();
+  });
+
+  it("rejects a malformed lockfile instead of yielding a bogus port", () => {
+    expect(readPortLockfile(withTempLockfile("{not json")).error).toMatch(/not valid JSON/);
+    expect(readPortLockfile(withTempLockfile(JSON.stringify({ port: 0 }))).port).toBeNull();
+    expect(readPortLockfile(withTempLockfile(JSON.stringify({ port: 99999 }))).port).toBeNull();
+    expect(readPortLockfile(withTempLockfile(JSON.stringify({}))).error).toMatch(/no usable "port" field/);
+  });
+});
+
+describe("bridgePortCandidates", () => {
+  const noLockfile = { path: TEST_PORT_LOCKFILE, exists: false, port: null, pid: null, startedAt: null, error: "not found", pidAlive: null };
+
+  it("tries the published port first, then the derived one, then the legacy one", () => {
+    const lockfile = { ...noLockfile, exists: true, port: 63300, error: null };
+    const { candidates } = bridgePortCandidates({ lockfile });
+    expect(candidates.map((c) => c.port)).toEqual([
+      63300,
+      deriveProjectPort(TEST_PROJECT_DIR),
+      LEGACY_BRIDGE_PORT,
+    ]);
+    expect(candidates[0].source).toBe("lockfile");
+  });
+
+  it("still finds a bridge with no lockfile at all", () => {
+    const { candidates } = bridgePortCandidates({ lockfile: noLockfile });
+    expect(candidates.map((c) => c.port)).toEqual([
+      deriveProjectPort(TEST_PROJECT_DIR),
+      LEGACY_BRIDGE_PORT,
+    ]);
+  });
+
+  it("does not probe the same port twice", () => {
+    const lockfile = { ...noLockfile, exists: true, port: LEGACY_BRIDGE_PORT, error: null };
+    const { candidates } = bridgePortCandidates({ lockfile });
+    expect(candidates.filter((c) => c.port === LEGACY_BRIDGE_PORT)).toHaveLength(1);
+  });
+
+  it("honours an explicit port and probes nothing else", () => {
+    const lockfile = { ...noLockfile, exists: true, port: 63300, error: null };
+    const { candidates } = bridgePortCandidates({ explicitPort: 51234, lockfile });
+    expect(candidates).toEqual([{ port: 51234, source: "explicit" }]);
+  });
+});
+
+describe("describeMissingBridge", () => {
+  it("names the exact lockfile path and every port it tried", () => {
+    const lockfile = readPortLockfile(path.join(os.tmpdir(), "ue-mcp-absent", "port.json"));
+    const { candidates } = bridgePortCandidates({ lockfile });
+    const msg = describeMissingBridge({ host: "127.0.0.1", candidates, lockfile, lastError: "ECONNREFUSED" });
+
+    expect(msg).toContain(lockfile.path);
+    expect(msg).toContain(TEST_PROJECT_UPROJECT);
+    for (const c of candidates) expect(msg).toContain(`ws://127.0.0.1:${c.port}`);
+    expect(msg).toContain("not found");
+    expect(msg).toContain("ECONNREFUSED");
+  });
+
+  it("calls out a stale lockfile whose editor is gone", () => {
+    const lockfile = { path: TEST_PORT_LOCKFILE, exists: true, port: 63300, pid: 4242, startedAt: null, error: null, pidAlive: false };
+    const { candidates } = bridgePortCandidates({ lockfile });
+    expect(describeMissingBridge({ host: "127.0.0.1", candidates, lockfile })).toContain("stale lockfile");
+  });
+});
+


### PR DESCRIPTION
Fixes #797.

## Problem

The bridge binds a per-project port (derived from the project root path) and publishes the port it actually bound to `<Project>/Saved/UE_MCP_Bridge/port.json`. The test harnesses still dialled the legacy fixed `9877`:

- `tests/setup.ts` defaulted to `process.env.UE_MCP_TEST_PORT ?? 9877`
- `tests/reload-bridge.ts` hardcoded `new EditorBridge("localhost", 9877)`
- `scripts/smoke-test.js` read a lockfile but fell back to `9877` with a generic "could not connect" message

So every run against a freshly started editor failed, and the workaround was passing `UE_MCP_TEST_PORT=<port>` by hand.

## Change

`scripts/bridge-target.mjs` resolves the endpoint once for both harnesses:

1. the port recorded in the test project's lockfile,
2. the port derived from the project path (same algorithm as `src/port.ts` and the C++ bridge),
3. the legacy fixed port,

probing each in turn. When nothing answers, the failure names the exact lockfile path that was read, the state it was in (missing, malformed, or stale with a dead pid), and every port that was tried with where it came from.

The project stays hardcoded to `tests/ue_mcp/ue_mcp.uproject` relative to the checkout. Host and port remain overridable, so two checks now stand between connecting and the first mutation: the host must be loopback, and the connected editor is asked for its project directory, which must be this checkout's `tests/ue_mcp`. Anything else, or no answer at all, aborts before a single request is sent. That is the behavior the docs already promised.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run tests/unit` 341 passed (35 files), including 18 new cases covering derivation parity with `src/port.ts`, lockfile parsing, candidate ordering, the failure message, and both guards
- `node scripts/smoke-test.js` with no editor running prints the actionable message and exits 1

No files under `plugin/` are touched, so no C++ build is needed. A live `npm run test:smoke` run is left to the maintainer.