### PR TITLE
docs: the feedback signing endpoint is live, it just has no key installed

### DIFF
--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -148,7 +148,7 @@ Anonymous reports are signed by a hosted service rather than by this package, so
 
 If that service is unreachable or turned off, nothing is lost: the call returns the approved body as a prefilled "new issue" URL you can open in one click, and `author="user"` keeps working independently.
 
-**Status:** the hosted endpoint is not deployed yet, so `author="bot"` takes the prefilled-URL path on every call today. See [#461](https://github.com/db-lyon/ue-mcp/issues/461) for the design and the reason the key left the package first. `author="user"`, the default, posts directly and is unaffected.
+**Status:** the endpoint is live but has no signing key installed yet, so it answers `signing_not_configured` and `author="bot"` takes the prefilled-URL path on every call today. See [#461](https://github.com/db-lyon/ue-mcp/issues/461) for the design and the reason the key left the package first. `author="user"`, the default, posts directly and is unaffected.
 
 ### Authorizing as your GitHub user
 
@@ -238,7 +238,7 @@ The hook handler self-gates: if `feedback` is in `ue-mcp.yml`'s `ue-mcp.disable[
 - **The agent is the adversary for the consent step.** The MCP elicitation prompt is rendered by your client, and the response comes back to the server over the protocol — the agent has no IPC to forge an approval.
 - **The redaction passes are non-bypassable.** They run before the body reaches the elicitation prompt or `submitFeedback`, and the agent never sees the pre-scrubbed bytes.
 - **Routing cannot aim a report at an arbitrary repo.** The `repo` parameter is accepted only for ue-mcp core or a repo a registered plugin owns, and the `Tracker` field on the approval prompt only accepts the two values it offered. There is no path from "an agent wrote a string" to "an issue on any GitHub project".
-- **The package ships no credentials.** `author="user"` posts with a token you authorized yourself through GitHub's device flow, stored under `~/.ue-mcp/`. `author="bot"` posts through a hosted signing service (`POST https://plugins.ue-mcp.com/api/feedback`) whose contract is to hold the `ue-mcp-feedback` App key server-side, apply per-caller rate limits, re-run the redaction pass, and only open issues on ue-mcp core or the tracker of a published plugin. Until that endpoint is deployed the anonymous path hands back a prefilled issue URL instead of posting. Either way there is no key inside the package to extract.
+- **The package ships no credentials.** `author="user"` posts with a token you authorized yourself through GitHub's device flow, stored under `~/.ue-mcp/`. `author="bot"` posts through a hosted signing service (`POST https://plugins.ue-mcp.com/api/feedback`) whose contract is to hold the `ue-mcp-feedback` App key server-side, apply per-caller rate limits, re-run the redaction pass, and only open issues on ue-mcp core or the tracker of a published plugin. Until a signing key is installed on that deployment the anonymous path hands back a prefilled issue URL instead of posting. Either way there is no key inside the package to extract.
 - **Disable the category if you don't want it available.** Add `"feedback"` to `ue-mcp.yml`'s `ue-mcp.disable[]` and the tool is not registered with the MCP server. The category checkbox lives in the **Agent behavior** section of `npx ue-mcp init` (default unchecked on fresh installs).
 
 ## For maintainers


### PR DESCRIPTION
Correction to #849, which claimed the hosted feedback signing endpoint was not deployed. It is.

```
$ curl -s -i -X POST -H 'Content-Type: application/json' \
    -d '{"title":"probe","body":"probe","repo":"db-lyon/ue-mcp"}' \
    https://plugins.ue-mcp.com/api/feedback
HTTP/2 503
{"error":"Anonymous feedback signing is not configured on this deployment.","code":"signing_not_configured"}
```

That is the endpoint's own "no key on this deploy" branch, and it is the exact case `submitAsBot` maps to `bot_unavailable` with `code: "not_configured"`, so `author="bot"` hands back the prefilled issue URL rather than failing.

The docs now say the remaining step is installing a signing key on the deployment, not building a service.

Docs only. `npx tsc --noEmit` clean, `npx vitest run tests/unit` 533 passed. No `plugin/` changes.
