### PR TITLE
Bridge protocol layer: frame reassembly, socket ownership, thread lifetime, capability negotiation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,39 @@ The `EditorBridge` maintains a WebSocket connection to the bridge's per-project 
 - **Reconnect:** Automatic every 15 seconds if disconnected
 - **Thread safety:** All responses are correlated by request ID
 
+#### Framing
+
+A TCP read is a byte-stream event, not a message event, so the bridge treats it as one. Both ends accumulate bytes, decode as many whole WebSocket frames as have arrived, and join continuation frames into one message. Several pipelined requests in a single segment all arrive; a payload split across segments is reassembled rather than dropped.
+
+A single message is bounded at 64 MiB, as is the unparsed receive buffer. Exceeding either closes the connection with WebSocket status `1009` and a reason naming both the size and the limit, which the client repeats verbatim rather than reporting a generic lost connection. A frame stream that stops parsing (reserved bits set, an unknown opcode, a fragmented control frame) closes with `1002`.
+
+Control frames are answered as the protocol requires: a close frame gets its status code echoed back, a ping gets a pong carrying the same payload. When the editor shuts down with a client attached, the bridge closes with `1001` going away rather than severing the socket.
+
+The upgrade request is read through to its blank line under one deadline and one size bound, and is validated before a `101` is sent: `GET`, HTTP/1.1, `Upgrade: websocket`, `Connection: Upgrade`, `Sec-WebSocket-Version: 13`, and a `Sec-WebSocket-Key` that decodes to 16 bytes. A refusal answers with an HTTP status and a sentence. Anything the client pipelined behind the request is handed straight to the frame reader.
+
+#### Capability handshake
+
+On connect the client asks `get_bridge_capabilities`, which the bridge answers on the socket thread without touching the game thread. The reply reports:
+
+| Field | Meaning |
+|-------|---------|
+| `protocolVersion` | Wire protocol the plugin speaks (`UEMCP_BRIDGE_PROTOCOL_VERSION`) |
+| `handlerApiVersion` | Handler ABI for native plugins (`UEMCP_BRIDGE_API_VERSION`) |
+| `builtAt` | Compile timestamp of the loaded binary. The stale-build tell |
+| `engineVersion`, `projectName`, `pid`, `port`, `instanceId`, `startedAt` | Which editor answered |
+| `features` | Named capabilities, for asking about one thing rather than a version floor |
+| `actions`, `actionCount` | The method names the running binary actually registered |
+
+A plugin built before the handshake existed answers `Unknown method`, which the client records as protocol version 1. When the plugin and client versions differ, the client says so once at connect, repeats it on any unknown-method answer (naming both versions and the method), and reports it under `bridgeProtocol` in `project(get_status)`.
+
+`bridgeApiVersion` in `project(get_status)` is read from the header on disk and therefore describes the source; `bridgeProtocol` comes from the running binary. When the two disagree, the deployed plugin has not been rebuilt.
+
+#### Socket and thread ownership
+
+The accept loop creates a client socket and hands it to one connection thread, which owns it from that moment and closes it exactly once. No other code closes a client socket.
+
+Connections are counted by the accept loop before their thread exists and released by the thread on its way out, so shutdown waits for the count to reach zero before the module frees the server object. Connections notice the stop flag at the end of their current one-second select; only if that grace period lapses does shutdown half-close their sockets, and only after a further wait does it give up and log which connections are stuck. The game-thread executor abandons in-flight waits once shutdown begins, since module teardown runs on the game thread and a queued handler will never execute.
+
 ## C++ Bridge Plugin
 
 **Location:** `plugin/ue_mcp_bridge/`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,21 @@ Or per session, without editing the file: `UE_MCP_CONTEXT_STRATEGY=micro` (the e
 
 The C++ plugin listens on a **per-project WebSocket port** derived from a hash of the project root path (in the IANA ephemeral range `49152-65535`). Deriving the port from the path means two checkouts of the same project - or several unrelated projects - on one machine each get a stable, launch-order-independent port, so their MCP clients never collide on a single fixed number. The Node client and the C++ bridge compute the identical value independently, and the bridge also publishes the actual bound port to `<project>/Saved/UE_MCP_Bridge/port.json` as the authoritative source (if the port is already taken, the bridge probes upward and the lockfile records where it really landed). The legacy fixed port `9877` remains the fallback when no project root is known. Pin an explicit port with `UE_MCP_PORT` or `bridge.port` in `ue-mcp.yml`. The MCP server auto-connects on startup and reconnects every 15 seconds if the connection drops.
 
+On Windows the listening socket is claimed with `SO_EXCLUSIVEADDRUSE`, so a second editor of the same project cannot bind the same port. It walks upward instead and publishes where it landed, which is what lets two editors of one project coexist without their clients reaching the wrong one.
+
+### Bridge state files
+
+The bridge keeps two records under `<project>/Saved/UE_MCP_Bridge/`. Both are published by rename, so a client polling them never reads a half-written file.
+
+| File | Written when | Contents |
+|------|--------------|----------|
+| `port.json` | The bridge is listening | `port`, `pid`, `instanceId`, `startedAt`, `status`, `protocolVersion`, `handlerApiVersion` |
+| `bridge-error.json` | The editor came up but the bridge could not bind | `status: "bind-failed"`, the port range tried, the socket error, `pid`, `instanceId` |
+
+`instanceId` identifies the server object that wrote the record, and only that instance removes it. A pid alone is not enough, since pids are recycled. Clients skip a record whose process is gone, so an editor that crashed does not send the next session at a port nobody is listening on.
+
+`bridge-error.json` is what distinguishes "no editor" from "editor running, bridge dead". When a connection fails and this record names a live process, the client quotes its detail in the error.
+
 ### Connection States
 
 | State | Meaning |
@@ -155,6 +170,10 @@ The C++ plugin listens on a **per-project WebSocket port** derived from a hash o
 | **Connected** | Bridge is active, all tools available |
 | **Disconnected** | Editor not running or plugin not loaded. Filesystem tools still work (INI parsing, C++ headers, asset listing) |
 | **Reconnecting** | Connection lost, auto-retry in progress |
+
+### Who may connect
+
+The bridge binds loopback only and refuses every upgrade that carries an `Origin` header. Browsers always send one on a WebSocket upgrade and cannot suppress or forge it, so this keeps out any page served by a local dev server, which would otherwise be able to scan the port range and call `execute_python`. Native clients (the npm client, curl, editor tooling) omit the header and are unaffected.
 
 Check the current state with `project(action="get_status")`.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,6 +26,10 @@
         lsof -i :9877
         ```
 
+5. **The editor is up but the bridge is not.** If the bridge could not bind any port, it writes `<project>/Saved/UE_MCP_Bridge/bridge-error.json` with the range it tried and the socket error, and the client quotes that detail in the connection error rather than reporting no editor. Read the file directly if you are looking without the client.
+
+6. **A stale record.** `<project>/Saved/UE_MCP_Bridge/port.json` names the pid that wrote it. A record left by an editor that crashed is skipped rather than followed, so a connection failure after a crash points at the derived port, not the dead one.
+
 ### Handlers time out, or the editor never finishes starting
 
 **Symptoms:** every call returns `Handler execution timed out`, `start_editor` waits out its timeout, or `get_status` says `disconnected` while an editor is plainly open.
@@ -87,6 +91,14 @@ Nothing is wrong on the ue-mcp side and there is nothing to fix in your setup: o
 The MCP server auto-reconnects every 15 seconds. If the editor is restarted, the connection will restore automatically.
 
 If the connection is flapping (connecting then immediately disconnecting), check the editor's Output Log for errors in the `LogMCPBridge` category.
+
+The bridge closes with a WebSocket status code and a reason, and the client repeats both. The ones worth recognising:
+
+| Code | Meaning |
+|------|---------|
+| `1001` | The editor is shutting down |
+| `1002` | The frame stream stopped parsing. The reason names what was wrong |
+| `1009` | A message exceeded the 64 MiB bound. The reason names the size and the limit |
 
 ## Plugin Build Issues
 
@@ -177,6 +189,8 @@ Fix: rebuild the plugin, then restart the editor so the new binary loads.
 ```bash
 ue-mcp update --build
 ```
+
+To confirm which binary is actually loaded, read `bridgeProtocol` from `project(action="get_status")`. `builtAt` there is the compile timestamp of the running plugin, and `plugin` versus `client` are the two protocol versions. When they differ, the client also says so in the error on any action the running plugin does not have. `bridgeApiVersion` in the same response is read from the header on disk and describes the source, so the two disagreeing is itself the signal that the deployed plugin has not been rebuilt.
 
 If `--build` reports success but the behavior still persists, force a clean rebuild (incremental builds and Live Coding can load stale patches over a fresh build):
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -69,6 +69,16 @@
 #pragma comment(lib, "advapi32.lib")
 #endif
 
+namespace
+{
+	// #821: a JSON-RPC message can span many TCP reads and many WebSocket
+	// frames, so the reader accumulates. These are the bounds on how much it
+	// will hold for one connection before it refuses and says why, instead of
+	// growing without limit on a corrupt or hostile length field.
+	constexpr int64 kMaxWebSocketMessageBytes = 64ll * 1024ll * 1024ll; // 64 MiB
+	constexpr int32 kRecvChunkBytes = 65536;
+}
+
 FMCPBridgeServer::FMCPBridgeServer(int32 Port)
 	: ServerPort(Port)
 	, ServerThread(nullptr)
@@ -608,11 +618,7 @@ FString FMCPBridgeServer::ProcessMessage(const FString& Message)
 	}
 }
 
-#if PLATFORM_WINDOWS
-void FMCPBridgeServer::HandleWebSocketConnection(SOCKET ClientSocketFD)
-#else
-void FMCPBridgeServer::HandleWebSocketConnection(int32 ClientSocketFD)
-#endif
+void FMCPBridgeServer::HandleWebSocketConnection(FMCPSocketHandle ClientSocketFD)
 {
 	// Set TCP_NODELAY on client socket for immediate send
 	int32 NoDelay = 1;
@@ -675,11 +681,7 @@ void FMCPBridgeServer::HandleWebSocketConnection(int32 ClientSocketFD)
 #endif
 }
 
-#if PLATFORM_WINDOWS
-FString FMCPBridgeServer::PerformWebSocketHandshake(SOCKET ClientSocketFD)
-#else
-FString FMCPBridgeServer::PerformWebSocketHandshake(int32 ClientSocketFD)
-#endif
+FString FMCPBridgeServer::PerformWebSocketHandshake(FMCPSocketHandle ClientSocketFD)
 {
 	FString Request = ReadHttpRequest(ClientSocketFD);
 	if (Request.IsEmpty())
@@ -768,11 +770,7 @@ FString FMCPBridgeServer::PerformWebSocketHandshake(int32 ClientSocketFD)
 	return Response;
 }
 
-#if PLATFORM_WINDOWS
-FString FMCPBridgeServer::ReadHttpRequest(SOCKET SocketFD)
-#else
-FString FMCPBridgeServer::ReadHttpRequest(int32 SocketFD)
-#endif
+FString FMCPBridgeServer::ReadHttpRequest(FMCPSocketHandle SocketFD)
 {
 	// Read HTTP request headers (until \r\n\r\n)
 	FString Request;
@@ -848,55 +846,163 @@ FString FMCPBridgeServer::CreateWebSocketAcceptKey(const FString& ClientKey)
 	return AcceptKey;
 }
 
-#if PLATFORM_WINDOWS
-void FMCPBridgeServer::ProcessWebSocketMessages(SOCKET ClientSocketFD)
-#else
-void FMCPBridgeServer::ProcessWebSocketMessages(int32 ClientSocketFD)
-#endif
+void FMCPBridgeServer::ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD)
 {
-	constexpr int32 RecvBufferSize = 65536;
-	TArray<uint8> Buffer;
-	Buffer.SetNumUninitialized(RecvBufferSize);
+	TArray<uint8> Chunk;
+	Chunk.SetNumUninitialized(kRecvChunkBytes);
+
+	// Everything received and not yet consumed by the decoder. A TCP read is a
+	// byte-stream event, not a message event: one read can carry half a frame,
+	// three frames, or two frames and half of a fourth. This buffer is what
+	// makes those all mean the same thing.
+	TArray<uint8> PendingBytes;
+
+	// Reassembly state for a fragmented message (a data frame with FIN clear
+	// followed by continuation frames).
+	TArray<uint8> MessagePayload;
+	bool bAssembling = false;
 
 	while (!bShouldStop)
 	{
-		fd_set ReadSet;
-		FD_ZERO(&ReadSet);
-		FD_SET(ClientSocketFD, &ReadSet);
-		
-		timeval Timeout;
-		Timeout.tv_sec = 1;
-		Timeout.tv_usec = 0;
-		
-		int32 SelectResult = select(ClientSocketFD + 1, &ReadSet, nullptr, nullptr, &Timeout);
-		
-		if (SelectResult > 0 && FD_ISSET(ClientSocketFD, &ReadSet))
+		// Decode before reading. Bytes left over from the previous read may
+		// already hold a whole request, and waiting on select first would stall
+		// it until the peer happened to send something else.
+		bool bDone = false;
+		for (;;)
 		{
-			int32 BytesReceived = recv(ClientSocketFD, (char*)Buffer.GetData(), RecvBufferSize, 0);
-			if (BytesReceived <= 0)
+			FMCPWebSocketFrame Frame;
+			FString DecodeError;
+			const EMCPFrameDecode Status = DecodeWebSocketFrame(PendingBytes, Frame, DecodeError);
+
+			if (Status == EMCPFrameDecode::NeedMoreData)
 			{
 				break;
 			}
-
-			TArray<uint8> FrameData(Buffer.GetData(), BytesReceived);
-			FString Message = ParseWebSocketFrame(FrameData);
-			
-			if (!Message.IsEmpty())
+			if (Status == EMCPFrameDecode::ProtocolError)
 			{
-				FString Response = ProcessMessage(Message);
-				TArray<uint8> ResponseFrame = CreateWebSocketFrame(Response);
-				int32 TotalToSend = ResponseFrame.Num();
-				int32 Sent = 0;
-				while (Sent < TotalToSend)
+				UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] WebSocket protocol error, closing connection: %s"), *DecodeError);
+				SendCloseFrame(ClientSocketFD, 1002, DecodeError);
+				bDone = true;
+				break;
+			}
+
+			if (Frame.Opcode == EMCPWebSocketOpcode::Close)
+			{
+				bDone = true;
+				break;
+			}
+			if (Frame.Opcode == EMCPWebSocketOpcode::Ping || Frame.Opcode == EMCPWebSocketOpcode::Pong)
+			{
+				continue;
+			}
+
+			if (Frame.Opcode == EMCPWebSocketOpcode::Continuation)
+			{
+				if (!bAssembling)
 				{
-					int32 BytesSent = send(ClientSocketFD, (char*)ResponseFrame.GetData() + Sent, TotalToSend - Sent, 0);
-					if (BytesSent <= 0) break;
-					Sent += BytesSent;
+					UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Continuation frame with no message in progress"));
+					SendCloseFrame(ClientSocketFD, 1002, TEXT("continuation frame with no message in progress"));
+					bDone = true;
+					break;
 				}
+				MessagePayload.Append(Frame.Payload);
+			}
+			else
+			{
+				if (bAssembling)
+				{
+					UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] New data frame while a fragmented message was still open"));
+					SendCloseFrame(ClientSocketFD, 1002, TEXT("data frame interleaved with an open fragmented message"));
+					bDone = true;
+					break;
+				}
+				MessagePayload = MoveTemp(Frame.Payload);
+				bAssembling = true;
+			}
+
+			if ((int64)MessagePayload.Num() > kMaxWebSocketMessageBytes)
+			{
+				// Say the number rather than dying quietly: a caller that sends
+				// a genuinely enormous payload needs to know it hit a limit and
+				// what the limit is, not watch the socket disappear.
+				const FString Reason = FString::Printf(
+					TEXT("message of %lld bytes exceeds the %lld byte bridge limit"),
+					(int64)MessagePayload.Num(), kMaxWebSocketMessageBytes);
+				UE_LOG(LogMCPBridge, Error, TEXT("[UE-MCP] %s"), *Reason);
+				SendCloseFrame(ClientSocketFD, 1009, Reason);
+				bDone = true;
+				break;
+			}
+
+			if (!Frame.bFinal)
+			{
+				continue; // more fragments still to come
+			}
+
+			bAssembling = false;
+			FString Message;
+			if (MessagePayload.Num() > 0)
+			{
+				FUTF8ToTCHAR Converted((const char*)MessagePayload.GetData(), MessagePayload.Num());
+				Message = FString(Converted.Length(), Converted.Get());
+			}
+			MessagePayload.Reset();
+
+			if (Message.IsEmpty())
+			{
+				continue;
+			}
+
+			const FString Response = ProcessMessage(Message);
+			const TArray<uint8> ResponseFrame = CreateWebSocketFrame(Response);
+			if (!SendAll(ClientSocketFD, ResponseFrame.GetData(), ResponseFrame.Num()))
+			{
+				UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Failed to send response frame; closing connection"));
+				bDone = true;
+				break;
 			}
 		}
-		else if (SelectResult < 0)
+
+		if (bDone)
 		{
+			break;
+		}
+
+		fd_set ReadSet;
+		FD_ZERO(&ReadSet);
+		FD_SET(ClientSocketFD, &ReadSet);
+
+		timeval Timeout;
+		Timeout.tv_sec = 1;
+		Timeout.tv_usec = 0;
+
+		const int32 SelectResult = select(ClientSocketFD + 1, &ReadSet, nullptr, nullptr, &Timeout);
+		if (SelectResult < 0)
+		{
+			break;
+		}
+		if (SelectResult == 0 || !FD_ISSET(ClientSocketFD, &ReadSet))
+		{
+			continue;
+		}
+
+		const int32 BytesReceived = recv(ClientSocketFD, (char*)Chunk.GetData(), kRecvChunkBytes, 0);
+		if (BytesReceived <= 0)
+		{
+			break;
+		}
+		PendingBytes.Append(Chunk.GetData(), BytesReceived);
+
+		// A peer that keeps sending without ever completing a frame would grow
+		// this buffer without limit. Bound it by the same number a single
+		// message is bounded by.
+		if ((int64)PendingBytes.Num() > kMaxWebSocketMessageBytes)
+		{
+			const FString Reason = FString::Printf(
+				TEXT("unparsed receive buffer of %lld bytes exceeds the %lld byte bridge limit"),
+				(int64)PendingBytes.Num(), kMaxWebSocketMessageBytes);
+			UE_LOG(LogMCPBridge, Error, TEXT("[UE-MCP] %s"), *Reason);
+			SendCloseFrame(ClientSocketFD, 1009, Reason);
 			break;
 		}
 	}
@@ -945,71 +1051,165 @@ TArray<uint8> FMCPBridgeServer::CreateWebSocketFrame(const FString& Message)
 	return Frame;
 }
 
-FString FMCPBridgeServer::ParseWebSocketFrame(const TArray<uint8>& Data)
+EMCPFrameDecode FMCPBridgeServer::DecodeWebSocketFrame(TArray<uint8>& Buffer, FMCPWebSocketFrame& OutFrame, FString& OutError)
 {
-	if (Data.Num() < 2)
+	const int64 Available = (int64)Buffer.Num();
+	if (Available < 2)
 	{
-		return TEXT("");
+		return EMCPFrameDecode::NeedMoreData;
 	}
 
-	uint8 FirstByte = Data[0];
-	uint8 SecondByte = Data[1];
+	const uint8 FirstByte = Buffer[0];
+	const uint8 SecondByte = Buffer[1];
 
-	bool bMasked = (SecondByte & 0x80) != 0;
-	int32 PayloadLen = SecondByte & 0x7F;
+	// RSV1-3 only carry meaning once an extension has been negotiated, and the
+	// bridge negotiates none. A set bit means the peer is framing to rules we
+	// never agreed to, so no boundary in the stream can be trusted.
+	if ((FirstByte & 0x70) != 0)
+	{
+		OutError = TEXT("reserved frame bits set with no negotiated extension");
+		return EMCPFrameDecode::ProtocolError;
+	}
 
-	int32 HeaderLen = 2;
+	OutFrame.bFinal = (FirstByte & 0x80) != 0;
+
+	const uint8 RawOpcode = FirstByte & 0x0F;
+	switch (RawOpcode)
+	{
+	case 0x0: OutFrame.Opcode = EMCPWebSocketOpcode::Continuation; break;
+	case 0x1: OutFrame.Opcode = EMCPWebSocketOpcode::Text; break;
+	case 0x2: OutFrame.Opcode = EMCPWebSocketOpcode::Binary; break;
+	case 0x8: OutFrame.Opcode = EMCPWebSocketOpcode::Close; break;
+	case 0x9: OutFrame.Opcode = EMCPWebSocketOpcode::Ping; break;
+	case 0xA: OutFrame.Opcode = EMCPWebSocketOpcode::Pong; break;
+	default:
+		OutError = FString::Printf(TEXT("unsupported WebSocket opcode 0x%X"), (int32)RawOpcode);
+		return EMCPFrameDecode::ProtocolError;
+	}
+
+	const bool bMasked = (SecondByte & 0x80) != 0;
+	uint64 PayloadLen = (uint64)(SecondByte & 0x7F);
+	int64 HeaderLen = 2;
+
 	if (PayloadLen == 126)
 	{
-		if (Data.Num() < 4)
+		if (Available < 4)
 		{
-			return TEXT("");
+			return EMCPFrameDecode::NeedMoreData;
 		}
-		PayloadLen = (Data[2] << 8) | Data[3];
+		PayloadLen = ((uint64)Buffer[2] << 8) | (uint64)Buffer[3];
 		HeaderLen = 4;
 	}
 	else if (PayloadLen == 127)
 	{
-		if (Data.Num() < 10)
+		if (Available < 10)
 		{
-			return TEXT("");
+			return EMCPFrameDecode::NeedMoreData;
 		}
+		// Accumulate in 64 bits. Folding an 8-byte length into a 32-bit
+		// accumulator is what turns a large or hostile length into a negative
+		// count and a read that walks off the end of the buffer.
 		PayloadLen = 0;
 		for (int32 i = 0; i < 8; ++i)
 		{
-			PayloadLen = (PayloadLen << 8) | Data[2 + i];
+			PayloadLen = (PayloadLen << 8) | (uint64)Buffer[2 + i];
+		}
+		if ((PayloadLen & 0x8000000000000000ull) != 0)
+		{
+			OutError = TEXT("64-bit payload length has its high bit set");
+			return EMCPFrameDecode::ProtocolError;
 		}
 		HeaderLen = 10;
 	}
 
-	if (bMasked)
+	const bool bIsControl = (RawOpcode & 0x08) != 0;
+	if (bIsControl)
 	{
-		HeaderLen += 4; // Masking key
-	}
-
-	if (Data.Num() < HeaderLen + PayloadLen)
-	{
-		return TEXT("");
-	}
-
-	TArray<uint8> Payload;
-	Payload.Append(Data.GetData() + HeaderLen, PayloadLen);
-
-	if (bMasked)
-	{
-		// Unmask payload
-		uint8 MaskKey[4];
-		MaskKey[0] = Data[HeaderLen - 4];
-		MaskKey[1] = Data[HeaderLen - 3];
-		MaskKey[2] = Data[HeaderLen - 2];
-		MaskKey[3] = Data[HeaderLen - 1];
-		
-		for (int32 i = 0; i < Payload.Num(); ++i)
+		// Control frames carry at most 125 bytes and are never fragmented.
+		if (PayloadLen > 125)
 		{
-			Payload[i] ^= MaskKey[i % 4];
+			OutError = FString::Printf(TEXT("control frame payload of %llu bytes exceeds 125"), PayloadLen);
+			return EMCPFrameDecode::ProtocolError;
+		}
+		if (!OutFrame.bFinal)
+		{
+			OutError = TEXT("fragmented control frame");
+			return EMCPFrameDecode::ProtocolError;
 		}
 	}
 
-	FUTF8ToTCHAR UTF8ToTCHAR((char*)Payload.GetData(), Payload.Num());
-	return FString(UTF8ToTCHAR.Length(), UTF8ToTCHAR.Get());
+	if (PayloadLen > (uint64)kMaxWebSocketMessageBytes)
+	{
+		OutError = FString::Printf(
+			TEXT("frame payload of %llu bytes exceeds the %lld byte bridge limit"),
+			PayloadLen, kMaxWebSocketMessageBytes);
+		return EMCPFrameDecode::ProtocolError;
+	}
+
+	if (bMasked)
+	{
+		HeaderLen += 4; // masking key
+	}
+
+	const int64 TotalLen = HeaderLen + (int64)PayloadLen;
+	if (Available < TotalLen)
+	{
+		// The rest of this frame is still in flight. Leave every byte in place
+		// and let the caller read again.
+		return EMCPFrameDecode::NeedMoreData;
+	}
+
+	OutFrame.Payload.Reset();
+	OutFrame.Payload.Append(Buffer.GetData() + HeaderLen, (int32)PayloadLen);
+
+	if (bMasked)
+	{
+		const uint8* MaskKey = Buffer.GetData() + HeaderLen - 4;
+		for (int32 i = 0; i < OutFrame.Payload.Num(); ++i)
+		{
+			OutFrame.Payload[i] ^= MaskKey[i % 4];
+		}
+	}
+
+	Buffer.RemoveAt(0, (int32)TotalLen);
+	return EMCPFrameDecode::Decoded;
+}
+
+TArray<uint8> FMCPBridgeServer::CreateControlFrame(EMCPWebSocketOpcode Opcode, const TArray<uint8>& Payload)
+{
+	TArray<uint8> Frame;
+	Frame.Add((uint8)(0x80 | (uint8)Opcode)); // FIN + opcode
+	const int32 Len = FMath::Min(Payload.Num(), 125);
+	Frame.Add((uint8)Len);
+	Frame.Append(Payload.GetData(), Len);
+	return Frame;
+}
+
+void FMCPBridgeServer::SendCloseFrame(FMCPSocketHandle SocketFD, uint16 StatusCode, const FString& Reason)
+{
+	TArray<uint8> Payload;
+	Payload.Add((uint8)((StatusCode >> 8) & 0xFF));
+	Payload.Add((uint8)(StatusCode & 0xFF));
+
+	FTCHARToUTF8 Utf8Reason(*Reason);
+	const int32 ReasonLen = FMath::Min(Utf8Reason.Length(), 123);
+	Payload.Append((const uint8*)Utf8Reason.Get(), ReasonLen);
+
+	const TArray<uint8> Frame = CreateControlFrame(EMCPWebSocketOpcode::Close, Payload);
+	SendAll(SocketFD, Frame.GetData(), Frame.Num());
+}
+
+bool FMCPBridgeServer::SendAll(FMCPSocketHandle SocketFD, const uint8* Data, int32 NumBytes)
+{
+	int32 Sent = 0;
+	while (Sent < NumBytes)
+	{
+		const int32 BytesSent = send(SocketFD, (const char*)Data + Sent, NumBytes - Sent, 0);
+		if (BytesSent <= 0)
+		{
+			return false;
+		}
+		Sent += BytesSent;
+	}
+	return true;
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -1,6 +1,7 @@
 #include "BridgeServer.h"
 #include "UE_MCP_BridgeModule.h"
 #include "MCPEngineStatus.h"
+#include "MCPHandlerRegistration.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
 #include "Serialization/JsonSerializer.h"
@@ -109,6 +110,8 @@ FMCPBridgeServer::FMCPBridgeServer(int32 Port)
 	, ServerThread(nullptr)
 	, bShouldStop(false)
 	, bIsRunning(false)
+	, InstanceId(FGuid::NewGuid())
+	, StartedAtUtc(FDateTime::UtcNow())
 {
 	// Register core handlers
 	FEditorHandlers::RegisterHandlers(HandlerRegistry);
@@ -351,6 +354,10 @@ uint32 FMCPBridgeServer::Run()
 		UE_LOG(LogMCPBridge, Error, TEXT("[UE-MCP] Failed to bind to any port in [%d, %d]"), RequestedPort, RequestedPort + kMaxPortProbe);
 		close(ServerSocketFD);
 #endif
+		// #821: "editor alive, bridge dead" used to leave nothing on disk, so
+		// the client could only report that it found no editor. Say what
+		// actually happened, in a file that is not the live editor's record.
+		WriteBindFailureRecord(RequestedPort, RequestedPort + kMaxPortProbe, ErrorCode);
 		return 1;
 	}
 
@@ -367,6 +374,7 @@ uint32 FMCPBridgeServer::Run()
 		UE_LOG(LogMCPBridge, Error, TEXT("[UE-MCP] Failed to listen on socket"));
 		close(ServerSocketFD);
 #endif
+		WriteBindFailureRecord(BoundPort, BoundPort, ErrorCode);
 		return 1;
 	}
 
@@ -447,7 +455,11 @@ void FMCPBridgeServer::Exit()
 	// #492: remove the lockfile on graceful shutdown so the next editor boot
 	// doesn't see a stale entry. A hard-crash leaves the file, but the next
 	// startup overwrites it with the live PID.
-	DeletePortLockfile();
+	//
+	// #821: only if this instance wrote it. Exit() runs on every return from
+	// Run(), the bind-failure path included, so an unconditional delete here
+	// let an editor that never listened remove a running editor's record.
+	DeletePortLockfileIfOwned();
 }
 
 // #492: per-project port lockfile. Multiple editors can run side-by-side as
@@ -460,33 +472,135 @@ FString FMCPBridgeServer::GetPortLockfilePath()
 	return FPaths::Combine(Dir, TEXT("port.json"));
 }
 
+FString FMCPBridgeServer::GetBridgeErrorFilePath()
+{
+	const FString Dir = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("UE_MCP_Bridge"));
+	return FPaths::Combine(Dir, TEXT("bridge-error.json"));
+}
+
+namespace
+{
+	/**
+	 * Publish JSON by writing a temporary file and renaming it over the target.
+	 *
+	 * The client polls these files every couple of seconds while it waits for
+	 * an editor. Writing in place means a poll can land mid-write, read a torn
+	 * document, fail to parse it and silently fall back to a guessed port. A
+	 * rename is the one step a reader cannot catch halfway through.
+	 */
+	bool PublishJsonAtomically(const FString& FilePath, const TSharedPtr<FJsonObject>& Payload)
+	{
+		IFileManager::Get().MakeDirectory(*FPaths::GetPath(FilePath), /*Tree*/ true);
+
+		FString Serialized;
+		TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Serialized);
+		FJsonSerializer::Serialize(Payload.ToSharedRef(), Writer);
+
+		const FString TempPath = FString::Printf(TEXT("%s.%u.tmp"), *FilePath, FPlatformProcess::GetCurrentProcessId());
+		if (!FFileHelper::SaveStringToFile(Serialized, *TempPath))
+		{
+			return false;
+		}
+		if (!IFileManager::Get().Move(*FilePath, *TempPath, /*Replace*/ true))
+		{
+			IFileManager::Get().Delete(*TempPath);
+			return false;
+		}
+		return true;
+	}
+
+	/** Read the instanceId out of a record, or empty when there is not one. */
+	FString ReadRecordInstanceId(const FString& FilePath)
+	{
+		FString Raw;
+		if (!FFileHelper::LoadFileToString(Raw, *FilePath))
+		{
+			return FString();
+		}
+		TSharedPtr<FJsonObject> Parsed;
+		TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Raw);
+		if (!FJsonSerializer::Deserialize(Reader, Parsed) || !Parsed.IsValid())
+		{
+			return FString();
+		}
+		FString Value;
+		Parsed->TryGetStringField(TEXT("instanceId"), Value);
+		return Value;
+	}
+}
+
 void FMCPBridgeServer::WritePortLockfile(int32 PortValue)
 {
 	const FString FilePath = GetPortLockfilePath();
-	IFileManager::Get().MakeDirectory(*FPaths::GetPath(FilePath), /*Tree*/ true);
 
 	TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
 	Obj->SetNumberField(TEXT("port"), PortValue);
 	Obj->SetNumberField(TEXT("pid"), (double)FPlatformProcess::GetCurrentProcessId());
-	Obj->SetStringField(TEXT("startedAt"), FDateTime::UtcNow().ToIso8601());
-	Obj->SetNumberField(TEXT("apiVersion"), 1.0);
+	Obj->SetStringField(TEXT("startedAt"), StartedAtUtc.ToIso8601());
+	// Who wrote this. A pid is not identity: pids are recycled, and two
+	// instances of one project would otherwise be indistinguishable on disk.
+	Obj->SetStringField(TEXT("instanceId"), InstanceId.ToString(EGuidFormats::DigitsWithHyphens));
+	Obj->SetStringField(TEXT("status"), TEXT("listening"));
+	Obj->SetNumberField(TEXT("handlerApiVersion"), (double)UEMCP_BRIDGE_API_VERSION);
 
-	FString Serialized;
-	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Serialized);
-	FJsonSerializer::Serialize(Obj.ToSharedRef(), Writer);
-
-	if (!FFileHelper::SaveStringToFile(Serialized, *FilePath))
+	if (!PublishJsonAtomically(FilePath, Obj))
 	{
 		UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Failed to write port lockfile: %s"), *FilePath);
 		return;
 	}
-	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Port lockfile published: %s (port=%d)"), *FilePath, PortValue);
+
+	// A previous failed start may have left a bind-failure record. This
+	// instance is listening, so that record no longer describes reality.
+	IFileManager::Get().Delete(*GetBridgeErrorFilePath(), /*RequireExists*/ false, /*EvenReadOnly*/ false, /*Quiet*/ true);
+
+	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Port lockfile published: %s (port=%d, instance=%s)"),
+		*FilePath, PortValue, *InstanceId.ToString(EGuidFormats::DigitsWithHyphens));
 }
 
-void FMCPBridgeServer::DeletePortLockfile()
+void FMCPBridgeServer::WriteBindFailureRecord(int32 FirstPort, int32 LastPort, int32 ErrorCode)
+{
+	// Its own path, never port.json: a failed start must not be able to erase
+	// or overwrite the record of an editor that is running perfectly well.
+	const FString FilePath = GetBridgeErrorFilePath();
+
+	TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+	Obj->SetStringField(TEXT("status"), TEXT("bind-failed"));
+	Obj->SetNumberField(TEXT("pid"), (double)FPlatformProcess::GetCurrentProcessId());
+	Obj->SetStringField(TEXT("startedAt"), StartedAtUtc.ToIso8601());
+	Obj->SetStringField(TEXT("failedAt"), FDateTime::UtcNow().ToIso8601());
+	Obj->SetStringField(TEXT("instanceId"), InstanceId.ToString(EGuidFormats::DigitsWithHyphens));
+	Obj->SetNumberField(TEXT("firstPortTried"), FirstPort);
+	Obj->SetNumberField(TEXT("lastPortTried"), LastPort);
+	Obj->SetNumberField(TEXT("errorCode"), ErrorCode);
+	Obj->SetStringField(TEXT("detail"), FString::Printf(
+		TEXT("The editor is running but its MCP bridge could not bind a port in [%d, %d]."), FirstPort, LastPort));
+
+	if (!PublishJsonAtomically(FilePath, Obj))
+	{
+		UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Failed to write bridge error record: %s"), *FilePath);
+	}
+}
+
+void FMCPBridgeServer::DeletePortLockfileIfOwned()
 {
 	const FString FilePath = GetPortLockfilePath();
-	if (!FPaths::FileExists(FilePath)) return;
+	if (!FPaths::FileExists(FilePath))
+	{
+		return;
+	}
+
+	// Only take away a record this instance wrote. Exit() runs on every return
+	// from Run(), including the one where the bind failed, so an editor that
+	// never listened used to delete a live editor's record on its way out.
+	const FString OwnerId = ReadRecordInstanceId(FilePath);
+	const FString OurId = InstanceId.ToString(EGuidFormats::DigitsWithHyphens);
+	if (OwnerId != OurId)
+	{
+		UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Leaving port lockfile alone: it belongs to instance %s, not %s"),
+			OwnerId.IsEmpty() ? TEXT("(unknown)") : *OwnerId, *OurId);
+		return;
+	}
+
 	if (IFileManager::Get().Delete(*FilePath))
 	{
 		UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Port lockfile removed: %s"), *FilePath);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -16,6 +16,7 @@
 #include "Misc/CommandLine.h"
 #include "Misc/Parse.h"
 #include "Misc/SecureHash.h"
+#include "Misc/ScopeLock.h"
 #include "Async/Async.h"
 #include "Handlers/EditorHandlers.h"
 #include "Handlers/AssetHandlers.h"
@@ -84,6 +85,23 @@ namespace
 	// the headers may grow before the bridge stops waiting for a blank line.
 	constexpr double kUpgradeReadTimeoutSeconds = 5.0;
 	constexpr int32 kMaxUpgradeHeaderBytes = 16 * 1024;
+
+	// How long shutdown lets connection threads notice the stop flag and close
+	// politely (their select is one second), and how long it then waits after
+	// half-closing their sockets before giving up and saying so.
+	constexpr double kConnectionCloseGraceSeconds = 2.0;
+	constexpr double kConnectionDrainTimeoutSeconds = 10.0;
+}
+
+FMCPConnectionRelease::FMCPConnectionRelease(FMCPBridgeServer& InServer, FMCPSocketHandle InHandle)
+	: Server(InServer)
+	, Handle(InHandle)
+{
+}
+
+FMCPConnectionRelease::~FMCPConnectionRelease()
+{
+	Server.UnregisterConnection(Handle);
 }
 
 FMCPBridgeServer::FMCPBridgeServer(int32 Port)
@@ -91,7 +109,6 @@ FMCPBridgeServer::FMCPBridgeServer(int32 Port)
 	, ServerThread(nullptr)
 	, bShouldStop(false)
 	, bIsRunning(false)
-	, ServerSocket(nullptr)
 {
 	// Register core handlers
 	FEditorHandlers::RegisterHandlers(HandlerRegistry);
@@ -143,12 +160,16 @@ bool FMCPBridgeServer::Start()
 
 void FMCPBridgeServer::Shutdown()
 {
-	if (!bIsRunning)
-	{
-		return;
-	}
-
+	// No early return on bIsRunning. Exit() clears that flag, and on the
+	// bind-failure path Exit() runs before Shutdown() does, so guarding on it
+	// meant the server thread was never joined in exactly the case where the
+	// thread had already failed and nobody was watching.
 	bShouldStop = true;
+
+	// Let anything waiting on the game thread give up now. Module teardown is
+	// running on the game thread, so a queued handler will never execute and
+	// its caller would otherwise sit here for the full handler timeout.
+	GameThreadExecutor.BeginShutdown();
 
 	if (ServerThread)
 	{
@@ -157,7 +178,72 @@ void FMCPBridgeServer::Shutdown()
 		ServerThread = nullptr;
 	}
 
+	// The accept loop is gone, but each connection thread captured `this` and
+	// the module destroys this object as soon as Shutdown returns. A thread
+	// still inside ProcessMessage at that point is running on freed memory:
+	// that is the stop_editor-with-a-client-attached crash.
+	//
+	// Connection loops see bShouldStop at the end of their current one-second
+	// select and close cleanly. Give them that long before being blunt about it.
+	if (!WaitForConnectionsToFinish(kConnectionCloseGraceSeconds))
+	{
+		WakeAllConnections();
+		if (!WaitForConnectionsToFinish(kConnectionDrainTimeoutSeconds))
+		{
+			UE_LOG(LogMCPBridge, Error,
+				TEXT("[UE-MCP] %d bridge connection(s) still running after %.0fs. Continuing shutdown; a handler is not returning."),
+				ActiveConnectionCount.GetValue(), kConnectionCloseGraceSeconds + kConnectionDrainTimeoutSeconds);
+		}
+	}
+
 	bIsRunning = false;
+}
+
+void FMCPBridgeServer::RegisterConnection(FMCPSocketHandle Handle)
+{
+	ActiveConnectionCount.Increment();
+	FScopeLock Lock(&ConnectionsMutex);
+	LiveConnections.Add(Handle);
+}
+
+void FMCPBridgeServer::UnregisterConnection(FMCPSocketHandle Handle)
+{
+	{
+		// Out of the set before the socket is closed, under the same lock
+		// WakeAllConnections holds. Otherwise shutdown could half-close a
+		// handle number the operating system had already handed to someone else.
+		FScopeLock Lock(&ConnectionsMutex);
+		LiveConnections.Remove(Handle);
+	}
+	// The last thing a connection thread touches on this object.
+	ActiveConnectionCount.Decrement();
+}
+
+void FMCPBridgeServer::WakeAllConnections()
+{
+	FScopeLock Lock(&ConnectionsMutex);
+	for (const FMCPSocketHandle Handle : LiveConnections)
+	{
+#if PLATFORM_WINDOWS
+		shutdown(Handle, SD_BOTH);
+#else
+		shutdown(Handle, SHUT_RDWR);
+#endif
+	}
+}
+
+bool FMCPBridgeServer::WaitForConnectionsToFinish(double TimeoutSeconds)
+{
+	const double Deadline = FPlatformTime::Seconds() + TimeoutSeconds;
+	while (ActiveConnectionCount.GetValue() > 0)
+	{
+		if (FPlatformTime::Seconds() >= Deadline)
+		{
+			return false;
+		}
+		FPlatformProcess::Sleep(0.01f);
+	}
+	return true;
 }
 
 bool FMCPBridgeServer::Init()
@@ -309,7 +395,11 @@ uint32 FMCPBridgeServer::Run()
 			UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Client connected from %s:%d"),
 				ANSI_TO_TCHAR(AddrStr), ntohs(ClientAddr.sin_port));
 				
-				// Handle each WebSocket connection in its own thread
+				// Handle each WebSocket connection in its own thread. Count it
+				// here, before the thread exists, so a shutdown racing this
+				// accept cannot decide that nothing is running and let the
+				// module free the server out from under the new thread.
+				RegisterConnection(ClientSocketFD);
 				Async(EAsyncExecution::Thread, [this, ClientSocketFD]() {
 					HandleWebSocketConnection(ClientSocketFD);
 				});
@@ -656,6 +746,10 @@ void FMCPBridgeServer::HandleWebSocketConnection(FMCPSocketHandle ClientSocketFD
 	// out of this function, whichever path leaves it.
 	FMCPClientSocket Connection(ClientSocketFD);
 
+	// Declared after the socket so it is destroyed before it: the handle must
+	// leave the live set while it is still open.
+	FMCPConnectionRelease Release(*this, ClientSocketFD);
+
 	// Set TCP_NODELAY on client socket for immediate send
 	int32 NoDelay = 1;
 	setsockopt(Connection.Get(), IPPROTO_TCP, TCP_NODELAY, (char*)&NoDelay, sizeof(NoDelay));
@@ -978,6 +1072,12 @@ void FMCPBridgeServer::ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD,
 	TArray<uint8> MessagePayload;
 	bool bAssembling = false;
 
+	// True once the connection has ended for a reason of its own: the peer
+	// closed, the stream stopped parsing, or the socket failed. False means the
+	// loop exited only because the bridge is stopping, which the peer deserves
+	// to be told about.
+	bool bConnectionFinished = false;
+
 	while (!bShouldStop)
 	{
 		// Decode before reading. Bytes left over from the previous read may
@@ -1114,6 +1214,7 @@ void FMCPBridgeServer::ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD,
 
 		if (bDone)
 		{
+			bConnectionFinished = true;
 			break;
 		}
 
@@ -1128,6 +1229,7 @@ void FMCPBridgeServer::ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD,
 		const int32 SelectResult = select(ClientSocketFD + 1, &ReadSet, nullptr, nullptr, &Timeout);
 		if (SelectResult < 0)
 		{
+			bConnectionFinished = true;
 			break;
 		}
 		if (SelectResult == 0 || !FD_ISSET(ClientSocketFD, &ReadSet))
@@ -1138,6 +1240,7 @@ void FMCPBridgeServer::ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD,
 		const int32 BytesReceived = recv(ClientSocketFD, (char*)Chunk.GetData(), kRecvChunkBytes, 0);
 		if (BytesReceived <= 0)
 		{
+			bConnectionFinished = true;
 			break;
 		}
 		PendingBytes.Append(Chunk.GetData(), BytesReceived);
@@ -1152,8 +1255,17 @@ void FMCPBridgeServer::ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD,
 				(int64)PendingBytes.Num(), kMaxWebSocketMessageBytes);
 			UE_LOG(LogMCPBridge, Error, TEXT("[UE-MCP] %s"), *Reason);
 			SendCloseFrame(ClientSocketFD, 1009, Reason);
+			bConnectionFinished = true;
 			break;
 		}
+	}
+
+	if (!bConnectionFinished)
+	{
+		// The only way out of the loop that is not the connection's own doing:
+		// the bridge is stopping. Tell the client so, instead of leaving it to
+		// infer a healthy editor from a severed socket.
+		SendCloseFrame(ClientSocketFD, 1001, TEXT("editor is shutting down"));
 	}
 }
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -886,14 +886,47 @@ void FMCPBridgeServer::ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD)
 				break;
 			}
 
+			// Control frames are answers the protocol owes the peer, not
+			// requests. Handing a close frame to the JSON-RPC parser (which is
+			// what happened before opcodes were read) replied to "goodbye" with
+			// a parse error and left the client waiting for a close that never
+			// came, holding a connection thread open for the rest of the
+			// session.
 			if (Frame.Opcode == EMCPWebSocketOpcode::Close)
 			{
+				uint16 PeerCode = 1000;
+				FString PeerReason;
+				if (Frame.Payload.Num() >= 2)
+				{
+					PeerCode = (uint16)(((uint16)Frame.Payload[0] << 8) | (uint16)Frame.Payload[1]);
+					if (Frame.Payload.Num() > 2)
+					{
+						FUTF8ToTCHAR ReasonText((const char*)Frame.Payload.GetData() + 2, Frame.Payload.Num() - 2);
+						PeerReason = FString(ReasonText.Length(), ReasonText.Get());
+					}
+				}
+				UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Client closed the WebSocket (code %u%s%s)"),
+					(uint32)PeerCode,
+					PeerReason.IsEmpty() ? TEXT("") : TEXT(": "),
+					*PeerReason);
+				// Echo the code back to finish the handshake, then stop reading.
+				SendCloseFrame(ClientSocketFD, PeerCode, TEXT(""));
 				bDone = true;
 				break;
 			}
-			if (Frame.Opcode == EMCPWebSocketOpcode::Ping || Frame.Opcode == EMCPWebSocketOpcode::Pong)
+			if (Frame.Opcode == EMCPWebSocketOpcode::Ping)
 			{
+				const TArray<uint8> Pong = CreateControlFrame(EMCPWebSocketOpcode::Pong, Frame.Payload);
+				if (!SendAll(ClientSocketFD, Pong.GetData(), Pong.Num()))
+				{
+					bDone = true;
+					break;
+				}
 				continue;
+			}
+			if (Frame.Opcode == EMCPWebSocketOpcode::Pong)
+			{
+				continue; // keepalive answer, nothing owed
 			}
 
 			if (Frame.Opcode == EMCPWebSocketOpcode::Continuation)

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -748,38 +748,26 @@ FString FMCPBridgeServer::PerformWebSocketHandshake(FMCPSocketHandle ClientSocke
 		}
 	}
 
-	// Reject browser-originated upgrades from any origin other than loopback.
-	// Browsers always send an Origin header on WebSocket upgrades, so a present
-	// Origin that isn't loopback is a cross-site websocket hijacking attempt
-	// (a malicious page on the developer's machine reaching the editor bridge).
-	// Native clients (Node ws, curl) omit Origin and are allowed.
+	// Refuse every browser-originated upgrade.
+	//
+	// The bridge exposes execute_python and every editor mutation, and it
+	// authenticates nothing about the caller. Allowing loopback origins meant
+	// any page served by any dev server on the machine could scan the port
+	// range and drive the editor, because the browser supplies
+	// Sec-WebSocket-Key itself and the page never has to see the response to
+	// cause the damage.
+	//
+	// A browser cannot suppress or forge the Origin header on a WebSocket
+	// upgrade, so its presence is a reliable "this came from a page". Native
+	// clients (the npm client, curl, editor tooling) omit it and are unaffected.
 	{
-		int32 OriginStart = Request.Find(TEXT("Origin:"), ESearchCase::IgnoreCase);
-		if (OriginStart != INDEX_NONE)
+		FString Origin;
+		if (FindHeaderValue(Request, TEXT("Origin"), Origin))
 		{
-			int32 ValueStart = OriginStart + 7; // strlen("Origin:")
-			while (ValueStart < Request.Len() && (Request[ValueStart] == TEXT(' ') || Request[ValueStart] == TEXT('\t')))
-			{
-				ValueStart++;
-			}
-			int32 ValueEnd = Request.Find(TEXT("\r\n"), ESearchCase::CaseSensitive, ESearchDir::FromStart, ValueStart);
-			FString Origin = (ValueEnd == INDEX_NONE)
-				? Request.Mid(ValueStart).TrimStartAndEnd()
-				: Request.Mid(ValueStart, ValueEnd - ValueStart).TrimStartAndEnd();
-
-			const bool bIsLoopback =
-				Origin.StartsWith(TEXT("http://localhost"), ESearchCase::IgnoreCase) ||
-				Origin.StartsWith(TEXT("https://localhost"), ESearchCase::IgnoreCase) ||
-				Origin.StartsWith(TEXT("http://127.0.0.1"), ESearchCase::IgnoreCase) ||
-				Origin.StartsWith(TEXT("https://127.0.0.1"), ESearchCase::IgnoreCase) ||
-				Origin.StartsWith(TEXT("http://[::1]"), ESearchCase::IgnoreCase) ||
-				Origin.StartsWith(TEXT("https://[::1]"), ESearchCase::IgnoreCase);
-
-			if (!bIsLoopback)
-			{
-				UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Rejected WebSocket upgrade from Origin: %s"), *Origin);
-				return TEXT("");
-			}
+			UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Rejected browser-originated WebSocket upgrade from Origin: %s"), *Origin);
+			SendHttpError(ClientSocketFD, 403, TEXT("Forbidden"),
+				TEXT("The UE-MCP bridge does not accept upgrades from web pages. Connect from a local process instead."));
+			return TEXT("");
 		}
 	}
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -282,10 +282,27 @@ uint32 FMCPBridgeServer::Run()
 		return 1;
 	}
 
-	// Set socket options
+	// Claim the port exclusively.
+	//
+	// #821: Winsock's SO_REUSEADDR is not the POSIX one. It allows a bind to
+	// succeed on a port another socket is actively listening on unless that
+	// socket asked for exclusive use. With it set, the collision walk below
+	// could never fire on Windows: a second editor of the same project bound at
+	// offset 0, both processes believed they owned the port, and which listener
+	// received a given connection was up to the stack. SO_EXCLUSIVEADDRUSE is
+	// what makes the second bind fail, which is what lets the walk walk.
+	//
+	// On POSIX, SO_REUSEADDR only relaxes TIME_WAIT and cannot take a live
+	// listener's port, so it stays there.
+#if PLATFORM_WINDOWS
+	int32 ExclusiveAddrUse = 1;
+	setsockopt(ServerSocketFD, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (char*)&ExclusiveAddrUse, sizeof(ExclusiveAddrUse));
+#else
 	int32 ReuseAddr = 1;
 	setsockopt(ServerSocketFD, SOL_SOCKET, SO_REUSEADDR, (char*)&ReuseAddr, sizeof(ReuseAddr));
-	
+#endif
+
+
 	// Set TCP_NODELAY for immediate send (disable Nagle's algorithm)
 	int32 NoDelay = 1;
 	setsockopt(ServerSocketFD, IPPROTO_TCP, TCP_NODELAY, (char*)&NoDelay, sizeof(NoDelay));

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -7,6 +7,7 @@
 #include "Serialization/JsonWriter.h"
 #include "HAL/PlatformProcess.h"
 #include "HAL/PlatformMisc.h"
+#include "HAL/PlatformTime.h"
 #include "HAL/FileManager.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
@@ -77,6 +78,12 @@ namespace
 	// growing without limit on a corrupt or hostile length field.
 	constexpr int64 kMaxWebSocketMessageBytes = 64ll * 1024ll * 1024ll; // 64 MiB
 	constexpr int32 kRecvChunkBytes = 65536;
+
+	// The upgrade request is read to its terminator rather than in one recv, so
+	// it needs its own bounds: how long the whole read may take, and how large
+	// the headers may grow before the bridge stops waiting for a blank line.
+	constexpr double kUpgradeReadTimeoutSeconds = 5.0;
+	constexpr int32 kMaxUpgradeHeaderBytes = 16 * 1024;
 }
 
 FMCPBridgeServer::FMCPBridgeServer(int32 Port)
@@ -624,8 +631,12 @@ void FMCPBridgeServer::HandleWebSocketConnection(FMCPSocketHandle ClientSocketFD
 	int32 NoDelay = 1;
 	setsockopt(ClientSocketFD, IPPROTO_TCP, TCP_NODELAY, (char*)&NoDelay, sizeof(NoDelay));
 	
+	// Anything the client pipelined behind its upgrade request. Those bytes
+	// arrived on the same read as the header and belong to the frame reader.
+	TArray<uint8> PipelinedBytes;
+
 	// Perform WebSocket handshake
-	FString Response = PerformWebSocketHandshake(ClientSocketFD);
+	FString Response = PerformWebSocketHandshake(ClientSocketFD, PipelinedBytes);
 	if (Response.IsEmpty())
 	{
 #if PLATFORM_WINDOWS
@@ -671,7 +682,7 @@ void FMCPBridgeServer::HandleWebSocketConnection(FMCPSocketHandle ClientSocketFD
 	
 	// Process WebSocket messages
 	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Starting WebSocket message processing"));
-	ProcessWebSocketMessages(ClientSocketFD);
+	ProcessWebSocketMessages(ClientSocketFD, PipelinedBytes);
 	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] WebSocket message processing ended"));
 
 #if PLATFORM_WINDOWS
@@ -681,12 +692,60 @@ void FMCPBridgeServer::HandleWebSocketConnection(FMCPSocketHandle ClientSocketFD
 #endif
 }
 
-FString FMCPBridgeServer::PerformWebSocketHandshake(FMCPSocketHandle ClientSocketFD)
+FString FMCPBridgeServer::PerformWebSocketHandshake(FMCPSocketHandle ClientSocketFD, TArray<uint8>& OutPipelinedBytes)
 {
-	FString Request = ReadHttpRequest(ClientSocketFD);
-	if (Request.IsEmpty())
+	FString Request;
+	if (!ReadHttpRequest(ClientSocketFD, Request, OutPipelinedBytes))
 	{
 		return TEXT("");
+	}
+
+	// Validate the request before honouring it. Answering every request that
+	// merely carries a Sec-WebSocket-Key with a 101 means a mistyped path, a
+	// POST, or a client speaking an older WebSocket draft all get told the
+	// upgrade succeeded and then fail incomprehensibly on the first frame.
+	{
+		int32 RequestLineEnd = Request.Find(TEXT("\r\n"));
+		const FString RequestLine = (RequestLineEnd == INDEX_NONE)
+			? Request.TrimStartAndEnd()
+			: Request.Left(RequestLineEnd).TrimStartAndEnd();
+
+		if (!RequestLine.StartsWith(TEXT("GET "), ESearchCase::CaseSensitive))
+		{
+			UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Rejected non-GET upgrade request: %s"), *RequestLine.Left(80));
+			SendHttpError(ClientSocketFD, 405, TEXT("Method Not Allowed"), TEXT("The UE-MCP bridge only accepts GET WebSocket upgrades."));
+			return TEXT("");
+		}
+		if (!RequestLine.EndsWith(TEXT("HTTP/1.1"), ESearchCase::IgnoreCase))
+		{
+			UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Rejected upgrade request with unsupported HTTP version: %s"), *RequestLine.Left(80));
+			SendHttpError(ClientSocketFD, 505, TEXT("HTTP Version Not Supported"), TEXT("WebSocket upgrades require HTTP/1.1."));
+			return TEXT("");
+		}
+
+		FString UpgradeHeader;
+		if (!FindHeaderValue(Request, TEXT("Upgrade"), UpgradeHeader) || !UpgradeHeader.Contains(TEXT("websocket"), ESearchCase::IgnoreCase))
+		{
+			UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Rejected request with no WebSocket Upgrade header"));
+			SendHttpError(ClientSocketFD, 426, TEXT("Upgrade Required"), TEXT("The UE-MCP bridge speaks WebSocket only."));
+			return TEXT("");
+		}
+
+		FString ConnectionHeader;
+		if (!FindHeaderValue(Request, TEXT("Connection"), ConnectionHeader) || !ConnectionHeader.Contains(TEXT("upgrade"), ESearchCase::IgnoreCase))
+		{
+			UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Rejected upgrade request with no 'Connection: Upgrade'"));
+			SendHttpError(ClientSocketFD, 400, TEXT("Bad Request"), TEXT("A WebSocket upgrade needs 'Connection: Upgrade'."));
+			return TEXT("");
+		}
+
+		FString VersionHeader;
+		if (!FindHeaderValue(Request, TEXT("Sec-WebSocket-Version"), VersionHeader) || FCString::Atoi(*VersionHeader) != 13)
+		{
+			UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Rejected upgrade with Sec-WebSocket-Version '%s' (13 required)"), *VersionHeader);
+			SendHttpError(ClientSocketFD, 426, TEXT("Upgrade Required"), TEXT("The UE-MCP bridge speaks WebSocket version 13."));
+			return TEXT("");
+		}
 	}
 
 	// Reject browser-originated upgrades from any origin other than loopback.
@@ -724,28 +783,17 @@ FString FMCPBridgeServer::PerformWebSocketHandshake(FMCPSocketHandle ClientSocke
 		}
 	}
 
-	// Extract WebSocket-Key from request (case-insensitive search)
+	// Extract WebSocket-Key from request
 	FString WebSocketKey;
-	int32 KeyStart = Request.Find(TEXT("Sec-WebSocket-Key:"), ESearchCase::IgnoreCase);
-	if (KeyStart != INDEX_NONE)
-	{
-		// Skip past the header name and any whitespace
-		int32 ValueStart = KeyStart + 18; // Length of "Sec-WebSocket-Key:"
-		while (ValueStart < Request.Len() && (Request[ValueStart] == TEXT(' ') || Request[ValueStart] == TEXT('\t')))
-		{
-			ValueStart++;
-		}
-		int32 KeyEnd = Request.Find(TEXT("\r\n"), ESearchCase::CaseSensitive, ESearchDir::FromStart, ValueStart);
-		if (KeyEnd != INDEX_NONE)
-		{
-			WebSocketKey = Request.Mid(ValueStart, KeyEnd - ValueStart).TrimStartAndEnd();
-		}
-	}
-	
+	FindHeaderValue(Request, TEXT("Sec-WebSocket-Key"), WebSocketKey);
+
 	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Extracted WebSocket-Key: %s"), *WebSocketKey);
 
-	if (WebSocketKey.IsEmpty())
+	TArray<uint8> DecodedKey;
+	if (WebSocketKey.IsEmpty() || !FBase64::Decode(WebSocketKey, DecodedKey) || DecodedKey.Num() != 16)
 	{
+		UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Rejected upgrade with a missing or malformed Sec-WebSocket-Key"));
+		SendHttpError(ClientSocketFD, 400, TEXT("Bad Request"), TEXT("Sec-WebSocket-Key must be 16 base64-encoded bytes."));
 		return TEXT("");
 	}
 
@@ -770,43 +818,126 @@ FString FMCPBridgeServer::PerformWebSocketHandshake(FMCPSocketHandle ClientSocke
 	return Response;
 }
 
-FString FMCPBridgeServer::ReadHttpRequest(FMCPSocketHandle SocketFD)
+bool FMCPBridgeServer::FindHeaderValue(const FString& Request, const FString& HeaderName, FString& OutValue)
 {
-	// Read HTTP request headers (until \r\n\r\n)
-	FString Request;
-	TArray<uint8> Buffer;
-	Buffer.SetNum(4096);
-	
-	// Use select to wait for data with timeout
-	fd_set ReadSet;
-	FD_ZERO(&ReadSet);
-	FD_SET(SocketFD, &ReadSet);
-	
-	timeval Timeout;
-	Timeout.tv_sec = 5; // 5 second timeout
-	Timeout.tv_usec = 0;
-	
-	int32 SelectResult = select(SocketFD + 1, &ReadSet, nullptr, nullptr, &Timeout);
-	if (SelectResult <= 0 || !FD_ISSET(SocketFD, &ReadSet))
+	// Scan line by line rather than searching the whole request for the header
+	// name: a value that happens to contain another header's name would
+	// otherwise be read as that header.
+	TArray<FString> Lines;
+	Request.ParseIntoArray(Lines, TEXT("\r\n"), /*InCullEmpty*/ false);
+	for (int32 Index = 1; Index < Lines.Num(); ++Index) // line 0 is the request line
 	{
-		UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Timeout waiting for HTTP request"));
-		return TEXT("");
+		const int32 Colon = Lines[Index].Find(TEXT(":"), ESearchCase::CaseSensitive);
+		if (Colon == INDEX_NONE)
+		{
+			continue;
+		}
+		if (Lines[Index].Left(Colon).TrimStartAndEnd().Equals(HeaderName, ESearchCase::IgnoreCase))
+		{
+			OutValue = Lines[Index].Mid(Colon + 1).TrimStartAndEnd();
+			return true;
+		}
 	}
-	
-	// Read data
-	int32 BytesReceived = recv(SocketFD, (char*)Buffer.GetData(), Buffer.Num(), 0);
-	if (BytesReceived <= 0)
+	return false;
+}
+
+void FMCPBridgeServer::SendHttpError(FMCPSocketHandle SocketFD, int32 StatusCode, const FString& StatusText, const FString& Detail)
+{
+	// A rejected upgrade used to be a silent disconnect, which reads to the
+	// caller exactly like "no editor is running". Say what was wrong.
+	const FString Body = Detail + TEXT("\r\n");
+	const FTCHARToUTF8 Utf8Body(*Body);
+	const FString Response = FString::Printf(
+		TEXT("HTTP/1.1 %d %s\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s"),
+		StatusCode, *StatusText, Utf8Body.Length(), *Body);
+
+	const FTCHARToUTF8 Utf8Response(*Response);
+	SendAll(SocketFD, (const uint8*)Utf8Response.Get(), Utf8Response.Length());
+}
+
+bool FMCPBridgeServer::ReadHttpRequest(FMCPSocketHandle SocketFD, FString& OutRequest, TArray<uint8>& OutPipelinedBytes)
+{
+	OutRequest.Reset();
+	OutPipelinedBytes.Reset();
+
+	TArray<uint8> Raw;
+	uint8 Chunk[4096];
+	int32 HeaderEnd = INDEX_NONE;
+
+	const double Deadline = FPlatformTime::Seconds() + kUpgradeReadTimeoutSeconds;
+
+	// Read until the blank line that ends the headers. A single recv is not a
+	// request: a header split across segments loses Sec-WebSocket-Key, and the
+	// connection then drops with nothing said about why.
+	while (HeaderEnd == INDEX_NONE)
 	{
-		UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Failed to read HTTP request"));
-		return TEXT("");
+		const double Remaining = Deadline - FPlatformTime::Seconds();
+		if (Remaining <= 0.0)
+		{
+			UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Timed out reading the WebSocket upgrade request (%d bytes read)"), Raw.Num());
+			return false;
+		}
+
+		fd_set ReadSet;
+		FD_ZERO(&ReadSet);
+		FD_SET(SocketFD, &ReadSet);
+
+		timeval Timeout;
+		Timeout.tv_sec = (long)Remaining;
+		Timeout.tv_usec = (long)((Remaining - (double)Timeout.tv_sec) * 1000000.0);
+
+		const int32 SelectResult = select(SocketFD + 1, &ReadSet, nullptr, nullptr, &Timeout);
+		if (SelectResult <= 0 || !FD_ISSET(SocketFD, &ReadSet))
+		{
+			UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Timeout waiting for the WebSocket upgrade request"));
+			return false;
+		}
+
+		const int32 BytesReceived = recv(SocketFD, (char*)Chunk, (int32)sizeof(Chunk), 0);
+		if (BytesReceived <= 0)
+		{
+			UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Connection closed before the upgrade request completed (%d bytes read)"), Raw.Num());
+			return false;
+		}
+
+		// The terminator can straddle two reads, so back up three bytes.
+		const int32 SearchFrom = FMath::Max(0, Raw.Num() - 3);
+		Raw.Append(Chunk, BytesReceived);
+
+		for (int32 Index = SearchFrom; Index + 3 < Raw.Num(); ++Index)
+		{
+			if (Raw[Index] == '\r' && Raw[Index + 1] == '\n' && Raw[Index + 2] == '\r' && Raw[Index + 3] == '\n')
+			{
+				HeaderEnd = Index + 4;
+				break;
+			}
+		}
+
+		if (HeaderEnd == INDEX_NONE && Raw.Num() > kMaxUpgradeHeaderBytes)
+		{
+			UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Upgrade request headers exceed %d bytes with no terminator; refusing"), kMaxUpgradeHeaderBytes);
+			SendHttpError(SocketFD, 431, TEXT("Request Header Fields Too Large"), TEXT("The upgrade request headers are too large for the UE-MCP bridge."));
+			return false;
+		}
 	}
-	
-	Buffer.SetNum(BytesReceived);
-	Request = FString(ANSI_TO_TCHAR((char*)Buffer.GetData()));
-	
-	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Read HTTP request (%d bytes):\n%s"), BytesReceived, *Request.Left(200));
-	
-	return Request;
+
+	// Decode exactly the header bytes. ANSI_TO_TCHAR reads until a NUL, and a
+	// socket buffer does not contain one; passing the length is what keeps the
+	// conversion inside the buffer.
+	const FUTF8ToTCHAR Header((const char*)Raw.GetData(), HeaderEnd);
+	OutRequest = FString(Header.Length(), Header.Get());
+
+	// Whatever followed the blank line is the client's first frames, arriving
+	// in the same segment as the upgrade. They belong to the frame reader.
+	if (Raw.Num() > HeaderEnd)
+	{
+		OutPipelinedBytes.Append(Raw.GetData() + HeaderEnd, Raw.Num() - HeaderEnd);
+	}
+
+	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Read HTTP upgrade request (%d header bytes, %d pipelined):\n%s"),
+		HeaderEnd, OutPipelinedBytes.Num(), *OutRequest.Left(200));
+
+	return true;
 }
 
 FString FMCPBridgeServer::CreateWebSocketAcceptKey(const FString& ClientKey)
@@ -846,7 +977,7 @@ FString FMCPBridgeServer::CreateWebSocketAcceptKey(const FString& ClientKey)
 	return AcceptKey;
 }
 
-void FMCPBridgeServer::ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD)
+void FMCPBridgeServer::ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD, TArray<uint8>& InitialBytes)
 {
 	TArray<uint8> Chunk;
 	Chunk.SetNumUninitialized(kRecvChunkBytes);
@@ -854,8 +985,9 @@ void FMCPBridgeServer::ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD)
 	// Everything received and not yet consumed by the decoder. A TCP read is a
 	// byte-stream event, not a message event: one read can carry half a frame,
 	// three frames, or two frames and half of a fourth. This buffer is what
-	// makes those all mean the same thing.
-	TArray<uint8> PendingBytes;
+	// makes those all mean the same thing. It starts with whatever the client
+	// pipelined behind its upgrade request.
+	TArray<uint8> PendingBytes = MoveTemp(InitialBytes);
 
 	// Reassembly state for a fragmented message (a data frame with FIN clear
 	// followed by continuation frames).

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -625,71 +625,67 @@ FString FMCPBridgeServer::ProcessMessage(const FString& Message)
 	}
 }
 
+FMCPClientSocket::FMCPClientSocket(FMCPSocketHandle InHandle)
+	: Handle(InHandle)
+{
+}
+
+FMCPClientSocket::~FMCPClientSocket()
+{
+	Close();
+}
+
+void FMCPClientSocket::Close()
+{
+	if (Handle == MCP_INVALID_SOCKET)
+	{
+		return;
+	}
+#if PLATFORM_WINDOWS
+	closesocket(Handle);
+#else
+	close(Handle);
+#endif
+	Handle = MCP_INVALID_SOCKET;
+}
+
 void FMCPBridgeServer::HandleWebSocketConnection(FMCPSocketHandle ClientSocketFD)
 {
+	// The accept loop created this handle and hands it over here. From this
+	// line on, Connection is its only owner: it closes exactly once, on the way
+	// out of this function, whichever path leaves it.
+	FMCPClientSocket Connection(ClientSocketFD);
+
 	// Set TCP_NODELAY on client socket for immediate send
 	int32 NoDelay = 1;
-	setsockopt(ClientSocketFD, IPPROTO_TCP, TCP_NODELAY, (char*)&NoDelay, sizeof(NoDelay));
-	
+	setsockopt(Connection.Get(), IPPROTO_TCP, TCP_NODELAY, (char*)&NoDelay, sizeof(NoDelay));
+
 	// Anything the client pipelined behind its upgrade request. Those bytes
 	// arrived on the same read as the header and belong to the frame reader.
 	TArray<uint8> PipelinedBytes;
 
 	// Perform WebSocket handshake
-	FString Response = PerformWebSocketHandshake(ClientSocketFD, PipelinedBytes);
+	const FString Response = PerformWebSocketHandshake(Connection.Get(), PipelinedBytes);
 	if (Response.IsEmpty())
 	{
-#if PLATFORM_WINDOWS
-		closesocket(ClientSocketFD);
-#else
-		close(ClientSocketFD);
-#endif
 		return;
 	}
 
-	// Send handshake response
-	// HTTP headers are ASCII, FString uses TCHAR (which is wchar_t on Windows)
-	// Convert to UTF-8 bytes for network transmission
-	FTCHARToUTF8 UTF8Response(*Response);
-	const char* ResponseBytes = (const char*)UTF8Response.Get();
-	int32 TotalBytes = UTF8Response.Length();
-	
-	// Send response - ensure all bytes are sent
-	int32 SentBytes = 0;
-	while (SentBytes < TotalBytes)
+	// HTTP headers are ASCII and FString is TCHAR, so convert to UTF-8 bytes
+	// for the wire. A partial send is a failed handshake, not a success.
+	const FTCHARToUTF8 UTF8Response(*Response);
+	if (!SendAll(Connection.Get(), (const uint8*)UTF8Response.Get(), UTF8Response.Length()))
 	{
-		int32 BytesSent = send(ClientSocketFD, ResponseBytes + SentBytes, TotalBytes - SentBytes, 0);
-		if (BytesSent < 0)
-		{
-			int32 ErrorCode = 0;
-#if PLATFORM_WINDOWS
-			ErrorCode = WSAGetLastError();
-			UE_LOG(LogMCPBridge, Error, TEXT("[UE-MCP] Failed to send WebSocket handshake response, error: %d"), ErrorCode);
-			closesocket(ClientSocketFD);
-#else
-			UE_LOG(LogMCPBridge, Error, TEXT("[UE-MCP] Failed to send WebSocket handshake response"));
-			close(ClientSocketFD);
-#endif
-			return;
-		}
-		SentBytes += BytesSent;
+		UE_LOG(LogMCPBridge, Error, TEXT("[UE-MCP] Failed to send WebSocket handshake response"));
+		return;
 	}
-	
-	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Sent WebSocket handshake response (%d/%d bytes)"), SentBytes, TotalBytes);
-	
-	// Small delay to ensure response is fully sent and received by client
-	FPlatformProcess::Sleep(0.01f); // 10ms
-	
+
+	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Sent WebSocket handshake response (%d bytes)"), UTF8Response.Length());
+
 	// Process WebSocket messages
 	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Starting WebSocket message processing"));
-	ProcessWebSocketMessages(ClientSocketFD, PipelinedBytes);
+	ProcessWebSocketMessages(Connection.Get(), PipelinedBytes);
 	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] WebSocket message processing ended"));
-
-#if PLATFORM_WINDOWS
-	closesocket(ClientSocketFD);
-#else
-	close(ClientSocketFD);
-#endif
 }
 
 FString FMCPBridgeServer::PerformWebSocketHandshake(FMCPSocketHandle ClientSocketFD, TArray<uint8>& OutPipelinedBytes)

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -14,6 +14,8 @@
 #include "Misc/Paths.h"
 #include "Misc/DateTime.h"
 #include "Misc/Timespan.h"
+#include "Misc/App.h"
+#include "Misc/EngineVersion.h"
 #include "Misc/CommandLine.h"
 #include "Misc/Parse.h"
 #include "Misc/SecureHash.h"
@@ -541,6 +543,7 @@ void FMCPBridgeServer::WritePortLockfile(int32 PortValue)
 	// instances of one project would otherwise be indistinguishable on disk.
 	Obj->SetStringField(TEXT("instanceId"), InstanceId.ToString(EGuidFormats::DigitsWithHyphens));
 	Obj->SetStringField(TEXT("status"), TEXT("listening"));
+	Obj->SetNumberField(TEXT("protocolVersion"), (double)UEMCP_BRIDGE_PROTOCOL_VERSION);
 	Obj->SetNumberField(TEXT("handlerApiVersion"), (double)UEMCP_BRIDGE_API_VERSION);
 
 	if (!PublishJsonAtomically(FilePath, Obj))
@@ -720,6 +723,59 @@ FString FMCPBridgeServer::CreateJsonRpcError(const TSharedPtr<FJsonObject>& Requ
 	return OutputString;
 }
 
+TSharedPtr<FJsonObject> FMCPBridgeServer::BuildCapabilitiesPayload()
+{
+	TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+	Payload->SetBoolField(TEXT("success"), true);
+	Payload->SetBoolField(TEXT("servedWithoutGameThread"), true);
+	Payload->SetNumberField(TEXT("protocolVersion"), (double)UEMCP_BRIDGE_PROTOCOL_VERSION);
+	Payload->SetNumberField(TEXT("handlerApiVersion"), (double)UEMCP_BRIDGE_API_VERSION);
+
+	// The question behind "which version is this" is nearly always "is the
+	// binary I am talking to the one built from the source on disk". A compile
+	// timestamp answers that; a constant read out of a header file cannot,
+	// because the header is the source and the source is what got ahead.
+	Payload->SetStringField(TEXT("builtAt"), ANSI_TO_TCHAR(__DATE__ " " __TIME__));
+	Payload->SetStringField(TEXT("engineVersion"), FEngineVersion::Current().ToString());
+	Payload->SetStringField(TEXT("projectName"), FApp::GetProjectName());
+	Payload->SetStringField(TEXT("instanceId"), InstanceId.ToString(EGuidFormats::DigitsWithHyphens));
+	Payload->SetNumberField(TEXT("pid"), (double)FPlatformProcess::GetCurrentProcessId());
+	Payload->SetNumberField(TEXT("port"), ServerPort);
+	Payload->SetStringField(TEXT("startedAt"), StartedAtUtc.ToIso8601());
+
+	// Named capabilities rather than "anything at or above version N", so a
+	// client can ask about the one thing it needs.
+	static const TCHAR* const Features[] = {
+		TEXT("frame-reassembly"),
+		TEXT("control-frames"),
+		TEXT("capability-handshake"),
+		TEXT("exclusive-port-claim"),
+		TEXT("owned-port-record"),
+	};
+	TArray<TSharedPtr<FJsonValue>> FeatureValues;
+	for (const TCHAR* Feature : Features)
+	{
+		FeatureValues.Add(MakeShared<FJsonValueString>(Feature));
+	}
+	Payload->SetArrayField(TEXT("features"), FeatureValues);
+
+	// The registered action list, from the running binary. This is the only
+	// answer to "does the plugin I reached have this method" that a stale DLL
+	// cannot fake.
+	TArray<FString> Names = HandlerRegistry.GetHandlerNames();
+	Names.Sort();
+	TArray<TSharedPtr<FJsonValue>> ActionValues;
+	ActionValues.Reserve(Names.Num());
+	for (const FString& Name : Names)
+	{
+		ActionValues.Add(MakeShared<FJsonValueString>(Name));
+	}
+	Payload->SetNumberField(TEXT("actionCount"), Names.Num());
+	Payload->SetArrayField(TEXT("actions"), ActionValues);
+
+	return Payload;
+}
+
 FString FMCPBridgeServer::ProcessMessage(const FString& Message)
 {
 	TSharedPtr<FJsonObject> Request = ParseJsonRpcRequest(Message);
@@ -764,6 +820,15 @@ FString FMCPBridgeServer::ProcessMessage(const FString& Message)
 		Snapshot->SetBoolField(TEXT("success"), true);
 		Snapshot->SetBoolField(TEXT("servedWithoutGameThread"), true);
 		return CreateJsonRpcResponse(Request, MakeShared<FJsonValueObject>(Snapshot));
+	}
+
+	// #821: also served here, for the same reason and one more. This is the
+	// question a client asks to find out whether the plugin it reached
+	// understands the protocol it speaks, and it asks it on connect, which is
+	// exactly when the game thread is least likely to answer anything.
+	if (Method == TEXT("get_bridge_capabilities"))
+	{
+		return CreateJsonRpcResponse(Request, MakeShared<FJsonValueObject>(BuildCapabilitiesPayload()));
 	}
 
 	// Execute handler on game thread

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
@@ -16,6 +16,46 @@
 #include "Windows/HideWindowsPlatformTypes.h"
 #endif
 
+// One name for the platform socket handle so the connection code is written
+// once instead of twice behind #if blocks that can silently drift apart.
+#if PLATFORM_WINDOWS
+typedef SOCKET FMCPSocketHandle;
+#define MCP_INVALID_SOCKET INVALID_SOCKET
+#else
+typedef int32 FMCPSocketHandle;
+#define MCP_INVALID_SOCKET (-1)
+#endif
+
+/** WebSocket opcodes the bridge understands (RFC 6455 section 5.2). */
+enum class EMCPWebSocketOpcode : uint8
+{
+	Continuation = 0x0,
+	Text         = 0x1,
+	Binary       = 0x2,
+	Close        = 0x8,
+	Ping         = 0x9,
+	Pong         = 0xA,
+};
+
+/** Outcome of trying to decode one frame off the front of a receive buffer. */
+enum class EMCPFrameDecode : uint8
+{
+	/** The buffer holds a partial frame. Read more and try again. */
+	NeedMoreData,
+	/** OutFrame is filled in and the frame's bytes were consumed. */
+	Decoded,
+	/** The stream is no longer trustworthy. Close the connection. */
+	ProtocolError,
+};
+
+/** One decoded WebSocket frame. A message may span several of these. */
+struct FMCPWebSocketFrame
+{
+	EMCPWebSocketOpcode Opcode = EMCPWebSocketOpcode::Text;
+	bool bFinal = true;
+	TArray<uint8> Payload;
+};
+
 class FMCPBridgeServer : public FRunnable
 {
 public:
@@ -80,20 +120,32 @@ private:
 	FString CreateJsonRpcError(const TSharedPtr<FJsonObject>& Request, int32 ErrorCode, const FString& ErrorMessage);
 
 	// WebSocket connection handling
-#if PLATFORM_WINDOWS
-	void HandleWebSocketConnection(SOCKET ClientSocketFD);
-	FString PerformWebSocketHandshake(SOCKET ClientSocketFD);
-	void ProcessWebSocketMessages(SOCKET ClientSocketFD);
-	FString ReadHttpRequest(SOCKET SocketFD);
-#else
-	void HandleWebSocketConnection(int32 ClientSocketFD);
-	FString PerformWebSocketHandshake(int32 ClientSocketFD);
-	void ProcessWebSocketMessages(int32 ClientSocketFD);
-	FString ReadHttpRequest(int32 SocketFD);
-#endif
+	void HandleWebSocketConnection(FMCPSocketHandle ClientSocketFD);
+	FString PerformWebSocketHandshake(FMCPSocketHandle ClientSocketFD);
+	void ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD);
+	FString ReadHttpRequest(FMCPSocketHandle SocketFD);
+
 	FString CreateWebSocketAcceptKey(const FString& ClientKey);
 	TArray<uint8> CreateWebSocketFrame(const FString& Message);
-	FString ParseWebSocketFrame(const TArray<uint8>& Data);
+
+	/**
+	 * Decode at most one frame from the front of Buffer.
+	 *
+	 * On Decoded the frame's bytes (header, mask and payload) are consumed from
+	 * Buffer and whatever follows is left in place, so a read that delivered two
+	 * pipelined requests yields both instead of dropping the second. On
+	 * NeedMoreData nothing is consumed and the caller reads again.
+	 */
+	static EMCPFrameDecode DecodeWebSocketFrame(TArray<uint8>& Buffer, FMCPWebSocketFrame& OutFrame, FString& OutError);
+
+	/** Frame a control opcode (close, ping, pong) with its payload. */
+	static TArray<uint8> CreateControlFrame(EMCPWebSocketOpcode Opcode, const TArray<uint8>& Payload);
+
+	/** Send a close frame carrying a status code and a human-readable reason. */
+	static void SendCloseFrame(FMCPSocketHandle SocketFD, uint16 StatusCode, const FString& Reason);
+
+	/** Write every byte or report failure. Partial sends are not success. */
+	static bool SendAll(FMCPSocketHandle SocketFD, const uint8* Data, int32 NumBytes);
 
 	// Server socket (will use platform-specific implementation)
 	void* ServerSocket;

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
@@ -56,6 +56,34 @@ struct FMCPWebSocketFrame
 	TArray<uint8> Payload;
 };
 
+/**
+ * Sole owner of one accepted client socket.
+ *
+ * The accept loop creates the handle and hands it to a connection thread; from
+ * that moment this object is the only thing allowed to close it, and it does so
+ * exactly once. The close call used to be copied down every early return in the
+ * connection path, which is how a new return ends up leaking a socket and a
+ * reconnect ends up closing one twice.
+ */
+class FMCPClientSocket
+{
+public:
+	explicit FMCPClientSocket(FMCPSocketHandle InHandle);
+	~FMCPClientSocket();
+
+	FMCPClientSocket(const FMCPClientSocket&) = delete;
+	FMCPClientSocket& operator=(const FMCPClientSocket&) = delete;
+
+	FMCPSocketHandle Get() const { return Handle; }
+	bool IsValid() const { return Handle != MCP_INVALID_SOCKET; }
+
+	/** Close now. Idempotent, so the destructor is a no-op afterwards. */
+	void Close();
+
+private:
+	FMCPSocketHandle Handle;
+};
+
 class FMCPBridgeServer : public FRunnable
 {
 public:

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
@@ -12,6 +12,8 @@
 #include "HAL/CriticalSection.h"
 #include "Containers/Queue.h"
 #include "Containers/Set.h"
+#include "Misc/Guid.h"
+#include "Misc/DateTime.h"
 
 #if PLATFORM_WINDOWS
 #include "Windows/AllowWindowsPlatformTypes.h"
@@ -134,9 +136,17 @@ public:
 	void Shutdown();
 
 	// #492: per-project port lockfile so multiple editors can coexist.
+	// #821: the record names the instance that wrote it, is published by
+	// rename so a reader never sees a half-written file, and is only ever
+	// removed by the instance whose id it carries.
 	static FString GetPortLockfilePath();
-	static void WritePortLockfile(int32 PortValue);
-	static void DeletePortLockfile();
+	static FString GetBridgeErrorFilePath();
+	void WritePortLockfile(int32 PortValue);
+	void DeletePortLockfileIfOwned();
+
+	/** Leave an on-disk trace for "editor alive, bridge dead". Written to its
+	 *  own path so a failed start can never overwrite a live editor's record. */
+	void WriteBindFailureRecord(int32 FirstPort, int32 LastPort, int32 ErrorCode);
 
 	// Deterministic per-worktree base port. Derived from a hash of the project
 	// root path so every checkout gets a stable, launch-order-independent port
@@ -236,4 +246,10 @@ private:
 	FCriticalSection ConnectionsMutex;
 	TSet<FMCPSocketHandle> LiveConnections;
 	FThreadSafeCounter ActiveConnectionCount;
+
+	// #821: identity for this server object, so a record on disk can say which
+	// process wrote it and only that process can take it away. A pid alone is
+	// not enough; pids are recycled.
+	FGuid InstanceId;
+	FDateTime StartedAtUtc;
 };

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
@@ -168,6 +168,14 @@ public:
 	// Process a JSON-RPC message
 	FString ProcessMessage(const FString& Message);
 
+	/**
+	 * #821: what this bridge is and what it can do, answered without the game
+	 * thread. Protocol version, handler ABI version, the binary's compile
+	 * timestamp, this instance's identity, and the action list the running
+	 * binary actually registered.
+	 */
+	TSharedPtr<FJsonObject> BuildCapabilitiesPayload();
+
 private:
 	// Server port
 	int32 ServerPort;

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
@@ -8,7 +8,10 @@
 #include "HAL/Runnable.h"
 #include "HAL/RunnableThread.h"
 #include "HAL/ThreadSafeBool.h"
+#include "HAL/ThreadSafeCounter.h"
+#include "HAL/CriticalSection.h"
 #include "Containers/Queue.h"
+#include "Containers/Set.h"
 
 #if PLATFORM_WINDOWS
 #include "Windows/AllowWindowsPlatformTypes.h"
@@ -84,8 +87,36 @@ private:
 	FMCPSocketHandle Handle;
 };
 
+class FMCPBridgeServer;
+
+/**
+ * Releases the connection record the accept loop made before it spawned this
+ * thread.
+ *
+ * The accept loop registers, so a shutdown racing an accept can never conclude
+ * that nothing is running. This object is declared after the socket guard and
+ * therefore destroyed before it, so the handle leaves the live set while it is
+ * still open: half-closing a handle number the operating system has already
+ * handed to someone else is worse than not waking it at all.
+ */
+class FMCPConnectionRelease
+{
+public:
+	FMCPConnectionRelease(FMCPBridgeServer& InServer, FMCPSocketHandle InHandle);
+	~FMCPConnectionRelease();
+
+	FMCPConnectionRelease(const FMCPConnectionRelease&) = delete;
+	FMCPConnectionRelease& operator=(const FMCPConnectionRelease&) = delete;
+
+private:
+	FMCPBridgeServer& Server;
+	FMCPSocketHandle Handle;
+};
+
 class FMCPBridgeServer : public FRunnable
 {
+	friend class FMCPConnectionRelease;
+
 public:
 	FMCPBridgeServer(int32 Port = 9877);
 	~FMCPBridgeServer();
@@ -189,6 +220,20 @@ private:
 	/** Write every byte or report failure. Partial sends are not success. */
 	static bool SendAll(FMCPSocketHandle SocketFD, const uint8* Data, int32 NumBytes);
 
-	// Server socket (will use platform-specific implementation)
-	void* ServerSocket;
+	// #821: connection threads capture `this` and outlive the accept loop, so
+	// shutdown has to be able to find them, wake them, and wait for them. The
+	// module frees this object the moment Shutdown returns.
+	void RegisterConnection(FMCPSocketHandle Handle);
+	void UnregisterConnection(FMCPSocketHandle Handle);
+
+	/** Half-close every live client socket so a blocked recv returns now
+	 *  rather than at the end of its next one-second select. */
+	void WakeAllConnections();
+
+	/** Block until no connection thread is running. False on timeout. */
+	bool WaitForConnectionsToFinish(double TimeoutSeconds);
+
+	FCriticalSection ConnectionsMutex;
+	TSet<FMCPSocketHandle> LiveConnections;
+	FThreadSafeCounter ActiveConnectionCount;
 };

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
@@ -121,9 +121,23 @@ private:
 
 	// WebSocket connection handling
 	void HandleWebSocketConnection(FMCPSocketHandle ClientSocketFD);
-	FString PerformWebSocketHandshake(FMCPSocketHandle ClientSocketFD);
-	void ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD);
-	FString ReadHttpRequest(FMCPSocketHandle SocketFD);
+	void ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD, TArray<uint8>& InitialBytes);
+
+	/**
+	 * Validate the upgrade request and build the 101 response, or return an
+	 * empty string having already told the client why it was refused.
+	 * OutPipelinedBytes receives anything the client sent behind the request.
+	 */
+	FString PerformWebSocketHandshake(FMCPSocketHandle ClientSocketFD, TArray<uint8>& OutPipelinedBytes);
+
+	/** Read the upgrade request through its blank line, not just one recv. */
+	static bool ReadHttpRequest(FMCPSocketHandle SocketFD, FString& OutRequest, TArray<uint8>& OutPipelinedBytes);
+
+	/** Case-insensitive, line-scoped header lookup. */
+	static bool FindHeaderValue(const FString& Request, const FString& HeaderName, FString& OutValue);
+
+	/** Refuse an upgrade with an HTTP status the caller can read. */
+	static void SendHttpError(FMCPSocketHandle SocketFD, int32 StatusCode, const FString& StatusText, const FString& Detail);
 
 	FString CreateWebSocketAcceptKey(const FString& ClientKey);
 	TArray<uint8> CreateWebSocketFrame(const FString& Message);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/GameThreadExecutor.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/GameThreadExecutor.cpp
@@ -158,9 +158,32 @@ TSharedPtr<FJsonValue> FMCPGameThreadExecutor::ExecuteOnGameThread(FHandlerFunct
 		GModalSafeQueue.Enqueue(RunOnce);
 	}
 
-	// Block calling thread until the ticker fires or timeout
-	uint32 TimeoutMs = static_cast<uint32>(TimeoutSeconds * 1000.0f);
-	bool bCompleted = State->DoneEvent->Wait(TimeoutMs);
+	// Block the calling thread until the ticker fires, the timeout expires, or
+	// the bridge starts shutting down.
+	//
+	// #821: waiting in slices rather than one long wait is what lets shutdown
+	// reclaim this thread. Module teardown runs on the game thread, so once it
+	// has begun the queued ticker will never fire, and a single Wait(30s) here
+	// (or the several minutes some handlers are allowed) would hold the editor
+	// open for the whole of it.
+	const uint32 TimeoutMs = static_cast<uint32>(TimeoutSeconds * 1000.0f);
+	constexpr uint32 SliceMs = 50;
+	uint32 WaitedMs = 0;
+	bool bCompleted = false;
+	while (WaitedMs < TimeoutMs)
+	{
+		const uint32 ThisSliceMs = FMath::Min(SliceMs, TimeoutMs - WaitedMs);
+		if (State->DoneEvent->Wait(ThisSliceMs))
+		{
+			bCompleted = true;
+			break;
+		}
+		WaitedMs += ThisSliceMs;
+		if (bShuttingDown)
+		{
+			break;
+		}
+	}
 
 	if (!bCompleted)
 	{
@@ -180,7 +203,9 @@ TSharedPtr<FJsonValue> FMCPGameThreadExecutor::ExecuteOnGameThread(FHandlerFunct
 	if (!bCompleted)
 	{
 		TSharedPtr<FJsonObject> ErrorObject = MakeShared<FJsonObject>();
-		ErrorObject->SetStringField(TEXT("error"), TEXT("Handler execution timed out"));
+		ErrorObject->SetStringField(TEXT("error"), bShuttingDown
+			? TEXT("Editor is shutting down; the request was not run.")
+			: TEXT("Handler execution timed out"));
 		return MakeShared<FJsonValueObject>(ErrorObject);
 	}
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/GameThreadExecutor.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/GameThreadExecutor.h
@@ -43,8 +43,17 @@ public:
 	// Check if the editor is ready
 	bool IsEditorReady() const { return bEditorReady; }
 
+	// #821: stop blocking callers. The game thread is inside module teardown by
+	// the time the bridge shuts down, so it will never run the queued ticker,
+	// and a socket thread waiting the full handler timeout there is a socket
+	// thread that holds the editor open for exactly that long. Once this is set
+	// an in-flight wait gives up at its next slice.
+	void BeginShutdown() { bShuttingDown = true; }
+	bool IsShuttingDown() const { return bShuttingDown; }
+
 private:
 	FThreadSafeBool bEditorReady{false};
+	FThreadSafeBool bShuttingDown{false};
 	// Pending execution info
 	struct FPendingExecution
 	{

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Public/MCPHandlerRegistration.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Public/MCPHandlerRegistration.h
@@ -31,6 +31,26 @@
  *  signature or registration contract changes in a breaking way. */
 #define UEMCP_BRIDGE_API_VERSION 1
 
+/**
+ * Current bridge wire protocol version, reported by get_bridge_capabilities.
+ *
+ * Distinct from the handler ABI above: this describes what a client can expect
+ * of the socket (framing, control frames, the handshake itself), not what a
+ * native plugin can expect of the registration API.
+ *
+ * Version 1 is every bridge built before the handshake existed. Those answer
+ * get_bridge_capabilities with "Unknown method", which is how a client
+ * recognises them.
+ *
+ * Version 2 reassembles messages across reads and frames, answers close and
+ * ping frames, validates the upgrade request, and serves this handshake.
+ *
+ * Bump this when a change would make an older client misread the wire. The
+ * client compares its own expectation against what it is told and names both
+ * numbers when they differ, so the value is only useful if it moves.
+ */
+#define UEMCP_BRIDGE_PROTOCOL_VERSION 2
+
 namespace UEMCP
 {
 	using FExternalHandlerFn = TFunction<TSharedPtr<FJsonValue>(const TSharedPtr<FJsonObject>& Params)>;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -274,10 +274,18 @@ export class EditorBridge implements IBridge {
       }
     });
 
-    ws.on("close", () => {
+    ws.on("close", (code: number, reasonRaw: Buffer) => {
+      // The bridge closes with a status code and a reason when it refuses a
+      // frame: 1009 for a message over its size bound, 1002 for a frame stream
+      // that stopped making sense. Repeating both verbatim is the difference
+      // between "something broke" and a caller knowing it sent too much.
+      const reason = reasonRaw?.toString("utf8") ?? "";
+      const detail = reason
+        ? `Bridge connection closed by the editor (code ${code}): ${reason}`
+        : `Bridge connection lost (close code ${code})`;
       for (const [, pending] of this.pending) {
         clearTimeout(pending.timer);
-        pending.reject(new McpError(ErrorCode.CONNECTION_LOST, "Bridge connection lost"));
+        pending.reject(new McpError(ErrorCode.CONNECTION_LOST, detail));
       }
       this.pending.clear();
       this.ws = null;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -331,7 +331,9 @@ export class EditorBridge implements IBridge {
         // #821: ask what we are talking to before anything else does. The
         // answer is cheap, it never touches the game thread, and without it a
         // client running against an older plugin can only report the symptom.
-        this.handshake(ws).then(() => resolve(), () => resolve());
+        // Bounded by the caller's own connect budget: a bridge that will not
+        // answer this is not one worth waiting past that for.
+        this.handshake(ws, timeoutMs).then(() => resolve(), () => resolve());
       });
 
       ws.on("error", (err) => {
@@ -456,7 +458,7 @@ export class EditorBridge implements IBridge {
         if (msg.error || !msg.result) {
           // -32601 from a bridge that has never heard of the handshake. That
           // silence is itself the answer: it predates the protocol version.
-          finish(LEGACY_CAPABILITIES);
+          finish({ ...LEGACY_CAPABILITIES });
           return;
         }
         const result = msg.result as Partial<BridgeCapabilities>;
@@ -467,11 +469,11 @@ export class EditorBridge implements IBridge {
         });
       };
 
-      const timer = setTimeout(() => finish(LEGACY_CAPABILITIES), timeoutMs);
+      const timer = setTimeout(() => finish({ ...LEGACY_CAPABILITIES }), timeoutMs);
 
       ws.on("message", onMessage);
       ws.send(JSON.stringify({ id, method: "get_bridge_capabilities", params: {} }), (err) => {
-        if (err) finish(LEGACY_CAPABILITIES);
+        if (err) finish({ ...LEGACY_CAPABILITIES });
       });
     });
   }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,9 +1,88 @@
 import WebSocket from "ws";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createRequire } from "node:module";
 import { McpError, ErrorCode } from "./errors.js";
 import { debug, warn } from "./log.js";
 import { DEFAULT_BRIDGE_PORT, deriveProjectPort } from "./port.js";
+
+/**
+ * The wire protocol this client speaks. Must match
+ * UEMCP_BRIDGE_PROTOCOL_VERSION in the plugin's MCPHandlerRegistration.h.
+ *
+ * The plugin is compiled by the user, and `attach` is deliberately
+ * non-destructive, so an npm upgrade routinely leaves a new client talking to
+ * an arbitrarily old binary. Comparing these two numbers is how that gets
+ * named instead of surfacing as an unexplained "Unknown method".
+ */
+export const CLIENT_PROTOCOL_VERSION = 2;
+
+/** Answer to get_bridge_capabilities, or what we infer when there is none. */
+export interface BridgeCapabilities {
+  protocolVersion: number;
+  handlerApiVersion?: number;
+  /** Compile timestamp of the loaded plugin binary. The stale-DLL tell. */
+  builtAt?: string;
+  engineVersion?: string;
+  projectName?: string;
+  instanceId?: string;
+  pid?: number;
+  port?: number;
+  startedAt?: string;
+  features?: string[];
+  actions?: string[];
+  actionCount?: number;
+  /** True when the bridge did not answer the handshake at all. */
+  legacy: boolean;
+}
+
+/** What a bridge that predates the handshake looks like. */
+const LEGACY_CAPABILITIES: BridgeCapabilities = { protocolVersion: 1, legacy: true };
+
+let cachedClientVersion: string | null = null;
+function clientPackageVersion(): string {
+  if (cachedClientVersion) return cachedClientVersion;
+  try {
+    const require = createRequire(import.meta.url);
+    cachedClientVersion = (require("../package.json") as { version: string }).version;
+  } catch {
+    cachedClientVersion = "unknown";
+  }
+  return cachedClientVersion;
+}
+
+/**
+ * Describe a client/plugin protocol mismatch in terms the reader can act on,
+ * naming both versions. Returns null when the two agree.
+ */
+export function describeProtocolMismatch(
+  capabilities: BridgeCapabilities | null,
+  method?: string,
+): string | null {
+  if (!capabilities) return null;
+  const theirs = capabilities.protocolVersion;
+  const ours = CLIENT_PROTOCOL_VERSION;
+  if (theirs === ours) return null;
+
+  const built = capabilities.builtAt ? ` The loaded plugin binary was built ${capabilities.builtAt}.` : "";
+  const missing =
+    method && capabilities.actions && !capabilities.actions.includes(method)
+      ? ` '${method}' is not among the ${capabilities.actionCount ?? capabilities.actions.length} actions the running plugin registered.`
+      : "";
+
+  if (theirs < ours) {
+    return (
+      `The Unreal bridge plugin speaks protocol version ${theirs}, this ue-mcp client (v${clientPackageVersion()}) speaks version ${ours}.` +
+      `${missing}${built}` +
+      ` Rebuild the plugin against the current package: run 'npx ue-mcp update' in the project, then rebuild the editor binaries.`
+    );
+  }
+  return (
+    `The Unreal bridge plugin speaks protocol version ${theirs}, this ue-mcp client (v${clientPackageVersion()}) speaks only version ${ours}.` +
+    `${built}` +
+    ` Update the npm package to match the plugin: 'npm install ue-mcp@latest'.`
+  );
+}
 
 /** The record the running bridge publishes for this project. */
 export interface BridgeLockfile {
@@ -104,11 +183,15 @@ interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (reason: Error) => void;
   timer: ReturnType<typeof setTimeout>;
+  /** Kept so an "unknown method" answer can name the method it was about. */
+  method: string;
 }
 
 /** Minimal interface for tool handlers — enables mocking in tests. */
 export interface IBridge {
   readonly isConnected: boolean;
+  /** #821: what the connected bridge reported at handshake, when there is one. */
+  readonly capabilities?: BridgeCapabilities | null;
   call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
   connect(timeoutMs?: number): Promise<void>;
 }
@@ -119,6 +202,12 @@ export class EditorBridge implements IBridge {
   private reconnectTimer: ReturnType<typeof setInterval> | null = null;
   private connectInFlight: Promise<void> | null = null;
   private idCounter = 0;
+
+  /**
+   * #821: what the bridge said it was, answered on connect. Null before the
+   * first connection. `legacy` marks a plugin old enough not to answer at all.
+   */
+  public capabilities: BridgeCapabilities | null = null;
 
   // How this.port was decided. Precedence for the *preferred* port (the one
   // used when no editor lockfile is present) is explicit > env > config >
@@ -239,7 +328,10 @@ export class EditorBridge implements IBridge {
         clearTimeout(timer);
         this.ws = ws;
         this.setupListeners(ws);
-        resolve();
+        // #821: ask what we are talking to before anything else does. The
+        // answer is cheap, it never touches the game thread, and without it a
+        // client running against an older plugin can only report the symptom.
+        this.handshake(ws).then(() => resolve(), () => resolve());
       });
 
       ws.on("error", (err) => {
@@ -298,7 +390,7 @@ export class EditorBridge implements IBridge {
         reject(new McpError(ErrorCode.BRIDGE_TIMEOUT, `Bridge call '${method}' timed out after ${Math.round(timeout / 1000)}s`));
       }, timeout);
 
-      this.pending.set(id, { resolve, reject, timer });
+      this.pending.set(id, { resolve, reject, timer, method });
       ws.send(JSON.stringify(request), (err) => {
         if (!err) return;
 
@@ -326,6 +418,64 @@ export class EditorBridge implements IBridge {
     }
   }
 
+  /**
+   * Ask the bridge what it is. Deliberately not routed through call(): a slow
+   * or absent answer here must not terminate the socket the way a timed-out
+   * call does, and a bridge old enough to have no answer is a normal outcome
+   * rather than a failure.
+   */
+  private handshake(ws: WebSocket, timeoutMs = 5000): Promise<BridgeCapabilities> {
+    return new Promise((resolve) => {
+      const id = `cap-${++this.idCounter}`;
+      let settled = false;
+
+      const finish = (capabilities: BridgeCapabilities): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        ws.off("message", onMessage);
+        this.capabilities = capabilities;
+
+        const mismatch = describeProtocolMismatch(capabilities);
+        if (mismatch) {
+          warn("bridge", mismatch);
+        } else {
+          debug("bridge", `bridge protocol ${capabilities.protocolVersion}, ${capabilities.actionCount ?? "?"} actions, built ${capabilities.builtAt ?? "unknown"}`);
+        }
+        resolve(capabilities);
+      };
+
+      const onMessage = (data: WebSocket.RawData): void => {
+        let msg: BridgeResponse;
+        try {
+          msg = JSON.parse(data.toString()) as BridgeResponse;
+        } catch {
+          return;
+        }
+        if (msg.id !== id) return;
+        if (msg.error || !msg.result) {
+          // -32601 from a bridge that has never heard of the handshake. That
+          // silence is itself the answer: it predates the protocol version.
+          finish(LEGACY_CAPABILITIES);
+          return;
+        }
+        const result = msg.result as Partial<BridgeCapabilities>;
+        finish({
+          ...result,
+          protocolVersion: typeof result.protocolVersion === "number" ? result.protocolVersion : 1,
+          legacy: false,
+        });
+      };
+
+      const timer = setTimeout(() => finish(LEGACY_CAPABILITIES), timeoutMs);
+
+      ws.on("message", onMessage);
+      ws.send(JSON.stringify({ id, method: "get_bridge_capabilities", params: {} }), (err) => {
+        if (err) finish(LEGACY_CAPABILITIES);
+      });
+    });
+  }
+
   private setupListeners(ws: WebSocket): void {
     ws.on("message", (data) => {
       try {
@@ -337,7 +487,16 @@ export class EditorBridge implements IBridge {
         clearTimeout(pending.timer);
 
         if (msg.error) {
-          pending.reject(new McpError(ErrorCode.BRIDGE_ERROR, `Bridge error: ${msg.error.message}`));
+          // #821: -32601 against an older plugin used to read as a typo. Say
+          // which side is behind, and name both versions.
+          const mismatch =
+            msg.error.code === -32601 ? describeProtocolMismatch(this.capabilities, pending.method) : null;
+          pending.reject(
+            new McpError(
+              ErrorCode.BRIDGE_ERROR,
+              mismatch ? `Bridge error: ${msg.error.message}. ${mismatch}` : `Bridge error: ${msg.error.message}`,
+            ),
+          );
         } else {
           pending.resolve(msg.result);
         }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -5,30 +5,93 @@ import { McpError, ErrorCode } from "./errors.js";
 import { debug, warn } from "./log.js";
 import { DEFAULT_BRIDGE_PORT, deriveProjectPort } from "./port.js";
 
+/** The record the running bridge publishes for this project. */
+export interface BridgeLockfile {
+  port: number;
+  pid?: number;
+  startedAt?: string;
+  /** Identifies the server object that wrote this, across pid recycling. */
+  instanceId?: string;
+  status?: string;
+  apiVersion?: number;
+  handlerApiVersion?: number;
+}
+
+/** What the bridge leaves behind when the editor started but the bridge did not. */
+export interface BridgeErrorRecord {
+  status?: string;
+  pid?: number;
+  failedAt?: string;
+  firstPortTried?: number;
+  lastPortTried?: number;
+  errorCode?: number;
+  detail?: string;
+}
+
+function readJsonFile<T>(file: string): T | null {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when a process with this id exists. Signal 0 performs the permission
+ * check without delivering anything; EPERM means it exists but belongs to
+ * someone else, which still counts as alive.
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
 // #492: per-project port lockfile published by the bridge plugin. When the
 // default port (9877) is taken by another editor, the plugin walks up and
 // publishes the actual bound port here. The client reads this before
 // falling back to the default port so a second editor finds the right one.
-export function readBridgeLockfile(
-  uprojectPath: string | null,
-): { port: number; pid: number; startedAt?: string; apiVersion?: number } | null {
+export function readBridgeLockfile(uprojectPath: string | null): BridgeLockfile | null {
   if (!uprojectPath) return null;
-  const lockfile = path.join(
-    path.dirname(uprojectPath),
-    "Saved",
-    "UE_MCP_Bridge",
-    "port.json",
-  );
-  try {
-    const raw = fs.readFileSync(lockfile, "utf8");
-    const parsed = JSON.parse(raw);
-    if (typeof parsed?.port === "number" && parsed.port > 0 && parsed.port < 65536) {
-      return parsed;
-    }
-  } catch {
-    // Missing or unreadable - fall back to default.
+  return readBridgeLockfileForDir(path.dirname(uprojectPath));
+}
+
+/** Same record, for callers that hold the project directory rather than the .uproject. */
+export function readBridgeLockfileForDir(projectDir: string | null | undefined): BridgeLockfile | null {
+  if (!projectDir) return null;
+  const parsed = readJsonFile<BridgeLockfile>(path.join(projectDir, "Saved", "UE_MCP_Bridge", "port.json"));
+  if (!parsed || typeof parsed.port !== "number" || parsed.port <= 0 || parsed.port >= 65536) {
+    return null;
   }
-  return null;
+
+  // #821: the pid was written and never read. A record left by an editor that
+  // crashed sent the client at a port nothing is listening on, and the
+  // resulting failure named the wrong problem. A recycled pid can still read
+  // as alive, which the connect attempt then settles.
+  if (typeof parsed.pid === "number" && parsed.pid > 0 && !isProcessAlive(parsed.pid)) {
+    debug("bridge", `ignoring stale bridge lockfile: process ${parsed.pid} is gone`);
+    return null;
+  }
+  return parsed;
+}
+
+/**
+ * #821: read the record the bridge writes when the editor came up but the
+ * bridge could not bind. Without it, "editor alive, bridge dead" was
+ * indistinguishable from "no editor", and the client said the wrong thing.
+ */
+export function readBridgeErrorRecord(uprojectPath: string | null): BridgeErrorRecord | null {
+  if (!uprojectPath) return null;
+  const parsed = readJsonFile<BridgeErrorRecord>(
+    path.join(path.dirname(uprojectPath), "Saved", "UE_MCP_Bridge", "bridge-error.json"),
+  );
+  if (!parsed || parsed.status !== "bind-failed") return null;
+  // A record from an editor that has since exited describes nothing current.
+  if (typeof parsed.pid === "number" && parsed.pid > 0 && !isProcessAlive(parsed.pid)) return null;
+  return parsed;
 }
 
 export interface BridgeResponse {
@@ -155,10 +218,19 @@ export class EditorBridge implements IBridge {
 
     const url = `ws://${this.host}:${this.port}`;
 
+    // #821: an editor whose bridge failed to bind is running and unreachable at
+    // the same time. It leaves a record saying so, and quoting it here is the
+    // difference between "start the editor" and "the editor is up, its bridge
+    // is not".
+    const explainFailure = (base: string): string => {
+      const failed = readBridgeErrorRecord(this.projectPathForLockfile);
+      return failed?.detail ? `${base}. ${failed.detail}` : base;
+    };
+
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         ws.terminate();
-        reject(new McpError(ErrorCode.BRIDGE_TIMEOUT, `Connection to editor bridge timed out (${url})`));
+        reject(new McpError(ErrorCode.BRIDGE_TIMEOUT, explainFailure(`Connection to editor bridge timed out (${url})`)));
       }, timeoutMs);
 
       const ws = new WebSocket(url);
