### PR TITLE
set_project: move the editor connection with the project (#818)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,7 +156,15 @@ The C++ plugin listens on a **per-project WebSocket port** derived from a hash o
 | **Disconnected** | Editor not running or plugin not loaded. Filesystem tools still work (INI parsing, C++ headers, asset listing) |
 | **Reconnecting** | Connection lost, auto-retry in progress |
 
-Check the current state with `project(action="get_status")`.
+Check the current state with `project(action="get_status")`. Alongside `editorConnected`, it reports `editorTarget`: the `.uproject` the connection belongs to, the port, and how that port was chosen (`lockfile`, `config`, `derived`, `env`, `explicit`). The connection is always bound to one project, so `editorTarget.projectPath` matches the loaded project.
+
+### Switching Projects
+
+`project(action="set_project", projectPath="...")` moves path resolution and the editor connection together. The socket to the previous project's editor is dropped before the new project is loaded, so no action can execute in the project you just left.
+
+The port for the new project is chosen from that project alone: its `Saved/UE_MCP_Bridge/port.json` lockfile first, then its own `bridge.port`, then the port derived from its root path.
+
+A port pinned with `UE_MCP_PORT` (or an explicit port argument) is the exception. It was chosen for whichever project the server started on and says nothing about the one you switched to, so if the new project has published no lockfile the switch still completes and the connection is refused with an explanation. Start the new project's editor, which publishes the lockfile, or clear the pin so each project gets its derived port.
 
 ## Plugin Deployment
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -157,6 +157,8 @@ Switch to the project at C:/path/to/Other.uproject.
 
 UE-MCP redeploys the bridge and reconnects. (Calls `project(action="set_project")` under the hood.)
 
+Path resolution and the editor connection move as one. The connection to the previous project's editor is dropped before the new project is loaded, so nothing can execute in the project you switched away from. If the new project's editor is not running, the switch still completes and the response reports the connection as unavailable: filesystem tools work, bridge actions wait for that editor. See [Switching Projects](configuration.md#switching-projects) for how the new project's port is chosen.
+
 ## Manual configuration
 
 If you'd rather skip `npx ue-mcp init`, edit the MCP client config yourself.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -19,7 +19,7 @@ UE-MCP exposes **<!-- count:tools -->24<!-- /count --> category tools** covering
 | Action | Description |
 |--------|-------------|
 | `get_status` | Check server mode and editor connection. Also reports pluginBuildStale when the compiled bridge is older than its source, which is the real cause of 'Unknown method' on handlers that do exist (#785) |
-| `set_project` | Switch project. Params: `projectPath` |
+| `set_project` | Switch project: moves both path resolution and the editor connection to the new .uproject. Params: `projectPath` |
 | `get_info` | Read .uproject file details |
 | `read_config` | Read INI config. Params: `configName (e.g. 'Engine', 'Game')` |
 | `search_config` | Search INI files. Params: `query` |

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -43,11 +43,46 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>;
 }
 
+/**
+ * How the port the bridge is about to use was chosen.
+ *
+ * The first three are attributable to the targeted project: the lockfile is
+ * written by that project's own editor, the config port comes from that
+ * project's ue-mcp.yml, and the derived port is a hash of that project's root
+ * that the C++ side computes identically. The last two are pins that say
+ * nothing about which project answers on that port.
+ */
+export type BridgePortSource = "lockfile" | "config" | "derived" | "explicit" | "env" | "default";
+
+/** Which editor the bridge is pointed at, and how sure it is. */
+export interface BridgeTarget {
+  /** Absolute .uproject path whose editor this connection belongs to. */
+  projectPath: string | null;
+  /** Port the next connect will use, before any lockfile re-read. */
+  port: number;
+  portSource: BridgePortSource;
+  /**
+   * True when the port is attributable to `projectPath`. False means the port
+   * is a pin inherited from the environment or an earlier target, so
+   * connecting could land on some other project's editor. Connects are
+   * refused in that state (see connect()).
+   */
+  verified: boolean;
+}
+
 /** Minimal interface for tool handlers — enables mocking in tests. */
 export interface IBridge {
   readonly isConnected: boolean;
   call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
   connect(timeoutMs?: number): Promise<void>;
+  /**
+   * Move the connection to another project's editor (#818). Drops the current
+   * socket before returning, so the caller can re-point path resolution in the
+   * same synchronous step and never expose a state where the two disagree.
+   */
+  retargetProject(uprojectPath: string, configPort?: number): BridgeTarget;
+  /** Snapshot of the current target, for reporting and for tests. */
+  getTarget(): BridgeTarget;
 }
 
 export class EditorBridge implements IBridge {
@@ -63,7 +98,23 @@ export class EditorBridge implements IBridge {
   // it is the port the editor actually bound. Deriving only kicks in while the
   // source is still "default", so an explicit/env/config pin is never
   // clobbered by the path hash.
-  private portSource: "explicit" | "env" | "config" | "derived" | "default" = "default";
+  private portSource: BridgePortSource = "default";
+
+  /**
+   * Set once the bridge has been retargeted at a specific project (#818).
+   * A pinned port (constructor arg or UE_MCP_PORT) was chosen for whatever
+   * project the process started on, so after a switch it is not evidence about
+   * the new target. While this is true and no lockfile confirms the port,
+   * connect() refuses rather than risk answering as the wrong editor.
+   */
+  private unverifiedPin = false;
+
+  /**
+   * Bumped on every retarget and every socket teardown. A connect that was
+   * already in flight when the target moved must not install its socket, or a
+   * switch would silently reconnect to the project we just left.
+   */
+  private targetGeneration = 0;
 
   constructor(host?: string, port?: number) {
     // #497: default to 127.0.0.1 so the client picks the loopback IPv4 the
@@ -139,21 +190,94 @@ export class EditorBridge implements IBridge {
     }
   }
 
+  /**
+   * Point the bridge at another project's editor (#818).
+   *
+   * The socket is dropped before anything else, so from the moment this
+   * returns the only editor reachable is the one belonging to `uprojectPath`.
+   * The port is re-decided from that project alone: its lockfile first (the
+   * port its editor actually bound), then its own `bridge.port` config, then
+   * the port derived from its root path. A port pinned by the constructor or
+   * UE_MCP_PORT survives only as a last resort and is flagged unverified,
+   * because it was chosen for a different project.
+   *
+   * Callers must re-point path resolution in the same synchronous step. That
+   * is what keeps the pair honest: a handler can never observe the resolved
+   * project and the connected editor referring to different projects.
+   */
+  retargetProject(uprojectPath: string, configPort?: number): BridgeTarget {
+    const resolved = path.resolve(uprojectPath);
+    const previous = this.projectPathForLockfile;
+    this.closeSocket(`Bridge retargeted to ${resolved}`);
+    this.projectPathForLockfile = resolved;
+    this.unverifiedPin = false;
+
+    const lockfile = readBridgeLockfile(resolved);
+    if (lockfile) {
+      this.port = lockfile.port;
+      this.portSource = "lockfile";
+    } else if (typeof configPort === "number" && configPort > 0) {
+      this.port = configPort;
+      this.portSource = "config";
+    } else if (this.portSource === "explicit" || this.portSource === "env") {
+      this.unverifiedPin = true;
+    } else {
+      this.port = deriveProjectPort(path.dirname(resolved));
+      this.portSource = "derived";
+    }
+
+    debug(
+      "bridge",
+      `retargeted from ${previous ?? "(no project)"} to ${resolved}: port ${this.port} (${this.portSource})`,
+    );
+    return this.getTarget();
+  }
+
+  getTarget(): BridgeTarget {
+    return {
+      projectPath: this.projectPathForLockfile,
+      port: this.port,
+      portSource: this.portSource,
+      verified: !this.unverifiedPin,
+    };
+  }
+
   async connect(timeoutMs = 3000): Promise<void> {
     if (this.isConnected) return;
 
-    this.ws?.terminate();
+    this.closeSocket("Bridge reconnecting");
 
     // #492: if a per-project lockfile exists for this .uproject, prefer the
     // port it advertises over the default. Lets multiple editors run side-
     // by-side without their npm clients colliding on 9877.
     const lockfile = readBridgeLockfile(this.projectPathForLockfile);
-    if (lockfile && lockfile.port !== this.port) {
-      debug("bridge", `lockfile points at port ${lockfile.port}, using it instead of default ${this.port}`);
-      this.port = lockfile.port;
+    if (lockfile) {
+      if (lockfile.port !== this.port) {
+        debug("bridge", `lockfile points at port ${lockfile.port}, using it instead of default ${this.port}`);
+        this.port = lockfile.port;
+      }
+      // The target project's own editor published this port, which is the
+      // proof a pin could not give.
+      this.portSource = "lockfile";
+      this.unverifiedPin = false;
+    }
+
+    // #818: refuse rather than guess. The alternative is connecting to a port
+    // chosen for a different project and executing every subsequent mutation
+    // in an editor the caller never asked for.
+    if (this.unverifiedPin) {
+      throw new McpError(
+        ErrorCode.NOT_CONNECTED,
+        `Refusing to connect: the bridge is targeted at ${this.projectPathForLockfile}, ` +
+          `but port ${this.port} is pinned (${this.portSource === "env" ? "UE_MCP_PORT" : "explicit port argument"}) ` +
+          `and was not chosen for this project, so it may belong to another editor. ` +
+          `Start this project's editor (it publishes Saved/UE_MCP_Bridge/port.json), ` +
+          `or clear the pin so the per-project port is derived from the project path.`,
+      );
     }
 
     const url = `ws://${this.host}:${this.port}`;
+    const generation = this.targetGeneration;
 
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -165,6 +289,18 @@ export class EditorBridge implements IBridge {
 
       ws.on("open", () => {
         clearTimeout(timer);
+        // The target moved while this handshake was in flight. Installing the
+        // socket now would put the bridge back on the project we just left.
+        if (this.targetGeneration !== generation) {
+          ws.terminate();
+          reject(
+            new McpError(
+              ErrorCode.NOT_CONNECTED,
+              `Abandoned the connection to ${url}: the bridge was retargeted while connecting.`,
+            ),
+          );
+          return;
+        }
         this.ws = ws;
         this.setupListeners(ws);
         resolve();
@@ -243,15 +379,27 @@ export class EditorBridge implements IBridge {
 
   disconnect(): void {
     this.stopReconnecting();
+    this.closeSocket("Bridge disconnected", { graceful: true });
+  }
+
+  /**
+   * Drop the socket and fail everything riding on it. Retargeting terminates
+   * instead of closing: a close handshake leaves the socket usable for another
+   * round trip, and the caller is switching projects precisely because nothing
+   * more should reach this editor.
+   */
+  private closeSocket(reason: string, opts?: { graceful?: boolean }): void {
+    this.targetGeneration += 1;
     for (const [, pending] of this.pending) {
       clearTimeout(pending.timer);
-      pending.reject(new McpError(ErrorCode.CONNECTION_LOST, "Bridge disconnected"));
+      pending.reject(new McpError(ErrorCode.CONNECTION_LOST, reason));
     }
     this.pending.clear();
-    if (this.ws) {
-      this.ws.close();
-      this.ws = null;
-    }
+    const ws = this.ws;
+    this.ws = null;
+    if (!ws) return;
+    if (opts?.graceful) ws.close();
+    else ws.terminate();
   }
 
   private setupListeners(ws: WebSocket): void {
@@ -275,6 +423,10 @@ export class EditorBridge implements IBridge {
     });
 
     ws.on("close", () => {
+      // A socket we already replaced (retarget, reconnect) closes after its
+      // successor is live. Without this guard its late close event would null
+      // out the new connection and fail the calls riding on it.
+      if (this.ws !== ws) return;
       for (const [, pending] of this.pending) {
         clearTimeout(pending.timer);
         pending.reject(new McpError(ErrorCode.CONNECTION_LOST, "Bridge connection lost"));

--- a/src/flow/guarded-bridge.ts
+++ b/src/flow/guarded-bridge.ts
@@ -8,7 +8,7 @@
  *
  * Only `call` is gated; connection lifecycle delegates straight through.
  */
-import type { IBridge } from "../bridge.js";
+import type { BridgeTarget, IBridge } from "../bridge.js";
 import {
   GuardRegistry,
   makeCallContext,
@@ -31,6 +31,14 @@ export class GuardedBridge implements IBridge {
 
   connect(timeoutMs?: number): Promise<void> {
     return this.inner.connect(timeoutMs);
+  }
+
+  retargetProject(uprojectPath: string, configPort?: number): BridgeTarget {
+    return this.inner.retargetProject(uprojectPath, configPort);
+  }
+
+  getTarget(): BridgeTarget {
+    return this.inner.getTarget();
   }
 
   async call(

--- a/src/project-switch.ts
+++ b/src/project-switch.ts
@@ -1,0 +1,97 @@
+/**
+ * Switching the loaded project (#818).
+ *
+ * The server holds two things that describe one editor: a ProjectContext that
+ * resolves asset paths on disk, and a bridge socket that executes actions
+ * inside the running editor. Moving one without the other is not a degraded
+ * state, it is a destructive one: path-resolving actions read project B while
+ * every bridge action mutates project A, and both halves report success.
+ *
+ * This module is the only supported way to move them, and it moves them
+ * together:
+ *
+ *   1. Resolve and validate the target first. A bad path throws before
+ *      anything has changed, so a failed switch leaves the pair on the
+ *      project they were already on.
+ *   2. Retarget the bridge, then re-point the ProjectContext, with no await
+ *      between them. The socket to the previous editor is dropped inside step
+ *      one of that pair, so the only window between them is synchronous and
+ *      no handler can run inside it.
+ *   3. Only then try to connect. A failure here leaves the pair consistent
+ *      and simply disconnected, which is safe: nothing can reach any editor.
+ */
+import * as path from "node:path";
+import type { BridgeTarget, IBridge } from "./bridge.js";
+import { ProjectContext, readUeMcpConfig, resolveUProjectPath } from "./project.js";
+import { debug, info } from "./log.js";
+
+export interface ProjectSwitchResult {
+  /** Absolute .uproject now loaded. */
+  projectPath: string;
+  /** What was loaded before, null on the first load. */
+  previousProjectPath: string | null;
+  /** Where the bridge now points. Always the same project as projectPath. */
+  target: BridgeTarget;
+  connected: boolean;
+  /** Why the editor could not be reached, when it could not. */
+  connectError?: string;
+}
+
+export async function switchProject(
+  project: ProjectContext,
+  bridge: IBridge,
+  inputPath: string,
+  opts?: { connectTimeoutMs?: number },
+): Promise<ProjectSwitchResult> {
+  const previousProjectPath = project.projectPath;
+  // Throws on a bad path, before either half has moved.
+  const resolved = resolveUProjectPath(inputPath);
+  // The new project's own bridge.port, if it pins one. Read before the switch
+  // so the bridge never has to fall back on the previous project's setting.
+  const configPort = readUeMcpConfig(path.dirname(resolved)).bridge?.port;
+
+  // ── The pair moves here. Do not introduce an await between these two. ──
+  // retargetProject drops the socket to the previous editor before it
+  // returns, so from this point no bridge call can reach the project we are
+  // leaving, and setProject cannot fail in a way that strands the socket
+  // there either.
+  const target = bridge.retargetProject(resolved, configPort);
+  project.setProject(resolved);
+  // ──────────────────────────────────────────────────────────────────────
+
+  info(
+    "project",
+    `switched to ${project.projectName} (${resolved}); bridge port ${target.port} (${target.portSource})`,
+  );
+
+  let connected = false;
+  let connectError: string | undefined;
+  try {
+    await bridge.connect(opts?.connectTimeoutMs);
+    connected = bridge.isConnected;
+  } catch (e) {
+    // Not fatal. The editor for this project may simply not be running, and
+    // the pair is consistent either way.
+    connectError = e instanceof Error ? e.message : String(e);
+    debug("project", `no editor for ${resolved} after the switch`, e);
+  }
+
+  return {
+    projectPath: resolved,
+    previousProjectPath,
+    target: bridge.getTarget(),
+    connected,
+    connectError,
+  };
+}
+
+/**
+ * True when the bridge is connected to an editor other than the loaded
+ * project's. The switch path makes this unreachable; get_status reports it so
+ * that if some future path ever breaks the invariant, it is visible rather
+ * than silent (#818).
+ */
+export function isTargetDiverged(project: ProjectContext, target: BridgeTarget): boolean {
+  if (!project.projectPath || !target.projectPath) return false;
+  return path.resolve(project.projectPath) !== path.resolve(target.projectPath);
+}

--- a/src/project.ts
+++ b/src/project.ts
@@ -85,6 +85,9 @@ export class ProjectContext {
 
     this.projectName = path.basename(this.projectPath, ".uproject");
     this.contentDir = path.join(path.dirname(this.projectPath), "Content");
+    // The cache is keyed to nothing but the process, so a switch would keep
+    // resolving /MyPlugin/ paths against the project we just left.
+    this._pluginCache = null;
     this.parseUProject();
     this.loadConfig();
   }

--- a/src/project.ts
+++ b/src/project.ts
@@ -59,6 +59,49 @@ export interface UeMcpConfig {
   pluginConfig?: Record<string, { groups?: Record<string, boolean> } & Record<string, unknown>>;
 }
 
+/**
+ * Resolve a user-supplied path (a .uproject, or a directory holding one) to an
+ * absolute .uproject path. Pure: it touches no state, so a caller that has to
+ * move several things at once can validate the target first and leave
+ * everything where it was when the path is bad.
+ */
+export function resolveUProjectPath(inputPath: string): string {
+  if (inputPath.endsWith(".uproject")) {
+    const resolved = path.resolve(inputPath);
+    if (!fs.existsSync(resolved)) {
+      throw new McpError(ErrorCode.NOT_FOUND, `No .uproject file at ${resolved}`);
+    }
+    return resolved;
+  }
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(inputPath);
+  } catch {
+    throw new McpError(ErrorCode.NOT_FOUND, `Project directory not found: ${inputPath}`);
+  }
+  const files = entries.filter((f) => f.endsWith(".uproject"));
+  if (files.length === 0) {
+    throw new McpError(ErrorCode.NOT_FOUND, `No .uproject file found in ${inputPath}`);
+  }
+  return path.resolve(inputPath, files[0]);
+}
+
+/**
+ * Read the merged `ue-mcp:` config for a project directory without loading the
+ * project. Lets a caller learn a project's settings (its pinned bridge port,
+ * say) before committing to the switch.
+ */
+export function readUeMcpConfig(projectDir: string): UeMcpConfig {
+  const block = loadLayeredUeMcpBlock(projectDir);
+  const parsed = UeMcpConfigSchema.safeParse(block);
+  if (!parsed.success) {
+    warn("project", `merged ue-mcp: config did not match expected shape - using defaults`, parsed.error);
+    return {};
+  }
+  return parsed.data;
+}
+
 export class ProjectContext {
   projectPath: string | null = null;
   projectName: string | null = null;
@@ -71,18 +114,7 @@ export class ProjectContext {
   }
 
   setProject(inputPath: string): void {
-    if (inputPath.endsWith(".uproject")) {
-      this.projectPath = path.resolve(inputPath);
-    } else {
-      const files = fs
-        .readdirSync(inputPath)
-        .filter((f) => f.endsWith(".uproject"));
-      if (files.length === 0) {
-        throw new McpError(ErrorCode.NOT_FOUND, `No .uproject file found in ${inputPath}`);
-      }
-      this.projectPath = path.resolve(inputPath, files[0]);
-    }
-
+    this.projectPath = resolveUProjectPath(inputPath);
     this.projectName = path.basename(this.projectPath, ".uproject");
     this.contentDir = path.join(path.dirname(this.projectPath), "Content");
     // The cache is keyed to nothing but the process, so a switch would keep
@@ -257,18 +289,8 @@ export class ProjectContext {
     migrateLegacyLocalYaml(this.projectDir);
     migrateLegacyFeedbackModeInYaml(this.projectDir);
 
-    const block = loadLayeredUeMcpBlock(this.projectDir);
-    const parsed = UeMcpConfigSchema.safeParse(block);
-    if (!parsed.success) {
-      warn(
-        "project",
-        `merged ue-mcp: config did not match expected shape - using defaults`,
-        parsed.error,
-      );
-      return;
-    }
-    this.config = parsed.data;
-    if (Object.keys(block).length > 0) {
+    this.config = readUeMcpConfig(this.projectDir);
+    if (Object.keys(this.config).length > 0) {
       info("project", `loaded config from ue-mcp.yml (merged with any global / env / local layers)`);
     }
   }

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -10,6 +10,7 @@ import { readDeployedBridgeApiVersion } from "../plugin/bridge-api.js";
 import { searchTools, type ToolSearchHit } from "../tool-search.js";
 import { getWorkarounds } from "../workaround-tracker.js";
 import { readLogState, readEngineSnapshot } from "../engine-observer.js";
+import { switchProject, isTargetDiverged } from "../project-switch.js";
 
 /**
  * Resolve a module name to its Source/<Module> directory, searching the project
@@ -95,12 +96,26 @@ export const projectTool: ToolDef = categoryTool(
           };
         })();
 
+        // Which editor this connection belongs to (#818). "connected" on its
+        // own never said whose editor answered, so a bridge left on another
+        // project read as a healthy session.
+        const target = ctx.bridge.getTarget();
+
         return {
           engine: offlineEngine ?? undefined,
           pluginBuildStale: freshness.checked ? freshness.stale : undefined,
           pluginBuildWarning: freshness.stale ? freshness.message : undefined,
           mode: ctx.bridge.isConnected ? "live" : "disconnected",
           editorConnected: ctx.bridge.isConnected,
+          editorTarget: {
+            projectPath: target.projectPath,
+            port: target.port,
+            portSource: target.portSource,
+          },
+          // Bridge calls and path resolution would be hitting different
+          // projects. Unreachable through set_project, reported so it can
+          // never be silent again.
+          editorTargetMismatch: isTargetDiverged(ctx.project, target) || undefined,
           project: ctx.project.isLoaded ? { name: ctx.project.projectName, path: ctx.project.projectPath, contentDir: ctx.project.contentDir, engineAssociation: ctx.project.engineAssociation, config: Object.keys(ctx.project.config).length > 0 ? ctx.project.config : undefined } : null,
           // Bridge ABI version of the deployed plugin in this project.
           // Plugins declaring nativeModule.minBridgeApi compare against
@@ -114,12 +129,31 @@ export const projectTool: ToolDef = categoryTool(
       },
     },
     set_project: {
-      description: "Switch project. Params: projectPath",
+      description: "Switch project: moves both path resolution and the editor connection to the new .uproject. Params: projectPath",
       handler: async (ctx, p) => {
-        ctx.project.setProject(p.projectPath as string);
+        // switchProject moves the bridge and the path resolver together (#818).
+        // Doing it here by hand is what left the socket on the previous
+        // project's editor while every path resolved against the new one.
+        const switched = await switchProject(ctx.project, ctx.bridge, p.projectPath as string);
         const result = deploy(ctx.project);
-        try { await ctx.bridge.connect(); } catch { /* editor might not be running */ }
-        return { success: true, projectName: ctx.project.projectName, contentDir: ctx.project.contentDir, engineAssociation: ctx.project.engineAssociation, editorConnected: ctx.bridge.isConnected, bridgeSetup: deploySummary(result) };
+        return {
+          success: true,
+          projectName: ctx.project.projectName,
+          contentDir: ctx.project.contentDir,
+          engineAssociation: ctx.project.engineAssociation,
+          previousProject: switched.previousProjectPath ?? undefined,
+          editorConnected: switched.connected,
+          // The editor this connection belongs to. Always the project above.
+          editorTarget: {
+            projectPath: switched.target.projectPath,
+            port: switched.target.port,
+            portSource: switched.target.portSource,
+          },
+          // Present when no editor answered: the switch still completed, and
+          // nothing can reach the previous project's editor any more.
+          editorUnreachable: switched.connectError,
+          bridgeSetup: deploySummary(result),
+        };
       },
     },
     get_info: {

--- a/tests/unit/bridge-retarget.test.ts
+++ b/tests/unit/bridge-retarget.test.ts
@@ -1,0 +1,194 @@
+// #818: the connection target and the resolved project must move together.
+// These cover the bridge half of that guarantee: retargeting drops the socket
+// to the previous editor, re-decides the port from the new project alone, and
+// refuses to connect when the port cannot be attributed to the new project.
+import { once } from "node:events";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AddressInfo } from "node:net";
+import { WebSocketServer } from "ws";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { EditorBridge } from "../../src/bridge.js";
+import { deriveProjectPort } from "../../src/port.js";
+
+/** A stand-in editor that answers every call with its own name. */
+async function fakeEditor(name: string): Promise<{
+  port: number;
+  received: string[];
+  close: () => Promise<void>;
+}> {
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  const received: string[] = [];
+  server.on("connection", (socket) => {
+    socket.on("message", (data) => {
+      const request = JSON.parse(data.toString()) as { id: string; method: string };
+      received.push(request.method);
+      socket.send(JSON.stringify({ id: request.id, result: { editor: name } }));
+    });
+  });
+  await once(server, "listening");
+  return {
+    port: (server.address() as AddressInfo).port,
+    received,
+    close: async () => {
+      for (const client of server.clients) client.terminate();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+/** Temp .uproject, optionally with the lockfile its editor would publish. */
+function makeProject(name: string, lockfilePort?: number): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ue-mcp-818-${name}-`));
+  const uproject = path.join(dir, `${name}.uproject`);
+  fs.writeFileSync(uproject, JSON.stringify({ FileVersion: 3, EngineAssociation: "5.7" }));
+  fs.mkdirSync(path.join(dir, "Content"), { recursive: true });
+  if (lockfilePort !== undefined) {
+    const lockDir = path.join(dir, "Saved", "UE_MCP_Bridge");
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(lockDir, "port.json"),
+      JSON.stringify({ port: lockfilePort, pid: 4242 }),
+    );
+  }
+  return uproject;
+}
+
+describe("EditorBridge.retargetProject", () => {
+  let savedEnvPort: string | undefined;
+
+  beforeEach(() => {
+    savedEnvPort = process.env.UE_MCP_PORT;
+    delete process.env.UE_MCP_PORT;
+  });
+
+  afterEach(() => {
+    if (savedEnvPort === undefined) delete process.env.UE_MCP_PORT;
+    else process.env.UE_MCP_PORT = savedEnvPort;
+  });
+
+  it("moves a live connection off the previous editor and onto the new project's", async () => {
+    const editorA = await fakeEditor("A");
+    const editorB = await fakeEditor("B");
+    const projectA = makeProject("A", editorA.port);
+    const projectB = makeProject("B", editorB.port);
+
+    const bridge = new EditorBridge("127.0.0.1", editorA.port);
+    bridge.setProjectContext(projectA);
+
+    try {
+      await expect(bridge.call("ping", {}, 1000)).resolves.toEqual({ editor: "A" });
+
+      const target = bridge.retargetProject(projectB);
+      // The socket to A is gone the moment the retarget returns, before any
+      // await gives another handler a chance to run.
+      expect(bridge.isConnected).toBe(false);
+      expect(target.projectPath).toBe(path.resolve(projectB));
+      expect(target.port).toBe(editorB.port);
+      expect(target.portSource).toBe("lockfile");
+      expect(target.verified).toBe(true);
+
+      await expect(bridge.call("ping", {}, 1000)).resolves.toEqual({ editor: "B" });
+      expect(editorA.received).toEqual(["ping"]);
+      expect(editorB.received).toEqual(["ping"]);
+    } finally {
+      bridge.disconnect();
+      await editorA.close();
+      await editorB.close();
+    }
+  });
+
+  it("re-derives the port from the new project root when it publishes no lockfile", () => {
+    const projectA = makeProject("A");
+    const projectB = makeProject("B");
+
+    const bridge = new EditorBridge();
+    bridge.setProjectContext(projectA);
+    expect(bridge.port).toBe(deriveProjectPort(path.dirname(projectA)));
+
+    const target = bridge.retargetProject(projectB);
+    expect(target.port).toBe(deriveProjectPort(path.dirname(projectB)));
+    expect(target.port).not.toBe(deriveProjectPort(path.dirname(projectA)));
+    expect(target.portSource).toBe("derived");
+    expect(target.verified).toBe(true);
+  });
+
+  it("prefers the new project's configured port over the previous project's", () => {
+    const bridge = new EditorBridge();
+    bridge.setProjectContext(makeProject("A"));
+
+    const target = bridge.retargetProject(makeProject("B"), 9999);
+    expect(target.port).toBe(9999);
+    expect(target.portSource).toBe("config");
+    expect(target.verified).toBe(true);
+  });
+
+  it("refuses to connect when only an inherited pin names the port", async () => {
+    process.env.UE_MCP_PORT = "9877";
+    const bridge = new EditorBridge();
+    bridge.setProjectContext(makeProject("A"));
+
+    const projectB = makeProject("B");
+    const target = bridge.retargetProject(projectB);
+    expect(target.verified).toBe(false);
+    expect(target.port).toBe(9877);
+
+    await expect(bridge.connect(200)).rejects.toThrow(/Refusing to connect/);
+    await expect(bridge.call("ping", {}, 200)).rejects.toThrow(/UE_MCP_PORT/);
+    expect(bridge.isConnected).toBe(false);
+  });
+
+  it("accepts the pinned port again once the new project's editor publishes a lockfile", async () => {
+    process.env.UE_MCP_PORT = "9877";
+    const editorB = await fakeEditor("B");
+    const bridge = new EditorBridge();
+    bridge.setProjectContext(makeProject("A"));
+
+    const projectB = makeProject("B");
+    expect(bridge.retargetProject(projectB).verified).toBe(false);
+
+    // The editor starts and publishes the port it actually bound.
+    const lockDir = path.join(path.dirname(projectB), "Saved", "UE_MCP_Bridge");
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(path.join(lockDir, "port.json"), JSON.stringify({ port: editorB.port, pid: 1 }));
+
+    try {
+      await expect(bridge.call("ping", {}, 1000)).resolves.toEqual({ editor: "B" });
+      expect(bridge.getTarget().verified).toBe(true);
+      expect(bridge.getTarget().portSource).toBe("lockfile");
+    } finally {
+      bridge.disconnect();
+      await editorB.close();
+    }
+  });
+
+  it("abandons a handshake that was in flight when the target moved", async () => {
+    const editorA = await fakeEditor("A");
+    const editorB = await fakeEditor("B");
+    const projectA = makeProject("A", editorA.port);
+    const projectB = makeProject("B", editorB.port);
+
+    const bridge = new EditorBridge();
+    bridge.setProjectContext(projectA);
+
+    try {
+      const connecting = bridge.connect(1000);
+      // Same tick: the handshake with A has not completed yet.
+      bridge.retargetProject(projectB);
+
+      await expect(connecting).rejects.toThrow(/retargeted while connecting/);
+      expect(bridge.isConnected).toBe(false);
+
+      await expect(bridge.call("ping", {}, 1000)).resolves.toEqual({ editor: "B" });
+      expect(editorA.received).toEqual([]);
+    } finally {
+      bridge.disconnect();
+      await editorA.close();
+      await editorB.close();
+    }
+  });
+});

--- a/tests/unit/guarded-bridge.test.ts
+++ b/tests/unit/guarded-bridge.test.ts
@@ -9,6 +9,8 @@ function fakeInner(result: unknown = { ok: true }): IBridge & { calls: Array<{ m
     calls,
     isConnected: true,
     connect: async () => {},
+    retargetProject: () => ({ projectPath: null, port: 0, portSource: "default" as const, verified: true }),
+    getTarget: () => ({ projectPath: null, port: 0, portSource: "default" as const, verified: true }),
     call: async (method, params) => {
       calls.push({ method, params });
       return result;

--- a/tests/unit/locking.test.ts
+++ b/tests/unit/locking.test.ts
@@ -48,6 +48,8 @@ function fakeBridge(calls: Array<[string, Record<string, unknown>]>, responder: 
   return {
     isConnected: true,
     connect: async () => {},
+    retargetProject: () => ({ projectPath: null, port: 0, portSource: "default" as const, verified: true }),
+    getTarget: () => ({ projectPath: null, port: 0, portSource: "default" as const, verified: true }),
     call: async (method: string, params?: Record<string, unknown>) => {
       calls.push([method, params ?? {}]);
       return responder(method, params ?? {});

--- a/tests/unit/project-switch.test.ts
+++ b/tests/unit/project-switch.test.ts
@@ -1,0 +1,275 @@
+// #818: after a project switch, path resolution and the editor connection
+// must describe the same project, or bridge actions mutate the project the
+// caller just switched away from.
+//
+// Each test drives the real ProjectContext and the real EditorBridge against
+// stand-in editors on loopback, so "which editor answered" is observed rather
+// than asserted about a mock.
+import { once } from "node:events";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AddressInfo } from "node:net";
+import { WebSocketServer } from "ws";
+import yaml from "js-yaml";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { EditorBridge } from "../../src/bridge.js";
+import { ProjectContext } from "../../src/project.js";
+import { switchProject, isTargetDiverged } from "../../src/project-switch.js";
+
+async function fakeEditor(name: string): Promise<{
+  port: number;
+  received: string[];
+  hang: boolean;
+  close: () => Promise<void>;
+}> {
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  const state = {
+    port: 0,
+    received: [] as string[],
+    hang: false,
+    close: async () => {
+      for (const client of server.clients) client.terminate();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+  server.on("connection", (socket) => {
+    socket.on("message", (data) => {
+      const request = JSON.parse(data.toString()) as { id: string; method: string };
+      state.received.push(request.method);
+      if (state.hang) return;
+      socket.send(JSON.stringify({ id: request.id, result: { editor: name } }));
+    });
+  });
+  await once(server, "listening");
+  state.port = (server.address() as AddressInfo).port;
+  return state;
+}
+
+function makeProject(name: string, opts?: { lockfilePort?: number; configPort?: number }): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `ue-mcp-switch-${name}-`));
+  const uproject = path.join(dir, `${name}.uproject`);
+  // No EngineAssociation: nothing in these tests should touch a real engine.
+  fs.writeFileSync(uproject, JSON.stringify({ FileVersion: 3 }));
+  fs.mkdirSync(path.join(dir, "Content"), { recursive: true });
+  if (opts?.lockfilePort !== undefined) {
+    const lockDir = path.join(dir, "Saved", "UE_MCP_Bridge");
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(path.join(lockDir, "port.json"), JSON.stringify({ port: opts.lockfilePort, pid: 7 }));
+  }
+  if (opts?.configPort !== undefined) {
+    fs.writeFileSync(
+      path.join(dir, "ue-mcp.yml"),
+      yaml.dump({ "ue-mcp": { version: 1, bridge: { port: opts.configPort } } }),
+    );
+  }
+  return uproject;
+}
+
+/** The invariant, checked as one statement. */
+function expectPairAgrees(project: ProjectContext, bridge: EditorBridge, uproject: string): void {
+  expect(project.projectPath).toBe(path.resolve(uproject));
+  expect(bridge.getTarget().projectPath).toBe(path.resolve(uproject));
+  expect(isTargetDiverged(project, bridge.getTarget())).toBe(false);
+}
+
+describe("switchProject", () => {
+  let savedEnvPort: string | undefined;
+  let globalCfg: string;
+
+  beforeEach(() => {
+    savedEnvPort = process.env.UE_MCP_PORT;
+    delete process.env.UE_MCP_PORT;
+    // Keep the developer's ~/.ue-mcp/config.yml out of these tests.
+    globalCfg = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-global-")), "config.yml");
+    process.env.UE_MCP_GLOBAL_CONFIG = globalCfg;
+  });
+
+  afterEach(() => {
+    delete process.env.UE_MCP_GLOBAL_CONFIG;
+    if (savedEnvPort === undefined) delete process.env.UE_MCP_PORT;
+    else process.env.UE_MCP_PORT = savedEnvPort;
+  });
+
+  it("moves path resolution and the live connection to the new project together", async () => {
+    const editorA = await fakeEditor("A");
+    const editorB = await fakeEditor("B");
+    const projectA = makeProject("A", { lockfilePort: editorA.port });
+    const projectB = makeProject("B", { lockfilePort: editorB.port });
+
+    const project = new ProjectContext();
+    const bridge = new EditorBridge();
+    project.setProject(projectA);
+    bridge.setProjectContext(project.projectPath);
+
+    try {
+      await expect(bridge.call("ping", {}, 1000)).resolves.toEqual({ editor: "A" });
+      expectPairAgrees(project, bridge, projectA);
+
+      const result = await switchProject(project, bridge, projectB, { connectTimeoutMs: 1000 });
+
+      expect(result.connected).toBe(true);
+      expect(result.previousProjectPath).toBe(path.resolve(projectA));
+      expectPairAgrees(project, bridge, projectB);
+      // Content paths and bridge calls now name the same project.
+      expect(project.resolveContentPath("/Game/Thing")).toContain(path.dirname(projectB));
+      await expect(bridge.call("place_actor", {}, 1000)).resolves.toEqual({ editor: "B" });
+      expect(editorA.received).toEqual(["ping"]);
+      expect(editorB.received).toEqual(["place_actor"]);
+    } finally {
+      bridge.disconnect();
+      await editorA.close();
+      await editorB.close();
+    }
+  });
+
+  it("leaves nothing reachable in the old editor when the new one is not running", async () => {
+    const editorA = await fakeEditor("A");
+    const projectA = makeProject("A", { lockfilePort: editorA.port });
+    // No lockfile and no editor: project B is simply not open.
+    const projectB = makeProject("B");
+
+    const project = new ProjectContext();
+    const bridge = new EditorBridge();
+    project.setProject(projectA);
+    bridge.setProjectContext(project.projectPath);
+
+    try {
+      await expect(bridge.call("ping", {}, 1000)).resolves.toEqual({ editor: "A" });
+
+      const result = await switchProject(project, bridge, projectB, { connectTimeoutMs: 300 });
+
+      expect(result.connected).toBe(false);
+      expect(result.connectError).toBeTruthy();
+      expectPairAgrees(project, bridge, projectB);
+      expect(bridge.isConnected).toBe(false);
+
+      // This is the bug: before the fix, this call executed in project A.
+      await expect(bridge.call("place_actor", {}, 300)).rejects.toThrow();
+      expect(editorA.received).toEqual(["ping"]);
+    } finally {
+      bridge.disconnect();
+      await editorA.close();
+    }
+  });
+
+  it("fails a call that was in flight to the old editor rather than letting it land", async () => {
+    const editorA = await fakeEditor("A");
+    const editorB = await fakeEditor("B");
+    editorA.hang = true;
+    const projectA = makeProject("A", { lockfilePort: editorA.port });
+    const projectB = makeProject("B", { lockfilePort: editorB.port });
+
+    const project = new ProjectContext();
+    const bridge = new EditorBridge();
+    project.setProject(projectA);
+    bridge.setProjectContext(project.projectPath);
+
+    try {
+      await bridge.connect(1000);
+      // Assert on the rejection before the switch runs, so the failure is
+      // observed the moment it happens rather than a tick later.
+      const inFlight = expect(bridge.call("slow_write", {}, 5000)).rejects.toThrow(/retargeted/);
+
+      await switchProject(project, bridge, projectB, { connectTimeoutMs: 1000 });
+
+      await inFlight;
+      expectPairAgrees(project, bridge, projectB);
+    } finally {
+      bridge.disconnect();
+      await editorA.close();
+      await editorB.close();
+    }
+  });
+
+  it("refuses a bad target and leaves both halves on the current project", async () => {
+    const editorA = await fakeEditor("A");
+    const projectA = makeProject("A", { lockfilePort: editorA.port });
+
+    const project = new ProjectContext();
+    const bridge = new EditorBridge();
+    project.setProject(projectA);
+    bridge.setProjectContext(project.projectPath);
+
+    try {
+      await expect(bridge.call("ping", {}, 1000)).resolves.toEqual({ editor: "A" });
+
+      const missingDir = path.join(os.tmpdir(), "ue-mcp-switch-does-not-exist");
+      await expect(switchProject(project, bridge, missingDir)).rejects.toThrow(/not found/i);
+
+      // Nothing moved: not the path resolver, not the socket.
+      expectPairAgrees(project, bridge, projectA);
+      expect(bridge.isConnected).toBe(true);
+      await expect(bridge.call("ping", {}, 1000)).resolves.toEqual({ editor: "A" });
+
+      const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-switch-empty-"));
+      await expect(switchProject(project, bridge, emptyDir)).rejects.toThrow(/No .uproject/);
+      expectPairAgrees(project, bridge, projectA);
+      expect(bridge.isConnected).toBe(true);
+    } finally {
+      bridge.disconnect();
+      await editorA.close();
+    }
+  });
+
+  it("takes the bridge port from the new project's config, not the old one's", async () => {
+    const editorB = await fakeEditor("B");
+    // A pins a port; B pins its own. Neither has published a lockfile.
+    const projectA = makeProject("A", { configPort: 9911 });
+    const projectB = makeProject("B", { configPort: editorB.port });
+
+    const project = new ProjectContext();
+    const bridge = new EditorBridge();
+    project.setProject(projectA);
+    bridge.setConfigPort(project.config.bridge?.port);
+    bridge.setProjectContext(project.projectPath);
+    expect(bridge.port).toBe(9911);
+
+    try {
+      const result = await switchProject(project, bridge, projectB, { connectTimeoutMs: 1000 });
+
+      expect(result.target.port).toBe(editorB.port);
+      expect(result.connected).toBe(true);
+      expectPairAgrees(project, bridge, projectB);
+      await expect(bridge.call("ping", {}, 1000)).resolves.toEqual({ editor: "B" });
+    } finally {
+      bridge.disconnect();
+      await editorB.close();
+    }
+  });
+
+  it("completes the switch but blocks the connection when only an inherited pin names the port", async () => {
+    const editorA = await fakeEditor("A");
+    const projectA = makeProject("A");
+    const projectB = makeProject("B");
+
+    // A pin from the environment: chosen for whatever project the process
+    // started on, and no evidence at all about project B.
+    process.env.UE_MCP_PORT = String(editorA.port);
+    const project = new ProjectContext();
+    const bridge = new EditorBridge();
+    project.setProject(projectA);
+    bridge.setProjectContext(project.projectPath);
+
+    try {
+      await expect(bridge.call("ping", {}, 1000)).resolves.toEqual({ editor: "A" });
+
+      const result = await switchProject(project, bridge, projectB, { connectTimeoutMs: 300 });
+
+      expect(result.connected).toBe(false);
+      expect(result.connectError).toMatch(/Refusing to connect/);
+      expect(result.target.verified).toBe(false);
+      expectPairAgrees(project, bridge, projectB);
+
+      // The pinned port still has editor A listening on it. Nothing reaches it.
+      await expect(bridge.call("place_actor", {}, 300)).rejects.toThrow(/Refusing to connect/);
+      expect(editorA.received).toEqual(["ping"]);
+    } finally {
+      bridge.disconnect();
+      await editorA.close();
+    }
+  });
+});

--- a/tests/unit/project.test.ts
+++ b/tests/unit/project.test.ts
@@ -284,3 +284,28 @@ describe("ProjectContext config loading", () => {
     expect(ctx.config.nativeTools?.enabled).toBe(false);
   });
 });
+
+describe("ProjectContext plugin discovery across a switch", () => {
+  function makeProjectWithPlugin(pluginName: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-plugin-cache-"));
+    const uproject = path.join(dir, "Test.uproject");
+    // No EngineAssociation: keeps discoverPlugins off any real engine install.
+    fs.writeFileSync(uproject, JSON.stringify({ FileVersion: 3 }));
+    const pluginDir = path.join(dir, "Plugins", pluginName);
+    fs.mkdirSync(path.join(pluginDir, "Content"), { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, `${pluginName}.uplugin`), "{}");
+    return uproject;
+  }
+
+  it("rediscovers plugins after the loaded project changes", () => {
+    const ctx = new ProjectContext();
+    ctx.setProject(makeProjectWithPlugin("AlphaPlugin"));
+    expect(ctx.discoverPlugins().map((p) => p.name)).toEqual(["AlphaPlugin"]);
+
+    ctx.setProject(makeProjectWithPlugin("BetaPlugin"));
+    expect(ctx.discoverPlugins().map((p) => p.name)).toEqual(["BetaPlugin"]);
+    // The stale cache used to keep resolving the previous project's mounts.
+    expect(ctx.resolvePluginPath("/AlphaPlugin/Thing")).toBeNull();
+    expect(ctx.resolvePluginPath("/BetaPlugin/Thing")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #818.

`set_project` re-pointed path resolution at the new `.uproject` and then called `connect()`, which returns early on a live socket and otherwise reads the previous project's lockfile. Either way the connection stayed on the editor the caller had just switched away from: path-resolving actions read project B while every bridge action mutated project A, both halves reporting success.

## What changed

**`EditorBridge.retargetProject(uprojectPath, configPort?)`** (`src/bridge.ts`). Drops the socket before it returns, then re-decides the port from the new project alone: its lockfile, then its own `bridge.port`, then the port derived from its root path. A port pinned by `UE_MCP_PORT` or a constructor argument was chosen for a different project, so it survives only as a last resort and is marked unverified; `connect()` then refuses with an explanation instead of risking another project's editor. Two adjacent hazards are closed with it: a connect already in flight when the target moves no longer installs its socket, and a replaced socket's late `close` event no longer nulls out its successor.

**`switchProject()`** (`src/project-switch.ts`) is now the only supported way to move the pair. It validates the target first, so a bad path throws with both halves still on the current project. It then retargets the bridge and re-points the `ProjectContext` with no `await` between them, so the only window is synchronous and no handler can run inside it. Connecting comes last, and a failure leaves the pair consistent and simply offline with the reason returned rather than swallowed.

**`get_status`** reports `editorTarget` (project path, port, port source) and `editorTargetMismatch`, so a divergence can never again be invisible.

**`discoverPlugins()`** cached for the process lifetime, so after a switch `/MyPlugin/` paths still resolved into the previous project's directory. The cache is dropped when the loaded project changes.

## Tests

`tests/unit/project-switch.test.ts` and `tests/unit/bridge-retarget.test.ts` drive the real `ProjectContext` and `EditorBridge` against stand-in editors on loopback, so which editor answered is observed rather than asserted about a mock:

- a live connection moves off editor A and onto editor B, and A receives nothing afterwards
- switching to a project whose editor is not running leaves nothing reachable in the old editor
- a call in flight to the old editor fails instead of landing
- a bad target path throws and leaves both halves on the current project, still connected
- the new project's configured port wins over the previous project's
- an inherited `UE_MCP_PORT` pin completes the switch and blocks the connection, and is accepted again once the new project's editor publishes its lockfile

373 unit tests pass, `npx tsc --noEmit` clean, `npm run audit:docs` clean.

## Notes

TypeScript only, nothing under `plugin/`, so no C++ build is needed.

Port provenance is the strongest proof available without a plugin change. A native identity handshake (the editor stating which project it has open, without the Python escape hatch) would let a pinned port be verified instead of refused, and belongs with the session work in #817.

Scoped to #818 and rebased on `main` after #833 landed. No overlap with the lifecycle targeting work in #819.