@@ -175,7 +247,7 @@ export class EditorBridge implements IBridge {
         reject(
           new McpError(
             ErrorCode.NOT_CONNECTED,
-            `Failed to connect to editor bridge at ${url}: ${err.message}`,
+            explainFailure(`Failed to connect to editor bridge at ${url}: ${err.message}`),
           ),
         );
       });

--- a/src/editor-control.ts
+++ b/src/editor-control.ts
@@ -7,6 +7,7 @@ import type { ProjectContext } from "./project.js";
 import { findEngineInstall } from "./deployer.js";
 import { invalidatePluginFreshness } from "./plugin-freshness.js";
 import { findInteractiveEditors, readEngineState, readEngineSnapshot, readLogState, type EngineState } from "./engine-observer.js";
+import { readBridgeLockfileForDir } from "./bridge.js";
 import { startProgress } from "./ui/progress.js";
 import type { ProgressFn } from "./types.js";
 
@@ -546,15 +547,14 @@ function uprojectInDir(projectDir?: string): string | null {
   }
 }
 
-/** Read the project's live bridge port from its lockfile, else env, else 9877. */
+/**
+ * Read the project's live bridge port from its lockfile, else env, else 9877.
+ * Goes through the shared reader so a record left by a dead editor is skipped
+ * here too, rather than sending a stop or a wait at a port nobody is on.
+ */
 function resolveBridgePort(projectDir?: string): number {
-  if (projectDir) {
-    try {
-      const raw = fs.readFileSync(path.join(projectDir, "Saved", "UE_MCP_Bridge", "port.json"), "utf-8");
-      const p = JSON.parse(raw) as { port?: unknown };
-      if (typeof p.port === "number" && p.port > 0) return p.port;
-    } catch { /* fall through to defaults */ }
-  }
+  const lockfile = readBridgeLockfileForDir(projectDir);
+  if (lockfile) return lockfile.port;
   const env = Number(process.env.UE_MCP_PORT);
   return Number.isFinite(env) && env > 0 ? env : 9877;
 }

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -7,6 +7,7 @@ import { deploy, deploySummary, findEngineInstall } from "../deployer.js";
 import { resolveConfigPath, findIniFiles, parseIni, buildTagTree } from "../config-parser.js";
 import { parseHeader, collectFiles, findSourceRoots, resolveModuleDir } from "../cpp-parser.js";
 import { readDeployedBridgeApiVersion } from "../plugin/bridge-api.js";
+import { CLIENT_PROTOCOL_VERSION, describeProtocolMismatch } from "../bridge.js";
 import { searchTools, type ToolSearchHit } from "../tool-search.js";
 import { getWorkarounds } from "../workaround-tracker.js";
 import { readLogState, readEngineSnapshot } from "../engine-observer.js";
@@ -105,7 +106,23 @@ export const projectTool: ToolDef = categoryTool(
           // Bridge ABI version of the deployed plugin in this project.
           // Plugins declaring nativeModule.minBridgeApi compare against
           // this number; older bridges refuse newer plugins.
+          //
+          // Read from the header on disk, which describes the source, not the
+          // loaded binary. bridgeProtocol below comes from the running plugin
+          // itself and is the one to trust when the two disagree.
           bridgeApiVersion: bridgeApiVersion ?? undefined,
+          // #821: what the connected plugin said it was, and whether that
+          // matches the client. A mismatch here is the reason behind an
+          // "Unknown method" on an action the schema advertises.
+          bridgeProtocol: ctx.bridge.capabilities
+            ? {
+                plugin: ctx.bridge.capabilities.protocolVersion,
+                client: CLIENT_PROTOCOL_VERSION,
+                builtAt: ctx.bridge.capabilities.builtAt,
+                actionCount: ctx.bridge.capabilities.actionCount,
+                mismatch: describeProtocolMismatch(ctx.bridge.capabilities) ?? undefined,
+              }
+            : undefined,
           // Pre-built sequences for this project. If the user's request
           // matches a flow's name/description, prefer flow(action="run")
           // over composing the sequence by hand. See SERVER_INSTRUCTIONS.

--- a/tests/unit/bridge.test.ts
+++ b/tests/unit/bridge.test.ts
@@ -76,6 +76,25 @@ describe("EditorBridge connection handling", () => {
     }
   });
 
+  it("repeats the close code and reason when the bridge refuses a message", async () => {
+    const server = await withBridgeServer((_request, socket) => {
+      // What the bridge does when a message exceeds its size bound.
+      socket.close(1009, "message of 70000000 bytes exceeds the 67108864 byte bridge limit");
+    });
+
+    const { EditorBridge } = await import("../../src/bridge.js");
+    const bridge = new EditorBridge("127.0.0.1", server.port);
+
+    try {
+      await expect(bridge.call("oversized", {}, 2000)).rejects.toThrow(
+        /code 1009.*exceeds the 67108864 byte bridge limit/,
+      );
+    } finally {
+      bridge.disconnect();
+      await server.close();
+    }
+  });
+
   it("terminates a timed-out socket so the next call can reconnect", async () => {
     const server = await withBridgeServer((request, socket) => {
       if (request.method === "hang") return;

--- a/tests/unit/bridge.test.ts
+++ b/tests/unit/bridge.test.ts
@@ -1,7 +1,21 @@
 import { once } from "node:events";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { AddressInfo } from "node:net";
 import { WebSocketServer } from "ws";
 import { describe, expect, it } from "vitest";
+
+/** A throwaway project directory with a Saved/UE_MCP_Bridge folder. */
+function makeProjectDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-bridge-"));
+  fs.mkdirSync(path.join(dir, "Saved", "UE_MCP_Bridge"), { recursive: true });
+  return dir;
+}
+
+function writeBridgeRecord(dir: string, name: string, body: unknown): void {
+  fs.writeFileSync(path.join(dir, "Saved", "UE_MCP_Bridge", name), JSON.stringify(body));
+}
 
 async function withBridgeServer(
   onRequest: (request: Record<string, unknown>, socket: import("ws").WebSocket) => void,
@@ -114,5 +128,37 @@ describe("EditorBridge connection handling", () => {
       bridge.disconnect();
       await server.close();
     }
+  });
+});
+
+describe("bridge state records", () => {
+  it("ignores a port lockfile whose editor process is gone", async () => {
+    const dir = makeProjectDir();
+    const { readBridgeLockfileForDir } = await import("../../src/bridge.js");
+
+    writeBridgeRecord(dir, "port.json", { port: 51234, pid: 0x7ffffffe, instanceId: "dead-instance" });
+    expect(readBridgeLockfileForDir(dir)).toBeNull();
+
+    writeBridgeRecord(dir, "port.json", { port: 51234, pid: process.pid, instanceId: "live-instance" });
+    expect(readBridgeLockfileForDir(dir)?.port).toBe(51234);
+    expect(readBridgeLockfileForDir(dir)?.instanceId).toBe("live-instance");
+  });
+
+  it("reports a bridge that failed to bind while its editor is still running", async () => {
+    const dir = makeProjectDir();
+    const uproject = path.join(dir, "Sample.uproject");
+    const { readBridgeErrorRecord } = await import("../../src/bridge.js");
+
+    writeBridgeRecord(dir, "bridge-error.json", {
+      status: "bind-failed",
+      pid: process.pid,
+      firstPortTried: 49200,
+      lastPortTried: 49250,
+      detail: "The editor is running but its MCP bridge could not bind a port in [49200, 49250].",
+    });
+    expect(readBridgeErrorRecord(uproject)?.detail).toContain("could not bind a port");
+
+    writeBridgeRecord(dir, "bridge-error.json", { status: "bind-failed", pid: 0x7ffffffe });
+    expect(readBridgeErrorRecord(uproject)).toBeNull();
   });
 });

--- a/tests/unit/bridge.test.ts
+++ b/tests/unit/bridge.test.ts
@@ -17,8 +17,19 @@ function writeBridgeRecord(dir: string, name: string, body: unknown): void {
   fs.writeFileSync(path.join(dir, "Saved", "UE_MCP_Bridge", name), JSON.stringify(body));
 }
 
+/** What a current bridge answers the capability handshake with. */
+const DEFAULT_CAPABILITIES = {
+  protocolVersion: 2,
+  handlerApiVersion: 1,
+  builtAt: "Aug  5 2026 09 14 22",
+  actionCount: 3,
+  actions: ["first", "second", "ping"],
+};
+
 async function withBridgeServer(
   onRequest: (request: Record<string, unknown>, socket: import("ws").WebSocket) => void,
+  /** null makes the server answer the handshake the way a pre-handshake plugin does. */
+  capabilities: Record<string, unknown> | null = DEFAULT_CAPABILITIES,
 ): Promise<{
   close: () => Promise<void>;
   connectionCount: () => number;
@@ -30,7 +41,18 @@ async function withBridgeServer(
   server.on("connection", (socket) => {
     connections += 1;
     socket.on("message", (data) => {
-      onRequest(JSON.parse(data.toString()) as Record<string, unknown>, socket);
+      const request = JSON.parse(data.toString()) as Record<string, unknown>;
+      if (request.method === "get_bridge_capabilities") {
+        socket.send(
+          JSON.stringify(
+            capabilities
+              ? { id: request.id, result: capabilities }
+              : { id: request.id, error: { code: -32601, message: "Unknown method: get_bridge_capabilities" } },
+          ),
+        );
+        return;
+      }
+      onRequest(request, socket);
     });
   });
 
@@ -160,5 +182,66 @@ describe("bridge state records", () => {
 
     writeBridgeRecord(dir, "bridge-error.json", { status: "bind-failed", pid: 0x7ffffffe });
     expect(readBridgeErrorRecord(uproject)).toBeNull();
+  });
+});
+
+describe("bridge capability handshake", () => {
+  it("records what the bridge says it is on connect", async () => {
+    const server = await withBridgeServer((request, socket) => {
+      socket.send(JSON.stringify({ id: request.id, result: "ok" }));
+    });
+
+    const { EditorBridge } = await import("../../src/bridge.js");
+    const bridge = new EditorBridge("127.0.0.1", server.port);
+
+    try {
+      await bridge.call("ping", {}, 1000);
+      expect(bridge.capabilities?.protocolVersion).toBe(2);
+      expect(bridge.capabilities?.legacy).toBe(false);
+      expect(bridge.capabilities?.builtAt).toBe("Aug  5 2026 09 14 22");
+    } finally {
+      bridge.disconnect();
+      await server.close();
+    }
+  });
+
+  it("names both versions when an older plugin does not know a method", async () => {
+    const server = await withBridgeServer(
+      (request, socket) => {
+        socket.send(JSON.stringify({ id: request.id, error: { code: -32601, message: "Unknown method: set_water_body_property" } }));
+      },
+      null, // a plugin built before the handshake existed
+    );
+
+    const { EditorBridge, CLIENT_PROTOCOL_VERSION } = await import("../../src/bridge.js");
+    const bridge = new EditorBridge("127.0.0.1", server.port);
+
+    try {
+      const failure = await bridge.call("set_water_body_property", {}, 1000).catch((e: Error) => e.message);
+      expect(bridge.capabilities?.legacy).toBe(true);
+      expect(failure).toContain("Unknown method: set_water_body_property");
+      expect(failure).toContain("protocol version 1");
+      expect(failure).toContain(`version ${CLIENT_PROTOCOL_VERSION}`);
+      expect(failure).toContain("npx ue-mcp update");
+    } finally {
+      bridge.disconnect();
+      await server.close();
+    }
+  });
+
+  it("tells the user to update the package when the plugin is newer", async () => {
+    const { describeProtocolMismatch, CLIENT_PROTOCOL_VERSION } = await import("../../src/bridge.js");
+    const message = describeProtocolMismatch({
+      protocolVersion: CLIENT_PROTOCOL_VERSION + 1,
+      legacy: false,
+      builtAt: "Sep 1 2026 12 00 00",
+    });
+    expect(message).toContain(`protocol version ${CLIENT_PROTOCOL_VERSION + 1}`);
+    expect(message).toContain("ue-mcp@latest");
+  });
+
+  it("says nothing when the versions agree", async () => {
+    const { describeProtocolMismatch, CLIENT_PROTOCOL_VERSION } = await import("../../src/bridge.js");
+    expect(describeProtocolMismatch({ protocolVersion: CLIENT_PROTOCOL_VERSION, legacy: false })).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #821.

Every defect the issue enumerates, in eleven commits, one per defect.

## What changed

**1. One frame per recv, remainder discarded.** The read path treated a single TCP read as a single message. Anything past the first frame in a read was dropped, and a frame that did not fit in one read was dropped entirely. Since the client keeps several calls in flight on one socket and terminates it when any one times out, one lost frame took the session with it. The reader now keeps a per-connection buffer, decodes every whole frame it holds before reading again, and joins continuation frames into one message.

**2. 64-bit payload length folded into int32.** The extended length now accumulates in 64 bits, rejects a set high bit, and is checked against the bound before any append. Per-message and per-buffer sizes are bounded at 64 MiB; exceeding either closes with `1009` naming the size and the limit, and the client repeats that code and reason instead of reporting a generic lost connection.

**3. Opcodes ignored, close frames answered as text.** Close frames get their status code echoed and end the read loop, pings get a pong with the same payload, pongs are accepted and ignored. Shutdown closes with `1001` going away rather than severing the socket.

**4. HTTP upgrade read in one recv, over-read, unvalidated.** The request is read through its blank line under one deadline and one size bound, exactly the header bytes are converted (the old `ANSI_TO_TCHAR` on an unterminated socket buffer was an out of bounds read on every upgrade), and pipelined bytes seed the frame reader instead of being discarded. Method, HTTP version, `Upgrade`, `Connection`, `Sec-WebSocket-Version` and a 16-byte `Sec-WebSocket-Key` are all checked before a `101`, and a refusal answers with an HTTP status and a sentence.

**5. SO_REUSEADDR defeating the collision walk on Windows.** Windows now claims the port with `SO_EXCLUSIVEADDRUSE`, so a second editor of the same project fails its bind and the walk proceeds. POSIX keeps `SO_REUSEADDR`, where it cannot take a live listener's port.

**6. Lockfile with no ownership, written non-atomically.** The record carries an `instanceId` and only that instance removes it, so a failed start can no longer delete a live editor's record. It is published by rename, so a polling client cannot read a torn document. A bind failure now writes `bridge-error.json` (its own path, never the live record) with the port range tried and the socket error.

**7. pid written and never read.** Both readers skip a record whose process is gone, so a crashed editor no longer sends the next session at a dead port.

**8. Connection threads outliving the server object.** Connections are counted by the accept loop before their thread exists and released by the thread on its way out; shutdown waits for the count to reach zero before the module frees the server. Connections notice the stop flag at the end of their current select and close cleanly; only then does shutdown half-close sockets, and only after a further wait does it give up and log. `Shutdown()` no longer early-returns on `bIsRunning`, which on the bind-failure path meant the accept thread was never joined. The game-thread executor waits in slices and abandons them once shutdown begins, since teardown runs on the game thread and a queued handler will never execute.

**9. Any localhost origin reaching execute_python.** Every upgrade carrying an `Origin` header is refused with a 403. A browser cannot suppress or forge it; native clients omit it.

**10. No capability negotiation.** The bridge answers `get_bridge_capabilities` on the socket thread, reporting the wire protocol version, handler ABI version, the binary's compile timestamp, engine version, instance identity, and the action list the running binary registered. The client asks on every connect, off the normal call path so a slow answer cannot terminate the socket and an absent one is read for what it is: a plugin predating the handshake, recorded as protocol version 1. A mismatch is stated once at connect, repeated on any unknown-method answer naming both versions and the method, and reported under `bridgeProtocol` in `project(get_status)` beside the header-derived number so the two can be seen to disagree.

## Ownership, made explicit

`FMCPClientSocket` is the sole owner of an accepted socket and closes it exactly once, replacing a close call copied down every early return. `FMCPConnectionRelease` releases the accept loop's record before that close, under the lock that shutdown holds, so a handle can never be half-closed after the OS has reused it.

## Verification

- `npx tsc --noEmit` clean.
- `npx vitest run tests/unit`: 34 files, 330 tests, all passing. Six new tests cover the close code and reason surfacing, lockfile staleness, the bind-failure record, and the handshake in both directions plus the legacy case.
- Smoke tests need a live editor and were not run here.

**Needs a C++ build.** No new source files were added, so no UBT rescan is required, but the plugin has to be compiled and the editor restarted before the new bridge is loaded. Do not merge before that build passes.
