### PR TITLE
Multi-editor: per-session state, CLI targeting, and a two-bridge test tier (#817)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,19 @@ jobs:
       - name: Unit tests
         run: npm run test:unit
 
+      - name: Multi-editor tier
+        # Two bridges on two loopback sockets, driven from one test process
+        # (#817, plan item 7.1). This gates merges on the routing property that
+        # multi-editor exists for: a call addressed to one editor arrives at
+        # that editor and at no other.
+        #
+        # The engine-dependent half of plan item 7.2 (the golden diff and the
+        # lifecycle matrix against a live editor) is NOT here and cannot be:
+        # these runners are ubuntu-latest with no Unreal install, so there is
+        # no editor to start and no second one to address. Everything above the
+        # handler is real; only the engine behind it is stubbed.
+        run: npm run test:multi-editor
+
       - name: Audit (high+ only, production deps)
         run: npm audit --omit=dev --audit-level=high
         continue-on-error: false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,18 @@ Calls with no `editor` run in the active session, which is the first project on 
 
 Multi-editor needs a bridge built from the current plugin source in each project involved. A project whose bridge is missing or stale is still registered and still startable; `project(action="list_editors")` reports it.
 
+**The CLI takes a target too.** Every one-shot subcommand accepts `--editor <name-or-path>`, resolved as a session name first and a project path second:
+
+```bash
+npx ue-mcp deploy --editor Beta
+npx ue-mcp build --editor Beta
+npx ue-mcp doctor --editor Beta
+npx ue-mcp context lean --editor Beta
+npx ue-mcp feedback list --editor Beta
+```
+
+The name is the one `project(action="list_editors")` reports, read back from the argv in your MCP client config, so a name means the same editor on the command line that it means in a tool call. Without the flag every subcommand behaves exactly as it did: positional path first, then the project in the current directory.
+
 ## Project Configuration (`ue-mcp.yml`)
 
 Project config lives in `ue-mcp.yml` next to your `.uproject`, tracked in git so every collaborator shares the same surface. `npx ue-mcp init` scaffolds and maintains it.
@@ -303,6 +315,8 @@ The C++ bridge plugin enables these UE plugins (adding them to `.uproject` if mi
 | `npx ue-mcp plugin uninstall <name>` | Inverse of install. |
 | `npx ue-mcp plugin create <name>` | Scaffold a new plugin package. See [Plugins](plugins.md). |
 | `npx ue-mcp context [full\|lean\|micro]` | Read or set the [context strategy](#context-strategy-full-lean-micro) in `ue-mcp.yml`. No argument prints the current strategy. |
+
+Every subcommand above also accepts `--editor <name-or-path>` to pick which of several editors it acts on. See [Several Editors From One Server](#several-editors-from-one-server).
 
 ## Editor Lifecycle
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "test:unit": "vitest run tests/unit",
+    "test:multi-editor": "vitest run tests/multi-editor",
     "audit:docs": "node scripts/audit-docs.mjs && node scripts/audit-params.mjs",
     "audit:handlers": "node scripts/audit-handlers.mjs",
     "audit": "npm run audit:docs && npm run audit:handlers",

--- a/scripts/bridge-target.mjs
+++ b/scripts/bridge-target.mjs
@@ -128,7 +128,16 @@ export function isProcessAlive(pid) {
  * guard, which runs after the connection is up.
  */
 export function bridgePortCandidates(options = {}) {
-  const { explicitPort = null, lockfile = readPortLockfile() } = options;
+  // `projectDir` names a project other than this repo's test project. It is
+  // only ever passed by a harness driving more than one editor (#817); every
+  // ordinary caller omits it and gets exactly the behaviour it always had.
+  const { explicitPort = null, projectDir = null } = options;
+  const targetDir = projectDir ?? TEST_PROJECT_DIR;
+  const lockfile = options.lockfile ?? readPortLockfile(
+    projectDir
+      ? path.join(projectDir, "Saved", "UE_MCP_Bridge", "port.json")
+      : TEST_PORT_LOCKFILE,
+  );
 
   const candidates = [];
   const add = (port, source) => {
@@ -143,7 +152,7 @@ export function bridgePortCandidates(options = {}) {
   }
 
   add(lockfile.port, "lockfile");
-  add(deriveProjectPort(TEST_PROJECT_DIR), "derived from project path");
+  add(deriveProjectPort(targetDir), "derived from project path");
   add(LEGACY_BRIDGE_PORT, "legacy fixed port");
   return { candidates, lockfile };
 }

--- a/src/build-cli.ts
+++ b/src/build-cli.ts
@@ -2,6 +2,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { buildProject } from "./editor-control.js";
+import { takeEditorTarget, EditorFlagError } from "./editor-flag.js";
 
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
@@ -10,7 +11,16 @@ const RED = "\x1b[31m";
 const CYAN = "\x1b[36m";
 
 function findUProject(): string | null {
-  const arg = process.argv[2];
+  // --editor names one of the editors this server drives; it wins over the
+  // positional, which in turn wins over cwd.
+  let arg: string | undefined;
+  try {
+    const target = takeEditorTarget(process.argv.slice(2));
+    arg = target.projectPath ?? target.rest[0];
+  } catch (e) {
+    console.log(`  ${RED}${e instanceof EditorFlagError ? e.message : String(e)}${RESET}`);
+    process.exit(1);
+  }
   if (arg && arg.endsWith(".uproject")) return path.resolve(arg);
   if (arg && fs.existsSync(arg) && fs.statSync(arg).isDirectory()) {
     const found = fs.readdirSync(arg).filter((f) => f.endsWith(".uproject"));

--- a/src/context-cli.ts
+++ b/src/context-cli.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import yaml from "js-yaml";
 import { dumpYaml } from "./yaml-dump.js";
+import { takeEditorTarget, EditorFlagError } from "./editor-flag.js";
 
 /**
  * `ue-mcp context [full|lean|micro|status] [project]` - read or set the context
@@ -34,20 +35,33 @@ function printHelp(): void {
     ue-mcp context lean            action names visible, descriptions on demand
     ue-mcp context micro           one gateway tool fronts everything (smallest)
 
-  A project path may be passed as the last argument; otherwise the .uproject in
-  the current directory is used. Restart your MCP client (/mcp in Claude Code)
-  after changing the strategy.
+  A project path may be passed as the last argument, or an editor named with
+  --editor <name-or-path>; otherwise the .uproject in the current directory is
+  used. Restart your MCP client (/mcp in Claude Code) after changing the
+  strategy.
 `);
 }
 
 function parseArgs(): { action: string; projectArg?: string; help: boolean } {
-  const args = process.argv.slice(2);
-  if (args.some((a) => a === "-h" || a === "--help" || a === "help")) {
+  const argv = process.argv.slice(2);
+  if (argv.some((a) => a === "-h" || a === "--help" || a === "help")) {
     return { action: "status", help: true };
   }
-  const positional = args.filter((a) => !a.startsWith("-"));
+  // Flags were dropped wholesale here, so --editor would have been silently
+  // discarded and the command would have retargeted cwd. Take it first, then
+  // keep the original positional-only behaviour for everything else.
+  let target: { projectPath?: string; rest: string[] };
+  try {
+    target = takeEditorTarget(argv);
+  } catch (e) {
+    console.log(`
+  ${RED}${e instanceof EditorFlagError ? e.message : String(e)}${RESET}
+`);
+    process.exit(1);
+  }
+  const positional = target.rest.filter((a) => !a.startsWith("-"));
   let action: string | undefined;
-  let projectArg: string | undefined;
+  let projectArg: string | undefined = target.projectPath;
   for (const a of positional) {
     if (!action && ACTIONS.has(a.toLowerCase())) action = a.toLowerCase();
     else if (!projectArg) projectArg = a;

--- a/src/deploy-cli.ts
+++ b/src/deploy-cli.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { ProjectContext } from "./project.js";
 import { deploy, deploySummary } from "./deployer.js";
 import { installSkills } from "./skills.js";
+import { takeEditorTarget, EditorFlagError } from "./editor-flag.js";
 
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
@@ -20,8 +21,15 @@ async function deployCmd() {
   console.log(`  ${BOLD}${CYAN}UE-MCP Deploy${RESET}`);
   console.log("");
 
-  // Find project: CLI arg, then cwd
-  let uprojectPath = process.argv[2] || "";
+  // Find project: --editor, then CLI arg, then cwd.
+  let target: { projectPath?: string; rest: string[] };
+  try {
+    target = takeEditorTarget(process.argv.slice(2));
+  } catch (e) {
+    fail(e instanceof EditorFlagError ? e.message : String(e));
+    process.exit(1);
+  }
+  let uprojectPath = target.projectPath || target.rest[0] || "";
 
   if (!uprojectPath) {
     const cwd = process.cwd();

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -11,6 +11,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { execSync } from "node:child_process";
 import { createRequire } from "node:module";
+import { takeEditorTarget, EditorFlagError } from "./editor-flag.js";
 
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
@@ -26,7 +27,16 @@ export interface DoctorReport {
   npmGlobal: { version: string | null; dir: string | null };
   localShadow: { version: string; dir: string } | null; // nearest node_modules/ue-mcp from cwd up
   effectiveNpx: string | null;    // what `npx ue-mcp` would run: shadow ?? global
-  runningServers: Array<{ pid: number; version: string | null; script: string; project: string | null; servesTarget: boolean }>;
+  runningServers: Array<{
+    pid: number;
+    version: string | null;
+    script: string;
+    /** First project positional; the one a single-editor server drives. */
+    project: string | null;
+    /** Every project positional, so a multi-editor server reports all of them (#817). */
+    projects?: string[];
+    servesTarget: boolean;
+  }>;
   targetProjectDir: string | null;   // dir of the .uproject doctor is reporting for
   bridgePlugin: { version: string | null; project: string } | null;
   bareNpxConfigs: string[];       // .mcp.json paths using bare `npx ue-mcp`
@@ -113,15 +123,25 @@ function versionForScript(scriptPath: string): string | null {
 const NON_SERVER_ARGS = new Set([
   "doctor", "update", "deploy", "build", "init", "hook", "uninstall-hooks",
   "auth", "feedback", "resolve", "plugin", "version", "--version", "-v", "--help", "-h", "help",
+  // These three were missing, so `ue-mcp context lean`, `ue-mcp login` and
+  // `ue-mcp logout` each parsed as a running server whose project was the
+  // subcommand's own name.
+  "context", "login", "logout",
 ]);
 
 /**
- * Parse a `node .../ue-mcp/dist/index.js <project>` command line into the script
- * path and the project argument. Returns null when the command line is not a
- * running server (a flag/subcommand invocation, or no ue-mcp index.js). Exported
- * for tests. (#550)
+ * Parse a `node .../ue-mcp/dist/index.js <project> [<project>...]` command line
+ * into the script path and every project argument. Returns null when the
+ * command line is not a running server (a flag/subcommand invocation, or no
+ * ue-mcp index.js). Exported for tests. (#550, #817)
+ *
+ * `project` is the first positional and is what a single-editor report reads.
+ * `projects` is all of them, so a server driving several editors is reported
+ * as driving several rather than as driving the first one only.
  */
-export function parseServerInvocation(cmd: string): { script: string; project: string | null } | null {
+export function parseServerInvocation(
+  cmd: string,
+): { script: string; project: string | null; projects: string[] } | null {
   const scriptMatch = cmd.match(/([A-Za-z]:[\\/].*?|\/.*?)ue-mcp[\\/]dist[\\/]index\.js/i);
   if (!scriptMatch) return null;
   const script = path.normalize((scriptMatch[1] ?? "") + path.join("ue-mcp", "dist", "index.js"));
@@ -129,17 +149,37 @@ export function parseServerInvocation(cmd: string): { script: string; project: s
   // First argument after index.js decides server-vs-CLI. The char right after
   // "index.js" may be the script path's own closing quote - drop it first.
   const idx = cmd.toLowerCase().indexOf("index.js");
-  let rest = cmd.slice(idx + "index.js".length).replace(/^"/, "").trim();
-  let firstArg = "";
-  if (rest.startsWith('"')) {
-    const close = rest.indexOf('"', 1);
-    firstArg = close > 0 ? rest.slice(1, close) : rest.slice(1);
-  } else {
-    firstArg = rest.split(/\s+/)[0] ?? "";
-  }
-  firstArg = firstArg.trim();
+  const rest = cmd.slice(idx + "index.js".length).replace(/^"/, "").trim();
+  const tokens = tokenizeArgs(rest);
+  const firstArg = (tokens[0] ?? "").trim();
   if (!firstArg || firstArg.startsWith("-") || NON_SERVER_ARGS.has(firstArg)) return null;
-  return { script: script.replace(/\\/g, "/"), project: firstArg };
+  const projects = tokens.filter((t) => !t.startsWith("-"));
+  return { script: script.replace(/\\/g, "/"), project: projects[0] ?? null, projects };
+}
+
+/** Split a command-line tail into arguments, honouring double quotes. */
+function tokenizeArgs(rest: string): string[] {
+  const out: string[] = [];
+  let current = "";
+  let quoted = false;
+  let started = false;
+  for (const ch of rest) {
+    if (ch === '"') {
+      quoted = !quoted;
+      started = true;
+      continue;
+    }
+    if (!quoted && /\s/.test(ch)) {
+      if (started) out.push(current);
+      current = "";
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) out.push(current);
+  return out.map((t) => t.trim()).filter((t) => t !== "");
 }
 
 /** The directory that owns a project arg (a .uproject file or its containing dir). */
@@ -150,8 +190,8 @@ function projectDirOf(projectArg: string | null): string | null {
 }
 
 /** Best-effort scan of running node processes for a ue-mcp server. */
-function findRunningServers(): Array<{ pid: number; version: string | null; script: string; project: string | null }> {
-  const out: Array<{ pid: number; version: string | null; script: string; project: string | null }> = [];
+function findRunningServers(): Array<{ pid: number; version: string | null; script: string; project: string | null; projects: string[] }> {
+  const out: Array<{ pid: number; version: string | null; script: string; project: string | null; projects: string[] }> = [];
   const selfPid = process.pid;
   let lines: string[] = [];
 
@@ -180,7 +220,7 @@ function findRunningServers(): Array<{ pid: number; version: string | null; scri
     const parsed = parseServerInvocation(cmd);
     if (!parsed) continue;
     if (out.some((s) => s.pid === pid)) continue;
-    out.push({ pid, version: versionForScript(parsed.script), script: parsed.script, project: parsed.project });
+    out.push({ pid, version: versionForScript(parsed.script), script: parsed.script, project: parsed.project, projects: parsed.projects });
   }
   return out;
 }
@@ -254,9 +294,17 @@ export function collectDoctor(projectArg?: string, cwd: string = process.cwd()):
   const uproject = findUproject(projectArg, cwd);
   const targetProjectDir = projectDirOf(uproject);
   const servers = findRunningServers().map((s) => {
-    const serverDir = projectDirOf(s.project);
-    const servesTarget = !!(targetProjectDir && serverDir &&
-      serverDir.toLowerCase() === targetProjectDir.toLowerCase());
+    // A server serves the target when ANY of its projects is the target: a
+    // multi-editor server driving the project doctor was asked about is
+    // serving it, and reporting otherwise reads as "no server is running".
+    const candidates = s.projects.length > 0 ? s.projects : [s.project];
+    const servesTarget = !!(
+      targetProjectDir &&
+      candidates.some((p) => {
+        const dir = projectDirOf(p);
+        return dir !== null && dir.toLowerCase() === targetProjectDir.toLowerCase();
+      })
+    );
     return { ...s, servesTarget };
   });
   return {
@@ -309,8 +357,15 @@ export function formatDoctor(d: DoctorReport): string {
     for (const s of servers) {
       const deleted = s.version === null;
       const v = deleted ? `${RED}deleted files${RESET}` : (s.version as string);
-      const proj = s.project ? path.basename(s.project.replace(/[\\/]+$/, "")) || s.project : "?";
-      const scope = s.servesTarget ? `${BOLD}this project${RESET}` : `${DIM}${proj}${RESET}`;
+      const names = (s.projects && s.projects.length > 0 ? s.projects : [s.project])
+        .filter((p): p is string => !!p)
+        .map((p) => path.basename(p.replace(/[\\/]+$/, "")) || p);
+      const proj = names.length > 0 ? names.join(", ") : "?";
+      const scope = s.servesTarget
+        ? names.length > 1
+          ? `${BOLD}this project${RESET} ${DIM}(with ${names.length - 1} more: ${proj})${RESET}`
+          : `${BOLD}this project${RESET}`
+        : `${DIM}${proj}${RESET}`;
       const mismatch = latest && s.version && s.version !== latest;
       const tag = deleted
         ? `${RED}(running pruned files - relaunch)${RESET}`
@@ -376,8 +431,15 @@ export function formatDoctor(d: DoctorReport): string {
   return lines.join("\n");
 }
 
-/** Entry point for `ue-mcp doctor [project.uproject]`. */
+/** Entry point for `ue-mcp doctor [project.uproject] [--editor <name-or-path>]`. */
 export function runDoctorCli(): void {
-  const projectArg = process.argv.slice(2).find((a) => !a.startsWith("-"));
+  let target: { projectPath?: string; rest: string[] };
+  try {
+    target = takeEditorTarget(process.argv.slice(2));
+  } catch (e) {
+    console.error(`  ${RED}${e instanceof EditorFlagError ? e.message : String(e)}${RESET}`);
+    process.exit(1);
+  }
+  const projectArg = target.projectPath ?? target.rest.find((a) => !a.startsWith("-"));
   console.log(formatDoctor(collectDoctor(projectArg)));
 }

--- a/src/editor-control.ts
+++ b/src/editor-control.ts
@@ -852,7 +852,8 @@ export async function buildProject(
       // A build is the only event that can turn a "stale plugin" verdict fresh
       // ahead of the cache TTL, so drop the cached answer here rather than
       // making the next get_status report a binary that no longer exists.
-      invalidatePluginFreshness();
+      // Only this project's: a build in one editor says nothing about another.
+      invalidatePluginFreshness(resolvedPath);
       resolve(
         code === 0
           ? { success: true, exitCode: 0, message: "Build succeeded" }

--- a/src/editor-flag.ts
+++ b/src/editor-flag.ts
@@ -1,0 +1,287 @@
+/**
+ * `--editor <name-or-path>` for the one-shot CLI subcommands (#817, plan 6.2).
+ *
+ * `deploy`, `build`, `init`, `plugin`, `context`, `doctor`, `resolve`,
+ * `update`, `feedback` and `uninstall-hooks` each run in their own process
+ * with no session registry: the registry only exists inside a running server.
+ * So a session NAME has to be resolved from the same place the server got its
+ * sessions from, which is the argv recorded in the MCP client config, and the
+ * naming rule has to match SessionRegistry's exactly or `--editor beta` would
+ * mean one project to the server and another to the CLI.
+ *
+ * Resolution order is name first, path second, as the plan specifies. A name
+ * is the more specific claim: a bare project name that also happens to be a
+ * directory in cwd should address the registered editor, not the directory.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export const EDITOR_FLAG = "--editor";
+
+export interface EditorFlagParse {
+  /** The value passed to --editor, or undefined when the flag was absent. */
+  editor?: string;
+  /** argv with the flag and its value removed, so existing parsing is untouched. */
+  rest: string[];
+}
+
+/**
+ * Pull `--editor <value>` (or `--editor=<value>`) out of an argument list.
+ *
+ * Every other argument is returned untouched and in order, including other
+ * flags: this must not become a general-purpose argument parser, because
+ * several of these subcommands forward the remainder verbatim.
+ */
+export function parseEditorFlag(argv: string[]): EditorFlagParse {
+  const rest: string[] = [];
+  let editor: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === EDITOR_FLAG) {
+      const value = argv[i + 1];
+      if (value !== undefined && !value.startsWith("-")) {
+        editor = value;
+        i++;
+      }
+      continue;
+    }
+    if (arg.startsWith(`${EDITOR_FLAG}=`)) {
+      editor = arg.slice(EDITOR_FLAG.length + 1);
+      continue;
+    }
+    rest.push(arg);
+  }
+  return { editor, rest };
+}
+
+/** One editor the server is configured to drive. */
+export interface ConfiguredEditor {
+  /** The handle the running server answers to, from the same rule it uses. */
+  name: string;
+  /** Absolute .uproject path, or the directory argument when no file resolves. */
+  projectPath: string;
+  /** Which client config this came from, for error messages. */
+  source: string;
+}
+
+/**
+ * The session names a server started with these positionals would assign.
+ *
+ * Mirrors SessionRegistry: the project's base name, de-duplicated with a
+ * numeric suffix in registration order. Kept here rather than imported so the
+ * CLI does not construct a ProjectContext (and therefore does not need the
+ * project to be loadable) just to learn what it would be called.
+ */
+export function namesForProjects(projectPaths: string[]): string[] {
+  const taken = new Set<string>();
+  const names: string[] = [];
+  for (const p of projectPaths) {
+    const base = projectBaseName(p);
+    let name = base;
+    for (let i = 2; taken.has(name.toLowerCase()); i++) name = `${base}-${i}`;
+    taken.add(name.toLowerCase());
+    names.push(name);
+  }
+  return names;
+}
+
+function projectBaseName(projectPath: string): string {
+  const resolved = path.resolve(projectPath);
+  if (resolved.toLowerCase().endsWith(".uproject")) return path.basename(resolved, path.extname(resolved));
+  const found = listUprojects(resolved)[0];
+  return found ? path.basename(found, ".uproject") : path.basename(resolved);
+}
+
+function listUprojects(dir: string): string[] {
+  try {
+    if (!fs.statSync(dir).isDirectory()) return [];
+    return fs
+      .readdirSync(dir)
+      .filter((f) => f.toLowerCase().endsWith(".uproject"))
+      .map((f) => path.join(dir, f));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Every editor the MCP client configs on this machine say the server drives.
+ *
+ * Read-only and best-effort: a malformed or absent config contributes nothing
+ * rather than failing the subcommand that only wanted to deploy to cwd.
+ */
+export function discoverConfiguredEditors(cwd: string = process.cwd()): ConfiguredEditor[] {
+  const out: ConfiguredEditor[] = [];
+  const seen = new Set<string>();
+  for (const { file, positionals } of readServerInvocations(cwd)) {
+    const names = namesForProjects(positionals);
+    positionals.forEach((projectPath, i) => {
+      const key = path.resolve(projectPath).toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push({ name: names[i], projectPath: path.resolve(projectPath), source: file });
+    });
+  }
+  return out;
+}
+
+interface ServerInvocation {
+  file: string;
+  positionals: string[];
+}
+
+/** The config files that can name a ue-mcp server invocation, nearest first. */
+function candidateConfigFiles(cwd: string): string[] {
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  const appData = process.env.APPDATA || (home ? path.join(home, "AppData", "Roaming") : "");
+  const files = [
+    path.join(cwd, ".mcp.json"),
+    path.join(cwd, ".cursor", "mcp.json"),
+  ];
+  if (home) {
+    files.push(path.join(home, ".claude", ".mcp.json"));
+    files.push(path.join(home, ".codex", "config.toml"));
+  }
+  if (appData) files.push(path.join(appData, "Claude", "claude_desktop_config.json"));
+  return files;
+}
+
+function readServerInvocations(cwd: string): ServerInvocation[] {
+  const out: ServerInvocation[] = [];
+  for (const file of candidateConfigFiles(cwd)) {
+    if (!fs.existsSync(file)) continue;
+    let raw: string;
+    try {
+      raw = fs.readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+    const positionals = file.toLowerCase().endsWith(".toml")
+      ? positionalsFromToml(raw)
+      : positionalsFromJson(raw);
+    if (positionals.length > 0) out.push({ file, positionals });
+  }
+  return out;
+}
+
+function positionalsFromJson(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw) as { mcpServers?: Record<string, { args?: unknown }> };
+    const args = parsed?.mcpServers?.["ue-mcp"]?.args;
+    return positionalsFromArgs(Array.isArray(args) ? args : []);
+  } catch {
+    return [];
+  }
+}
+
+function positionalsFromToml(raw: string): string[] {
+  // Only the [mcp_servers.ue-mcp] table's `args` line is of interest, and it is
+  // emitted by upsertCodexMcpServer as a single-line array of quoted strings.
+  const lines = raw.split(/\r?\n/);
+  let inTable = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("[")) {
+      inTable = trimmed === "[mcp_servers.ue-mcp]" || trimmed === '[mcp_servers."ue-mcp"]';
+      continue;
+    }
+    if (!inTable || !trimmed.startsWith("args")) continue;
+    const open = trimmed.indexOf("[");
+    const close = trimmed.lastIndexOf("]");
+    if (open < 0 || close <= open) continue;
+    const items = [...trimmed.slice(open + 1, close).matchAll(/"((?:[^"\\]|\\.)*)"/g)].map((m) =>
+      m[1].replace(/\\(.)/g, "$1"),
+    );
+    return positionalsFromArgs(items);
+  }
+  return [];
+}
+
+/**
+ * Drop the launcher words and flags, leaving the project positionals.
+ * `npx ue-mcp <project> [...]` and `node .../dist/index.js <project> [...]`
+ * are the two shapes init writes and doctor recognises.
+ */
+function positionalsFromArgs(args: unknown[]): string[] {
+  const out: string[] = [];
+  for (const raw of args) {
+    if (typeof raw !== "string") continue;
+    const arg = raw.trim();
+    if (!arg || arg.startsWith("-")) continue;
+    const lower = arg.toLowerCase();
+    if (lower === "ue-mcp" || lower === "npx" || lower === "node") continue;
+    if (lower.endsWith("index.js") || lower.endsWith(".mjs") || lower.endsWith(".cjs")) continue;
+    out.push(arg);
+  }
+  return out;
+}
+
+export class EditorFlagError extends Error {}
+
+/**
+ * Turn `--editor <value>` into a project path.
+ *
+ * Name first: a registered session name, then its project name. Path second: a
+ * .uproject file, or a directory holding exactly one. Anything else is an
+ * error naming what IS registered, because silently falling back to cwd would
+ * run a deploy or a build against the wrong project.
+ */
+export function resolveEditorFlag(editor: string, cwd: string = process.cwd()): string {
+  const needle = editor.trim();
+  if (!needle) throw new EditorFlagError(`${EDITOR_FLAG} needs a session name or a project path.`);
+
+  const configured = discoverConfiguredEditors(cwd);
+  const lower = needle.toLowerCase();
+  const byName = configured.find((e) => e.name.toLowerCase() === lower);
+  if (byName) return byName.projectPath;
+  const byProjectName = configured.find(
+    (e) => projectBaseName(e.projectPath).toLowerCase() === lower,
+  );
+  if (byProjectName) return byProjectName.projectPath;
+
+  const asPath = path.resolve(cwd, needle);
+  if (fs.existsSync(asPath)) {
+    if (asPath.toLowerCase().endsWith(".uproject")) return asPath;
+    const found = listUprojects(asPath);
+    if (found.length === 1) return found[0];
+    if (found.length > 1) {
+      throw new EditorFlagError(
+        `${EDITOR_FLAG} '${needle}' holds ${found.length} .uproject files; name one of them instead.`,
+      );
+    }
+  }
+  // A path that resolved to a registered project counts as that editor even
+  // when the config recorded it in the other form (file vs directory).
+  const byResolvedPath = configured.find(
+    (e) => sameProject(e.projectPath, asPath),
+  );
+  if (byResolvedPath) return byResolvedPath.projectPath;
+
+  const known = configured.length > 0
+    ? ` Registered editors: ${configured.map((e) => e.name).join(", ")}.`
+    : " No editors are registered in any MCP client config on this machine.";
+  throw new EditorFlagError(
+    `${EDITOR_FLAG} '${needle}' is neither a registered editor nor a project path.${known}`,
+  );
+}
+
+function sameProject(a: string, b: string): boolean {
+  const dirOf = (p: string) =>
+    (p.toLowerCase().endsWith(".uproject") ? path.dirname(p) : p).replace(/[\\/]+$/, "").toLowerCase();
+  return dirOf(path.resolve(a)) === dirOf(path.resolve(b));
+}
+
+/**
+ * Read `--editor` out of argv and turn it into a project path.
+ *
+ * Returns the remaining argv either way, so a subcommand keeps parsing exactly
+ * what it parsed before when the flag is absent.
+ */
+export function takeEditorTarget(
+  argv: string[],
+  cwd: string = process.cwd(),
+): { projectPath?: string; rest: string[] } {
+  const { editor, rest } = parseEditorFlag(argv);
+  if (editor === undefined) return { rest };
+  return { projectPath: resolveEditorFlag(editor, cwd), rest };
+}

--- a/src/feedback-cli.ts
+++ b/src/feedback-cli.ts
@@ -10,13 +10,15 @@
  */
 
 import * as readline from "node:readline";
+import * as path from "node:path";
 import {
   deleteDeferred,
   getPendingDir,
-  listDeferred,
+  listDeferred as listAllDeferred,
   loadDeferred,
   type DeferredFeedback,
 } from "./feedback-deferred.js";
+import { takeEditorTarget, EditorFlagError } from "./editor-flag.js";
 import { submitFeedback } from "./github-app.js";
 import {
   CORE_REPO,
@@ -102,10 +104,41 @@ function cmdMode(arg: string | undefined): void {
   }
 }
 
+/**
+ * `--editor <name-or-path>` scopes every listing to the entries that
+ * originated in that editor (#817). The deferred store is user-scoped, because
+ * feedback files against the ue-mcp tracker rather than the user's project, so
+ * the flag filters what is shown rather than pointing somewhere else.
+ */
+let editorFilter: string | null = null;
+
+function setEditorFilter(projectPath?: string): void {
+  if (!projectPath) {
+    editorFilter = null;
+    return;
+  }
+  editorFilter = projectPath.toLowerCase().endsWith(".uproject")
+    ? path.basename(projectPath, path.extname(projectPath))
+    : path.basename(projectPath.replace(/[\/]+$/, ""));
+}
+
+/** The deferred entries in scope: all of them, or one editor's. */
+function listDeferred(): DeferredFeedback[] {
+  const all = listAllDeferred();
+  if (!editorFilter) return all;
+  const needle = editorFilter.toLowerCase();
+  return all.filter((e) => (e.project ?? "").toLowerCase() === needle);
+}
+
 function cmdList(): void {
   const entries = listDeferred();
   if (entries.length === 0) {
-    info("No pending feedback submissions.");
+    const total = listAllDeferred().length;
+    if (editorFilter && total > 0) {
+      info(`No pending feedback submissions from '${editorFilter}'. ${total} pending from other editors.`);
+    } else {
+      info("No pending feedback submissions.");
+    }
     info(getPendingDir());
     return;
   }
@@ -375,8 +408,20 @@ function cmdDiscard(id: string): void {
 }
 
 async function main(): Promise<void> {
-  const sub = process.argv[2];
-  const id = process.argv[3];
+  // --editor scopes the deferred store to entries that originated in one of
+  // this server's editors. The store itself is user-scoped (feedback files
+  // against the ue-mcp tracker, not the project), so the flag is a filter
+  // rather than a different location.
+  let target: { projectPath?: string; rest: string[] };
+  try {
+    target = takeEditorTarget(process.argv.slice(2));
+  } catch (e) {
+    fail(e instanceof EditorFlagError ? e.message : String(e));
+    process.exit(1);
+  }
+  setEditorFilter(target.projectPath);
+  const sub = target.rest[0];
+  const id = target.rest[1];
 
   switch (sub) {
     case "mode":

--- a/src/feedback-routing.ts
+++ b/src/feedback-routing.ts
@@ -157,8 +157,8 @@ async function coreSurface(): Promise<CoreSurface> {
   const categories = new Set<string>();
   const actions = new Map<string, string>();
   try {
-    const { ALL_TOOLS } = await import("./tools.js");
-    for (const tool of ALL_TOOLS) {
+    const { getLiveToolGraph } = await import("./tools.js");
+    for (const tool of getLiveToolGraph()) {
       categories.add(tool.name.toLowerCase());
       for (const action of Object.keys(tool.actions)) {
         const a = action.toLowerCase();

--- a/src/flow/flow-tool.ts
+++ b/src/flow/flow-tool.ts
@@ -37,10 +37,24 @@ function rollbackLabel(e: { taskName: string; payload?: Record<string, unknown> 
   return typeof method === "string" && method.length > 0 ? method : e.taskName;
 }
 
+/**
+ * The task registry and flow config a call resolves to.
+ *
+ * Both are per editor (#817): the registry is built from that project's tool
+ * graph, and the config is that project's ue-mcp.yml. Passing plain values
+ * still works and means "the same one for every call", which is what a
+ * single-editor server and the script runner want.
+ */
+export type FlowRegistrySource = TaskRegistry | ((ctx: ToolContext) => TaskRegistry);
+export type FlowConfigSource = (() => FlowConfig) | ((ctx: ToolContext) => FlowConfig);
+
 export function createFlowTool(
-  registry: TaskRegistry,
-  reloadConfig: () => FlowConfig,
+  registrySource: FlowRegistrySource,
+  reloadConfig: FlowConfigSource,
 ): ToolDef {
+  const registryFor = (ctx: ToolContext): TaskRegistry =>
+    typeof registrySource === "function" ? registrySource(ctx) : registrySource;
+  const configFor = (ctx: ToolContext): FlowConfig => reloadConfig(ctx);
   return {
     name: "flow",
     description:
@@ -69,15 +83,15 @@ export function createFlowTool(
       rollback_on_failure: z.boolean().optional().describe("Invoke inverse tasks in reverse order on failure"),
     },
     actions: {
-      run: { handler: async (ctx, params) => runFlow(registry, reloadConfig(), ctx, params) },
-      plan: { handler: async (ctx, params) => planFlow(registry, reloadConfig(), ctx, params) },
-      list: { handler: async () => listFlows(reloadConfig()) },
+      run: { handler: async (ctx, params) => runFlow(registryFor(ctx), configFor(ctx), ctx, params) },
+      plan: { handler: async (ctx, params) => planFlow(registryFor(ctx), configFor(ctx), ctx, params) },
+      list: { handler: async (ctx) => listFlows(configFor(ctx)) },
     },
     handler: async (ctx, params) => {
       const action = params.action as string;
-      if (action === "list") return listFlows(reloadConfig());
-      if (action === "plan") return planFlow(registry, reloadConfig(), ctx, params);
-      if (action === "run") return runFlow(registry, reloadConfig(), ctx, params);
+      if (action === "list") return listFlows(configFor(ctx));
+      if (action === "plan") return planFlow(registryFor(ctx), configFor(ctx), ctx, params);
+      if (action === "run") return runFlow(registryFor(ctx), configFor(ctx), ctx, params);
       throw new Error(`Unknown flow action: ${action}`);
     },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,11 +369,16 @@ async function main() {
       getPlugins: () => getPlugins(load.surface.session),
     };
     for (const g of discoverTaskGuards(load.registry!, guardCtx, load.surface.session.bridge)) {
-      guardRegistry.register(g);
+      load.surface.session.guards.register(g);
     }
   }
-  if (guardRegistry.size > 0) {
-    info("guard", `${guardRegistry.size} bridge guard(s) active: ${guardRegistry.list().map((g) => g.name).join(", ")}`);
+  for (const session of sessions.list()) {
+    if (session.guards.size === 0) continue;
+    const label = sessions.size > 1 ? `editor '${session.name}': ` : "";
+    info(
+      "guard",
+      `${label}${session.guards.size} bridge guard(s) active: ${session.guards.list().map((g) => g.name).join(", ")}`,
+    );
   }
 
   // ── Plugin knowledge → server instructions ──────────────────────
@@ -516,7 +521,14 @@ async function main() {
         const task = await sessionRegistry.create(taskName, flowCtx, taskParams);
         // Locks are acquired in the editor the call runs in, so they must be
         // taken on that session's bridge rather than the process default.
-        const result = await withAssetLocks(session.bridge, lockingCfg, taskName, taskParams, () => task.run());
+        const result = await withAssetLocks(
+          session.bridge,
+          lockingCfg,
+          taskName,
+          taskParams,
+          () => task.run(),
+          session.lockOwnerId,
+        );
 
         if (!result.success) {
           const msg = result.error?.message ?? `Task ${taskName} failed`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,10 +38,17 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import yaml from "js-yaml";
 
-import { ALL_TOOLS } from "./tools.js";
+import { ALL_TOOLS, setLiveToolGraph } from "./tools.js";
 import { enrichToolsWithEpicCatalog, type EpicCatalog } from "./epic-enrich.js";
 import { checkPluginFreshness } from "./plugin-freshness.js";
 import { saveCatalogCache, loadCatalogCache, loadBakedCatalog } from "./epic-cache.js";
+import {
+  baseGraphFor,
+  unionSurface,
+  unionKnowledge,
+  explainMissingAction,
+  type SessionSurface,
+} from "./session-surface.js";
 
 type TextBlock = { type: "text"; text: string };
 
@@ -165,78 +172,34 @@ async function main() {
   // whatever answers 9877" mode, and project(set_project) can bind it later.
   if (sessions.size === 0) sessions.register({});
 
-  // Process-level construction (config, plugins, native tool enrichment,
-  // flows, HTTP) reads the first session's project, which for a single-editor
-  // server is the only one there has ever been.
+  // Process-level construction that has one answer per transport (the context
+  // strategy, the HTTP surface, the flow config source) reads the first
+  // session's project, which for a single-editor server is the only one there
+  // has ever been.
   const primary = sessions.active;
   const project = primary.project;
   const bridge = primary.bridge;
 
-  // ── Plugins ──────────────────────────────────────────────────────
-  // Read the user's `plugins:` entries from ue-mcp.yml (best-effort - a
-  // missing or invalid file means zero plugins, never a fatal error). Then
-  // resolve, validate, and inject into target categories BEFORE the flow
-  // registry is built so plugin tasks register cleanly.
-  const configDir = project.projectDir ?? undefined;
-  const pluginEntries = readPluginsEntries(configDir);
-  const pluginLoad = await loadPlugins(ALL_TOOLS, pluginEntries, configDir, pkg.version, project.config.pluginConfig);
-  const activeTools = pluginLoad.tools;
-  const pluginRecords = pluginLoad.records;
-
-  // ── Epic 5.8 native toolset surfacing (best-effort, startup) ─────
-  // If the editor bridge is reachable now, pull Epic's live toolset catalog and
-  // inject each tool as a first-class action into the matching ue-mcp category
-  // (GAS tools into `gas`, Niagara into `niagara`, etc.). This must run before
-  // the flow registry and MCP tool registration below so the injected actions
-  // are dispatchable and advertised. When the editor is not up yet, the `epic`
-  // gateway still works; a server restart picks up enrichment. (Re-enrichment on
-  // late connect would require tools/list_changed and is a follow-up.)
-  const nativeCfg = project.config.nativeTools ?? {};
-  const nativeEnabled = nativeCfg.enabled !== false; // on by default (opt-out)
-  if (!nativeEnabled) {
-    console.error("[ue-mcp] Native Epic tools disabled via ue-mcp.yml (nativeTools.enabled=false); epic gateway still available");
-  } else {
-    try {
-      // Source priority: live editor (most current, refreshes the cache) ->
-      // project cache (last-seen) -> baked snapshot shipped with the package
-      // (deterministic default so the surface appears on first cold startup and
-      // matches the generated docs). First available wins.
-      let catalog: EpicCatalog | null = null;
-      let source = "";
-      if (!bridge.isConnected) {
-        await bridge.connect(2000).catch(() => {});
-      }
-      if (bridge.isConnected) {
-        catalog = (await bridge.call("epic_list_toolsets", { includeSchemas: true }, 20000)) as EpicCatalog;
-        if (catalog?.toolsets?.length) {
-          saveCatalogCache(configDir, catalog, project.engineAssociation);
-          source = "live editor";
-        }
-      }
-      if (!catalog?.toolsets?.length) {
-        catalog = loadCatalogCache(configDir);
-        if (catalog?.toolsets?.length) source = "project cache";
-      }
-      if (!catalog?.toolsets?.length) {
-        catalog = loadBakedCatalog();
-        if (catalog?.toolsets?.length) source = "baked snapshot";
-      }
-      if (catalog?.toolsets?.length) {
-        const enriched = enrichToolsWithEpicCatalog(activeTools, catalog, {
-          excludeCategories: nativeCfg.exclude,
-        });
-        if (enriched.injected > 0) {
-          const summary = Object.entries(enriched.byCategory).map(([c, n]) => `${c}:${n}`).join(", ");
-          console.error(`[ue-mcp] Epic 5.8 toolsets (${source}): surfaced ${enriched.injected} tools (${summary})`);
-          if (enriched.createdCategories.length) {
-            console.error(`[ue-mcp] Epic-only categories added: ${enriched.createdCategories.join(", ")}`);
-          }
-        }
-      }
-    } catch (e) {
-      console.error(`[ue-mcp] Epic toolset enrichment skipped: ${e instanceof Error ? e.message : e}`);
-    }
+  // ── Per-session surfaces ─────────────────────────────────────────
+  // Plugins and the Epic catalog are project-scoped: the `plugins:` list lives
+  // in each project's ue-mcp.yml and the catalog is whatever that project's
+  // editor reports. Both are built per session against a graph cloned from the
+  // pristine declaration, so a second editor never inherits the first one's
+  // plugins or toolsets (#817). At one editor this is one clone enriched from
+  // one project, which is what the server did before.
+  const surfaces: SessionSurface[] = [];
+  const perSession = new Map<EditorSession, SessionLoad>();
+  for (const session of sessions.list()) {
+    const load = await buildSessionLoad(session, pkg.version, sessions.size > 1);
+    perSession.set(session, load);
+    surfaces.push(load.surface);
   }
+
+  const primaryLoad = perSession.get(primary)!;
+  const pluginLoad = primaryLoad.pluginLoad;
+  const pluginRecords = primaryLoad.surface.pluginRecords;
+  const configDir = project.projectDir ?? undefined;
+  const activeTools = primaryLoad.surface.tools;
 
   // ── Context-seeding strategy (full | lean | micro) ───────────────
   // Applied AFTER plugin + Epic enrichment so lean/micro discovery covers the
@@ -247,25 +210,60 @@ async function main() {
   //           visible, descriptions/params on demand)
   //   micro - one `tools` gateway (list_categories / describe / call) fronts
   //           everything; smallest possible seed
+  //
+  // The strategy is process-level: there is one transport, so one advertised
+  // shape. It comes from the first session, and any other session asking for
+  // a different one is named rather than silently overridden.
   const contextStrategy = resolveContextStrategy(project.config.context?.strategy);
-  const disabled = new Set(project.config.disable ?? []);
-  const enabledActive = activeTools.filter((t) => !disabled.has(t.name));
-
-  let advertisedTools: ToolDef[];
-  let registryTools: ToolDef[];
-  if (contextStrategy === "micro") {
-    const gateway = buildMicroGateway(enabledActive);
-    advertisedTools = [gateway];
-    // Keep every category task in the registry so flows still resolve.
-    registryTools = [gateway, ...activeTools];
-  } else if (contextStrategy === "lean") {
-    const leaned = applyLeanContext(activeTools);
-    advertisedTools = leaned.filter((t) => !disabled.has(t.name));
-    registryTools = leaned;
-  } else {
-    advertisedTools = enabledActive;
-    registryTools = activeTools;
+  const dissenting = surfaces
+    .filter((s) => s.session !== primary)
+    .filter((s) => resolveContextStrategy(s.session.project.config.context?.strategy) !== contextStrategy)
+    .map((s) => s.session.name);
+  if (dissenting.length > 0) {
+    console.error(
+      `[ue-mcp] Context strategy '${contextStrategy}' comes from '${primary.name}' and applies to the whole server; ` +
+        `${dissenting.join(", ")} ask for a different one and it is not applied.`,
+    );
   }
+  const disabled = primaryLoad.surface.disabled;
+
+  // Each session gets the strategy applied to its OWN graph, so its registry
+  // dispatches only what that project actually provides.
+  const loads = [...perSession.values()];
+  for (const load of loads) {
+    const enabled = load.surface.tools.filter((t) => !load.surface.disabled.has(t.name));
+    if (contextStrategy === "micro") {
+      const gateway = buildMicroGateway(enabled);
+      load.advertisedTools = [gateway];
+      // Keep every category task in the registry so flows still resolve.
+      load.registryTools = [gateway, ...load.surface.tools];
+    } else if (contextStrategy === "lean") {
+      const leaned = applyLeanContext(load.surface.tools);
+      load.advertisedTools = leaned.filter((t) => !load.surface.disabled.has(t.name));
+      load.registryTools = leaned;
+    } else {
+      load.advertisedTools = enabled;
+      load.registryTools = load.surface.tools;
+    }
+  }
+
+  // What the client is advertised. At one editor this is that editor's list,
+  // the same objects it always was. Beyond one it is the union, so an action
+  // only one project has is still addressable there, and dispatch to a session
+  // that lacks it is refused by name rather than falling through to a bridge
+  // that cannot serve it. A category a session disabled stays advertised for
+  // the others and is refused at dispatch for that one, naming its config.
+  const advertisedTools: ToolDef[] = sessions.size > 1
+    ? unionSurface(loads.map((l) => ({ ...l.surface, tools: l.advertisedTools }))).tools
+    : primaryLoad.advertisedTools;
+
+  // The union of every session's dispatchable graph. `search_tools`, the
+  // execute_python gate and the feedback router all ask "what does this server
+  // expose", and with a graph per session that answer no longer lives in the
+  // module-level declaration they used to read.
+  const dispatchUnion = unionSurface(loads.map((l) => ({ ...l.surface, tools: l.registryTools })));
+  setLiveToolGraph(dispatchUnion.tools);
+  const registryTools = primaryLoad.registryTools;
   if (contextStrategy !== "full") {
     console.error(`[ue-mcp] Context strategy: ${contextStrategy}`);
   }
@@ -273,11 +271,14 @@ async function main() {
   // Lazy flow accessor - reads ue-mcp.yml fresh each call so agents see
   // edits without a server restart. project(get_status) uses this so the
   // first call agents make in any session reveals the registered flows.
-  const getFlows = (): Array<{ name: string; description?: string }> => {
+  // Reads the addressed session's project, so a flow declared in one project's
+  // ue-mcp.yml is not reported as belonging to another's.
+  const getFlows = (forSession?: EditorSession): Array<{ name: string; description?: string }> => {
+    const load = perSession.get(forSession ?? primary) ?? primaryLoad;
     try {
-      const cfg = loadFlowConfig(activeTools, configDir, {
-        tasks: pluginLoad.taskDefs,
-        flows: pluginLoad.flowDefs,
+      const cfg = loadFlowConfig(load.surface.tools, load.configDir, {
+        tasks: load.pluginLoad.taskDefs,
+        flows: load.pluginLoad.flowDefs,
       }).config;
       return Object.entries(cfg.flows).map(([name, def]) => ({
         name,
@@ -288,7 +289,11 @@ async function main() {
     }
   };
 
-  const getPlugins = (): PluginInfo[] => pluginRecords.map((r) => toPluginInfo(r, project));
+  const getPlugins = (forSession?: EditorSession): PluginInfo[] => {
+    const target = forSession ?? primary;
+    const load = perSession.get(target) ?? primaryLoad;
+    return load.surface.pluginRecords.map((r) => toPluginInfo(r, target.project));
+  };
 
   // Elicitation is only meaningful once the client has advertised support
   // during initialize. We lazily probe at call time so the function is bound
@@ -331,21 +336,41 @@ async function main() {
     console.error(`[ue-mcp] Per-asset locking enabled (TTL ${lockingCfg.ttlSeconds}s)`);
   }
 
-  // ── Flow engine: task registry ──────────────────────────────────
-  const registry = buildFlowRegistry(registryTools);
-  for (const { name, ctor } of pluginLoad.taskRegistrations) {
-    registry.register(name, ctor);
+  // ── Flow engine: one task registry per session ──────────────────
+  // The registry is the dispatch layer, so it has to be built from the graph
+  // the addressed session actually has. Sharing one registry is what made a
+  // second editor dispatch the first editor's plugin tasks (#817).
+  for (const load of loads) {
+    const sessionRegistry = buildFlowRegistry(load.registryTools);
+    for (const { name, ctor } of load.pluginLoad.taskRegistrations) {
+      sessionRegistry.register(name, ctor);
+    }
+    for (const { classPath, ctor } of load.pluginLoad.classPathRegistrations) {
+      sessionRegistry.registerClassPath(classPath, ctor);
+    }
+    load.registry = sessionRegistry;
   }
-  for (const { classPath, ctor } of pluginLoad.classPathRegistrations) {
-    registry.registerClassPath(classPath, ctor);
-  }
+  const registry = primaryLoad.registry!;
   const taskCount = registry.listRegistered().length;
 
   // Populate the guard pipeline: any plugin-supplied `guard.<name>.<phase>` task
   // becomes a BridgeGuard. Each guard task runs with the RAW bridge in its
   // context so a guard cannot recurse through the pipeline. See flow/task-guards.ts.
-  for (const g of discoverTaskGuards(registry, ctx, bridge)) {
-    guardRegistry.register(g);
+  // Guards are discovered per session, from that session's own registry and
+  // against that session's own raw bridge, so a guard declared by one project's
+  // plugins cannot veto another project's calls.
+  for (const load of loads) {
+    const guardCtx: ToolContext = {
+      bridge: load.surface.session.guarded,
+      project: load.surface.session.project,
+      session: load.surface.session,
+      sessions,
+      getFlows: () => getFlows(load.surface.session),
+      getPlugins: () => getPlugins(load.surface.session),
+    };
+    for (const g of discoverTaskGuards(load.registry!, guardCtx, load.surface.session.bridge)) {
+      guardRegistry.register(g);
+    }
   }
   if (guardRegistry.size > 0) {
     info("guard", `${guardRegistry.size} bridge guard(s) active: ${guardRegistry.list().map((g) => g.name).join(", ")}`);
@@ -355,7 +380,10 @@ async function main() {
   // Attach per-category markdown to the AI-facing docs. Sized to the same
   // budget as SERVER_INSTRUCTIONS itself; deeper plugin docs remain
   // readable on demand via the file-reading surface.
-  const knowledgeBlock = buildKnowledgeBlock(pluginLoad.knowledgeByCategory);
+  // The union across sessions: instructions are sent once at initialize and
+  // cannot be renegotiated, so an editor whose plugins document a category
+  // has to have that documented for the whole server or not at all.
+  const knowledgeBlock = buildKnowledgeBlock(unionKnowledge(surfaces));
   const baseInstructions = contextStrategy === "micro"
     ? SERVER_INSTRUCTIONS_MICRO
     : contextStrategy === "lean"
@@ -457,15 +485,35 @@ async function main() {
         project: session.project,
         session,
         sessions,
-        getFlows,
-        getPlugins,
+        getFlows: () => getFlows(session),
+        getPlugins: () => getPlugins(session),
         elicit: ctx.elicit,
         onProgress: makeProgressReporter(extra),
         client: server.server.getClientVersion(),
       };
 
+      // The addressed session's own registry, built from that project's graph.
+      // A call for an action the session does not provide is refused here,
+      // naming the editors that do, rather than reaching a bridge that would
+      // answer "Unknown method" with no way to tell which editor was wrong.
+      const sessionRegistry = perSession.get(session)?.registry ?? registry;
+      const refusal = sessions.size > 1
+        ? explainMissingAction(
+            dispatchUnion,
+            taskName,
+            session.name,
+            sessionRegistry.listRegistered().includes(taskName),
+          )
+        : null;
+      if (refusal) {
+        return {
+          content: withUpgradeNotice([{ type: "text" as const, text: `Error [NOT_FOUND]: ${refusal}` }]),
+          isError: true,
+        };
+      }
+
       try {
-        const task = await registry.create(taskName, flowCtx, taskParams);
+        const task = await sessionRegistry.create(taskName, flowCtx, taskParams);
         // Locks are acquired in the editor the call runs in, so they must be
         // taken on that session's bridge rather than the process default.
         const result = await withAssetLocks(session.bridge, lockingCfg, taskName, taskParams, () => task.run());
@@ -529,13 +577,24 @@ async function main() {
   });
   console.error(`[ue-mcp] ue-mcp.yml loaded - ${Object.keys(initialLoad.config.flows).length} flow(s), ${Object.keys(initialLoad.config.tasks).length} custom task(s)`);
 
-  // Config is reloaded on every flow call - edit ue-mcp.yml without restarting
-  const reloadConfig = (): FlowConfig => loadFlowConfig(activeTools, configDir, {
-    tasks: pluginLoad.taskDefs,
-    flows: pluginLoad.flowDefs,
-  }).config;
-
-  const flowTool = createFlowTool(registry, reloadConfig);
+  // Config is reloaded on every flow call - edit ue-mcp.yml without restarting.
+  // Resolved from the addressed editor: a flow declared in one project's
+  // ue-mcp.yml belongs to that project, and its steps have to dispatch through
+  // that project's registry or a step naming an action only that project has
+  // would fail as unknown.
+  const loadFor = (target: ToolContext | undefined): SessionLoad =>
+    (target?.session ? perSession.get(target.session) : undefined) ?? primaryLoad;
+  const reloadConfigFor = (target?: ToolContext): FlowConfig => {
+    const load = loadFor(target);
+    return loadFlowConfig(load.surface.tools, load.configDir, {
+      tasks: load.pluginLoad.taskDefs,
+      flows: load.pluginLoad.flowDefs,
+    }).config;
+  };
+  const flowTool = createFlowTool(
+    (target) => loadFor(target).registry ?? registry,
+    reloadConfigFor,
+  );
   targetable.push(flowTool);
   const flowShape: Record<string, z.ZodType> = {};
   for (const [key, schema] of Object.entries(flowTool.schema)) {
@@ -611,6 +670,122 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+}
+
+/**
+ * Everything one editor session needs to serve a call: its own tool graph,
+ * its own plugin load, and (once the context strategy is known) its own
+ * advertised list and task registry.
+ */
+interface SessionLoad {
+  surface: SessionSurface;
+  pluginLoad: Awaited<ReturnType<typeof loadPlugins>>;
+  configDir: string | undefined;
+  advertisedTools: ToolDef[];
+  registryTools: ToolDef[];
+  registry?: ReturnType<typeof buildFlowRegistry>;
+}
+
+/**
+ * Build one session's surface: clone the pristine graph, load that project's
+ * plugins into the clone, then enrich the clone from that project's Epic
+ * catalog. Nothing here touches another session's graph or the declaration
+ * they were all cloned from.
+ */
+async function buildSessionLoad(
+  session: EditorSession,
+  packageVersion: string,
+  multi: boolean,
+): Promise<SessionLoad> {
+  const project = session.project;
+  const configDir = project.projectDir ?? undefined;
+  const label = multi ? `editor '${session.name}': ` : "";
+
+  // ── Plugins ──────────────────────────────────────────────────────
+  // Read the user's `plugins:` entries from ue-mcp.yml (best-effort - a
+  // missing or invalid file means zero plugins, never a fatal error). Then
+  // resolve, validate, and inject into target categories BEFORE the flow
+  // registry is built so plugin tasks register cleanly.
+  const pluginEntries = readPluginsEntries(configDir);
+  const pluginLoad = await loadPlugins(
+    baseGraphFor(ALL_TOOLS),
+    pluginEntries,
+    configDir,
+    packageVersion,
+    project.config.pluginConfig,
+  );
+  const tools = pluginLoad.tools;
+
+  // ── Epic 5.8 native toolset surfacing (best-effort, startup) ─────
+  // If this session's bridge is reachable now, pull Epic's live toolset
+  // catalog and inject each tool as a first-class action into the matching
+  // ue-mcp category (GAS tools into `gas`, Niagara into `niagara`, etc.).
+  // This must run before the flow registry and MCP tool registration so the
+  // injected actions are dispatchable and advertised. When the editor is not
+  // up yet, the `epic` gateway still works; a server restart picks up
+  // enrichment.
+  const nativeCfg = project.config.nativeTools ?? {};
+  if (nativeCfg.enabled === false) {
+    console.error(`[ue-mcp] ${label}Native Epic tools disabled via ue-mcp.yml (nativeTools.enabled=false); epic gateway still available`);
+  } else {
+    try {
+      // Source priority: live editor (most current, refreshes the cache) ->
+      // project cache (last-seen) -> baked snapshot shipped with the package
+      // (deterministic default so the surface appears on first cold startup
+      // and matches the generated docs). First available wins. The cache is
+      // already keyed by project directory, so each session reads and writes
+      // its own.
+      let catalog: EpicCatalog | null = null;
+      let source = "";
+      const bridge = session.bridge;
+      if (!bridge.isConnected) {
+        await bridge.connect(2000).catch(() => {});
+      }
+      if (bridge.isConnected) {
+        catalog = (await bridge.call("epic_list_toolsets", { includeSchemas: true }, 20000)) as EpicCatalog;
+        if (catalog?.toolsets?.length) {
+          saveCatalogCache(configDir, catalog, project.engineAssociation);
+          source = "live editor";
+        }
+      }
+      if (!catalog?.toolsets?.length) {
+        catalog = loadCatalogCache(configDir);
+        if (catalog?.toolsets?.length) source = "project cache";
+      }
+      if (!catalog?.toolsets?.length) {
+        catalog = loadBakedCatalog();
+        if (catalog?.toolsets?.length) source = "baked snapshot";
+      }
+      if (catalog?.toolsets?.length) {
+        const enriched = enrichToolsWithEpicCatalog(tools, catalog, {
+          excludeCategories: nativeCfg.exclude,
+        });
+        if (enriched.injected > 0) {
+          const summary = Object.entries(enriched.byCategory).map(([c, n]) => `${c}:${n}`).join(", ");
+          console.error(`[ue-mcp] ${label}Epic 5.8 toolsets (${source}): surfaced ${enriched.injected} tools (${summary})`);
+          if (enriched.createdCategories.length) {
+            console.error(`[ue-mcp] ${label}Epic-only categories added: ${enriched.createdCategories.join(", ")}`);
+          }
+        }
+      }
+    } catch (e) {
+      console.error(`[ue-mcp] ${label}Epic toolset enrichment skipped: ${e instanceof Error ? e.message : e}`);
+    }
+  }
+
+  return {
+    surface: {
+      session,
+      tools,
+      disabled: new Set(project.config.disable ?? []),
+      pluginRecords: pluginLoad.records,
+      knowledgeByCategory: pluginLoad.knowledgeByCategory,
+    },
+    pluginLoad,
+    configDir,
+    advertisedTools: tools,
+    registryTools: tools,
+  };
 }
 
 /**

--- a/src/init.ts
+++ b/src/init.ts
@@ -15,6 +15,7 @@ import { runFeedbackAuthStep } from "./auth-cli.js";
 import { getInstalledHooks } from "./user-state.js";
 import { detectMcpClients, isProjectScopedClient, writeMcpConfig } from "./mcp-client-config.js";
 import { deriveProjectPort } from "./port.js";
+import { takeEditorTarget, EditorFlagError } from "./editor-flag.js";
 
 /* ------------------------------------------------------------------ */
 /*  Tool categories                                                    */
@@ -211,8 +212,15 @@ async function init() {
   // write actually succeeded.
   const wrote: Array<{ what: string; where: string }> = [];
 
-  // 1. Get project path - check CLI arg, then cwd, then ask
-  let uprojectPath = process.argv[2] || "";
+  // 1. Get project path: check --editor, then CLI arg, then cwd, then ask
+  let initTarget: { projectPath?: string; rest: string[] };
+  try {
+    initTarget = takeEditorTarget(process.argv.slice(2));
+  } catch (e) {
+    fail(e instanceof EditorFlagError ? e.message : String(e));
+    process.exit(1);
+  }
+  let uprojectPath = initTarget.projectPath || initTarget.rest[0] || "";
 
   if (!uprojectPath) {
     // Auto-detect .uproject in current directory

--- a/src/locking.ts
+++ b/src/locking.ts
@@ -15,8 +15,22 @@ import { debug } from "./log.js";
 // agent drives one editor. The explicit asset(lock/unlock/list_locks) actions
 // work regardless of this setting.
 
-/** Stable id for this server process; sent with every lock op. */
+/**
+ * Stable id for this server process, and the fallback owner for a lock op with
+ * no editor session behind it.
+ *
+ * Locks live in the bridge, which is per editor, so the owner of a lock has to
+ * be per editor too (#817). Two editors sharing one owner id makes a lock taken
+ * in one look re-entrant in the other, which is the opposite of what locking is
+ * for. Sessions carry their own id and pass it in; this stays as the answer for
+ * a caller with no session, which is what a single-editor server had.
+ */
 export const SESSION_ID = crypto.randomUUID();
+
+/** Mint an owner id for one editor session. */
+export function newLockOwnerId(): string {
+  return crypto.randomUUID();
+}
 
 export interface LockingConfig {
   enabled: boolean;
@@ -113,10 +127,10 @@ export function classifyAction(taskName: string, params: Record<string, unknown>
   return { mutates: true, paths: [...paths] };
 }
 
-async function releaseAll(bridge: IBridge, paths: string[]): Promise<void> {
+async function releaseAll(bridge: IBridge, paths: string[], ownerId: string): Promise<void> {
   for (const p of paths) {
     try {
-      await bridge.call("release_lock", { path: p, sessionId: SESSION_ID });
+      await bridge.call("release_lock", { path: p, sessionId: ownerId });
     } catch (e) {
       debug("lock", `release_lock failed for ${p} (lease will expire)`, e);
     }
@@ -135,6 +149,8 @@ export async function withAssetLocks<T>(
   taskName: string,
   params: Record<string, unknown>,
   run: () => Promise<T>,
+  /** Who holds the locks. The addressed editor's id; omitted means this process. */
+  ownerId: string = SESSION_ID,
 ): Promise<T> {
   if (!cfg.enabled) return run();
 
@@ -145,16 +161,16 @@ export async function withAssetLocks<T>(
   for (const p of paths) {
     let res: { acquired?: boolean; holder?: { sessionId?: string; ttlSecondsRemaining?: number } } | undefined;
     try {
-      res = (await bridge.call("acquire_lock", { path: p, sessionId: SESSION_ID, ttlSeconds: cfg.ttlSeconds })) as typeof res;
+      res = (await bridge.call("acquire_lock", { path: p, sessionId: ownerId, ttlSeconds: cfg.ttlSeconds })) as typeof res;
     } catch (e) {
       // Lock subsystem unavailable - release what we took and run unlocked
       // rather than failing a legitimate mutation.
       debug("lock", `acquire_lock unavailable for ${p}; running unlocked`, e);
-      await releaseAll(bridge, held);
+      await releaseAll(bridge, held, ownerId);
       return run();
     }
     if (!res?.acquired) {
-      await releaseAll(bridge, held);
+      await releaseAll(bridge, held, ownerId);
       const holder = res?.holder?.sessionId ?? "another session";
       const wait = res?.holder?.ttlSecondsRemaining;
       throw new McpError(
@@ -168,6 +184,6 @@ export async function withAssetLocks<T>(
   try {
     return await run();
   } finally {
-    await releaseAll(bridge, held);
+    await releaseAll(bridge, held, ownerId);
   }
 }

--- a/src/plugin-cli.ts
+++ b/src/plugin-cli.ts
@@ -42,8 +42,13 @@ import {
 } from "./plugin/native-deploy.js";
 import { ALL_TOOLS } from "./tools.js";
 import { resolvePublishToken } from "./registry-auth.js";
+import { parseEditorFlag, resolveEditorFlag, EditorFlagError } from "./editor-flag.js";
 
-const args = process.argv.slice(2);
+// --editor names one of the editors this server drives; every project lookup
+// below starts from it instead of cwd. Taken before the subcommand is shifted
+// off so it can appear anywhere on the line.
+const parsedEditor = parseEditorFlag(process.argv.slice(2));
+const args = parsedEditor.rest;
 const sub = args.shift();
 
 const RESTART_NOTE =
@@ -61,6 +66,21 @@ function note(msg: string): void {
 interface ProjectInfo {
   projectDir: string;
   configPath: string;
+}
+
+/**
+ * Where project resolution starts: the editor named by --editor when there is
+ * one, cwd otherwise. Resolved lazily so a subcommand that never touches a
+ * project (login, publish) does not fail on an unresolvable name.
+ */
+function projectStartDir(): string {
+  if (parsedEditor.editor === undefined) return process.cwd();
+  try {
+    const projectPath = resolveEditorFlag(parsedEditor.editor);
+    return projectPath.toLowerCase().endsWith(".uproject") ? path.dirname(projectPath) : projectPath;
+  } catch (e) {
+    fail(e instanceof EditorFlagError ? e.message : String(e));
+  }
 }
 
 function findProjectDir(startDir: string): ProjectInfo {
@@ -203,7 +223,7 @@ function cmdInstall(): void {
     note(`resolved '${requested}' -> '${name}' via the registry`);
   }
 
-  const proj = findProjectDir(process.cwd());
+  const proj = findProjectDir(projectStartDir());
 
   // Ensure a package.json exists. npm install will refuse without one.
   if (!fs.existsSync(path.join(proj.projectDir, "package.json"))) {
@@ -343,7 +363,7 @@ function cmdInstall(): void {
 function cmdUninstall(): void {
   const name = args.shift();
   if (!name) fail("usage: ue-mcp plugin uninstall <name>");
-  const proj = findProjectDir(process.cwd());
+  const proj = findProjectDir(projectStartDir());
 
   // Remove any deployed native module BEFORE npm uninstall so we can still
   // read the manifest (for diagnostics) and so the state file stays
@@ -367,7 +387,7 @@ function cmdUninstall(): void {
 }
 
 function cmdList(): void {
-  const proj = findProjectDir(process.cwd());
+  const proj = findProjectDir(projectStartDir());
   const list = readPluginsList(proj.configPath);
   if (list.length === 0) {
     note(`no plugins declared in ${proj.configPath}`);
@@ -399,7 +419,7 @@ function cmdList(): void {
 
 function cmdUpdate(): void {
   const name = args.shift();
-  const proj = findProjectDir(process.cwd());
+  const proj = findProjectDir(projectStartDir());
   if (name) {
     runNpm(["update", name], proj.projectDir);
   } else {
@@ -1190,7 +1210,7 @@ async function cmdConfig(): Promise<void> {
     else if (a === "--global") target = "global";
   }
 
-  const proj = findProjectDir(process.cwd());
+  const proj = findProjectDir(projectStartDir());
   const resolved = resolveInstalledPlugin(proj, nameArg);
   const manifest = loadManifest(resolved.pkgDir).manifest;
   const groups = deriveGroups(manifest.flows);

--- a/src/plugin-freshness.ts
+++ b/src/plugin-freshness.ts
@@ -111,10 +111,25 @@ function findCompiledBinary(pluginDir: string): { file: string; mtimeMs: number 
 const CACHE_TTL_MS = 10_000;
 const cache = new Map<string, { at: number; value: PluginFreshness }>();
 
-/** Drop the cached verdict. Called after a build, which is the only thing that
- *  can flip a stale verdict to fresh sooner than the TTL. */
-export function invalidatePluginFreshness(): void {
-  cache.clear();
+/**
+ * Drop a cached verdict. Called after a build, which is the only thing that
+ * can flip a stale verdict to fresh sooner than the TTL.
+ *
+ * Per project (#817): a build targets one project, and clearing every entry
+ * made the other editors re-walk their plugin binaries for no reason and, on
+ * a slow disk, report a verdict they had already answered. Omitting the path
+ * still clears everything, which is what a caller with no project in hand
+ * wants.
+ */
+export function invalidatePluginFreshness(uprojectPath?: string | null): void {
+  if (!uprojectPath) {
+    cache.clear();
+    return;
+  }
+  cache.delete(uprojectPath);
+  // The key is whatever string the caller passed to checkPluginFreshness, so
+  // a resolved path and the spelling it arrived in can both be present.
+  cache.delete(path.resolve(uprojectPath));
 }
 
 export function checkPluginFreshness(uprojectPath: string | null): PluginFreshness {

--- a/src/privacy-scrub.ts
+++ b/src/privacy-scrub.ts
@@ -35,6 +35,19 @@ export interface PrivacyScrubContext {
   username?: string;
   /** OS home directory. Defaults to os.homedir(); tests pass an explicit value. */
   homeDir?: string;
+  /**
+   * Roots of the OTHER editors this server drives (#817, plan item 6.4).
+   *
+   * A feedback body is assembled from the submitting session, so in the normal
+   * case none of these appear in it. They are scrubbed anyway because the body
+   * is posted to a public tracker and the cost of being wrong is another
+   * project's absolute path leaving the machine. Redacted to the same tokens
+   * as the submitting project, so a reader cannot tell how many editors the
+   * server drives either.
+   */
+  otherProjectRoots?: string[];
+  /** Names of the other editors this server drives. Same reasoning as above. */
+  otherProjectNames?: string[];
 }
 
 export interface PrivacyScrubResult {
@@ -101,8 +114,16 @@ export function privacyScrub(
   const user = ctx.username ?? os.userInfo().username;
 
   replacePath(ctx.projectRoot, "REDACTED_PROJECT_ROOT", "project-root-path");
+  // Longest first among the other roots too, so a nested project root is not
+  // fragmented by its parent's replacement.
+  for (const root of [...(ctx.otherProjectRoots ?? [])].sort((a, b) => b.length - a.length)) {
+    replacePath(root, "REDACTED_PROJECT_ROOT", "other-project-root-path");
+  }
   replacePath(home,            "REDACTED_HOME",         "home-path");
   replaceWord(ctx.projectName, "REDACTED_PROJECT", "project-name");
+  for (const name of ctx.otherProjectNames ?? []) {
+    replaceWord(name, "REDACTED_PROJECT", "other-project-name");
+  }
   replaceWord(user,            "REDACTED_USER",    "username");
 
   return { text, hits };

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -9,6 +9,7 @@ import { execSync, spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { takeEditorTarget, EditorFlagError } from "./editor-flag.js";
 
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
@@ -45,7 +46,28 @@ function currentBranch(): string {
 /* ── Main ────────────────────────────────────────────────────────── */
 
 async function resolve() {
-  const args = process.argv.slice(3);
+  // --editor picks which of this server's editors the workflow runs in. Every
+  // git and gh call below inherits the process cwd, so the target is applied
+  // by moving there once, before any of them run.
+  let target: { projectPath?: string; rest: string[] };
+  try {
+    target = takeEditorTarget(process.argv.slice(3));
+  } catch (e) {
+    fail(e instanceof EditorFlagError ? e.message : String(e));
+    return;
+  }
+  if (target.projectPath) {
+    const dir = target.projectPath.toLowerCase().endsWith(".uproject")
+      ? path.dirname(target.projectPath)
+      : target.projectPath;
+    try {
+      process.chdir(dir);
+      ok(`Working in ${dir}`);
+    } catch (e) {
+      fail(`Could not enter ${dir}: ${e instanceof Error ? e.message : e}`);
+    }
+  }
+  const args = target.rest;
   const ciMode = args.includes("--ci") || !!process.env.CI;
   const issueArg = args.find((a) => !a.startsWith("-"));
   const issueNum = Number(issueArg);

--- a/src/session-surface.ts
+++ b/src/session-surface.ts
@@ -1,0 +1,179 @@
+/**
+ * Per-session tool surface (#817, plan items 4.1 and 4.2).
+ *
+ * Plugin loading and Epic catalog enrichment are project-scoped facts: the
+ * `plugins:` list lives in each project's `ue-mcp.yml`, and the Epic toolset
+ * catalog is whatever that project's editor reports. Both used to run once
+ * against one shared tool graph, so a second editor inherited the first one's
+ * plugins and toolsets, and a call to an action the second project's engine
+ * does not have would reach its bridge and fail there instead of being
+ * refused here.
+ *
+ * Each session now owns a graph cloned from the pristine declaration and
+ * enriched from its own project. What the client is advertised is the union
+ * of those graphs, with each action remembering which sessions provide it, so
+ * dispatch to a session that lacks one can say which sessions have it.
+ */
+import { z } from "zod";
+import type { ToolDef, ActionSpec } from "./types.js";
+import { cloneToolDef, cloneToolGraph } from "./types.js";
+import type { EditorSession } from "./session.js";
+import type { PluginRecord } from "./plugin/loader.js";
+
+/** One editor's fully-built surface. */
+export interface SessionSurface {
+  session: EditorSession;
+  /** This session's own graph: cloned, plugin-injected, Epic-enriched. */
+  tools: ToolDef[];
+  /** Categories this session's `ue-mcp.yml` disabled. */
+  disabled: Set<string>;
+  /** Plugin load records, for `plugins(list)` and `get_status`. */
+  pluginRecords: PluginRecord[];
+  /** Per-category markdown this session's plugins contribute. */
+  knowledgeByCategory: Record<string, string[]>;
+}
+
+/** Which sessions provide one action, and which of them disabled its category. */
+export interface ActionProviders {
+  /** Session names whose graph declares the action. */
+  providers: string[];
+  /** Session names that declare it but disabled the category in config. */
+  disabledIn: string[];
+}
+
+export interface UnionSurface {
+  /** One ToolDef per category name, carrying the union of every action. */
+  tools: ToolDef[];
+  /** `category.action` to the sessions that provide it. */
+  providers: Map<string, ActionProviders>;
+}
+
+/** A fresh, unenriched graph for one session to build on. */
+export function baseGraphFor(pristine: ToolDef[]): ToolDef[] {
+  return cloneToolGraph(pristine);
+}
+
+/**
+ * Merge every session's graph into the one surface the client sees.
+ *
+ * The first session that declares a category owns its description and schema,
+ * which keeps a single-editor server byte-identical to what it advertised
+ * before sessions existed. Actions only later sessions have are added to that
+ * category, so a toolset present in one project is still addressable there.
+ *
+ * A category a session disabled stays in the union rather than disappearing:
+ * hiding it would take a working tool away from the OTHER editors, which is
+ * not what that user's `disable:` asked for. The refusal happens at dispatch,
+ * for that session only, naming the config.
+ */
+export function unionSurface(surfaces: SessionSurface[]): UnionSurface {
+  // The merged category is a copy, never the first session's own object:
+  // folding another session's actions into that object would put them back
+  // into the graph this whole split exists to keep separate.
+  const providers = new Map<string, ActionProviders>();
+  const byName = new Map<string, ToolDef>();
+  const order: string[] = [];
+
+  const noteProvider = (tool: string, action: string, surface: SessionSurface) => {
+    const key = `${tool}.${action}`;
+    let entry = providers.get(key);
+    if (!entry) {
+      entry = { providers: [], disabledIn: [] };
+      providers.set(key, entry);
+    }
+    if (!entry.providers.includes(surface.session.name)) entry.providers.push(surface.session.name);
+    if (surface.disabled.has(tool) && !entry.disabledIn.includes(surface.session.name)) {
+      entry.disabledIn.push(surface.session.name);
+    }
+  };
+
+  for (const surface of surfaces) {
+    for (const tool of surface.tools) {
+      const existing = byName.get(tool.name);
+      if (!existing) {
+        byName.set(tool.name, surfaces.length > 1 ? cloneToolDef(tool) : tool);
+        order.push(tool.name);
+        for (const action of Object.keys(tool.actions)) noteProvider(tool.name, action, surface);
+        continue;
+      }
+      const added: Record<string, ActionSpec> = {};
+      for (const [action, spec] of Object.entries(tool.actions)) {
+        noteProvider(tool.name, action, surface);
+        if (!(action in existing.actions)) added[action] = spec;
+      }
+      if (Object.keys(added).length > 0) mergeActions(existing, added, tool);
+    }
+  }
+
+  return { tools: order.map((n) => byName.get(n)!), providers };
+}
+
+/**
+ * Fold actions from a later session's category into the advertised one.
+ *
+ * The action enum has to be rebuilt or MCP will reject the added names, and
+ * any schema key the donor category carries has to come along or the caller
+ * has no way to pass its arguments.
+ */
+function mergeActions(target: ToolDef, added: Record<string, ActionSpec>, donor: ToolDef): void {
+  Object.assign(target.actions, added);
+  for (const [key, schema] of Object.entries(donor.schema)) {
+    if (key === "action") continue;
+    if (!(key in target.schema)) target.schema[key] = schema;
+  }
+  rebuildActionEnum(target);
+}
+
+/** Re-derive a category's `action` enum from its live action keys. */
+function rebuildActionEnum(tool: ToolDef): void {
+  const names = Object.keys(tool.actions) as [string, ...string[]];
+  if (names.length === 0) return;
+  tool.schema.action = z.enum(names).describe("Action to perform");
+}
+
+/**
+ * Why a dispatch to one session failed when the action exists elsewhere.
+ * Returns null when the session can serve it.
+ */
+export function explainMissingAction(
+  union: UnionSurface,
+  taskName: string,
+  sessionName: string,
+  sessionHasTask: boolean,
+): string | null {
+  const entry = union.providers.get(taskName);
+  if (!entry) return null;
+  if (entry.disabledIn.includes(sessionName)) {
+    const category = taskName.split(".")[0];
+    return (
+      `'${taskName}' is disabled for editor '${sessionName}': that project's ue-mcp.yml lists '${category}' under 'disable'. ` +
+      (entry.providers.length > 1
+        ? `Editors that can run it: ${entry.providers.filter((p) => !entry.disabledIn.includes(p)).join(", ") || "none"}.`
+        : "Remove it from 'disable' to use it there.")
+    );
+  }
+  if (sessionHasTask) return null;
+  if (entry.providers.length === 0) return null;
+  return (
+    `'${taskName}' is not available in editor '${sessionName}'. ` +
+    `Editors that provide it: ${entry.providers.join(", ")}. ` +
+    `Address one with the 'editor' parameter.`
+  );
+}
+
+/** Union of every session's plugin knowledge, first contributor wins per blob. */
+export function unionKnowledge(surfaces: SessionSurface[]): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  const seen = new Set<string>();
+  for (const surface of surfaces) {
+    for (const [category, blobs] of Object.entries(surface.knowledgeByCategory)) {
+      for (const blob of blobs) {
+        const key = `${category}::${blob}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        (out[category] ??= []).push(blob);
+      }
+    }
+  }
+  return out;
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -29,6 +29,7 @@ import { makeResolveExistingFile } from "./flow/task-guards.js";
 import { normalizeProjectRoot } from "./port.js";
 import { McpError, ErrorCode } from "./errors.js";
 import { warn } from "./log.js";
+import { newLockOwnerId } from "./locking.js";
 
 /** Key used for the session that has no project bound. */
 export const DEFAULT_SESSION_KEY = "";
@@ -67,13 +68,24 @@ export class EditorSession {
   readonly guarded: GuardedBridge;
   /** Names of other sessions that resolved to the same port. */
   portSharedWith: string[] = [];
+  /**
+   * Who this editor's asset locks belong to (#817).
+   *
+   * The lock registry lives in the bridge, which is per editor, so the holder
+   * has to be per editor as well. One id shared across sessions would make a
+   * lock taken in one editor read as re-entrant in another, which defeats the
+   * point of taking it.
+   */
+  readonly lockOwnerId: string = newLockOwnerId();
 
   constructor(
     public name: string,
     /** Resolved project root. Moves when the session's project moves. */
     public key: string,
     readonly project: ProjectContext,
-    guards: GuardRegistry,
+    /** This session's own guard pipeline. Guards from one project's plugins
+     *  must not veto another project's calls, so each session has its own. */
+    readonly guards: GuardRegistry,
   ) {
     this.bridge = new EditorBridge();
     // Order matters: setConfigPort marks the port as config-pinned, which is
@@ -131,7 +143,18 @@ export class SessionRegistry {
   /** Held while a compound edit is mid-flight, so observers see one change. */
   private suppressNotify = false;
 
+  /**
+   * `guards` is the pipeline the FIRST session gets, so a caller that already
+   * built one (the server, which populates it after the task registries exist)
+   * keeps working unchanged at one editor. Every session after the first gets
+   * its own, because a guard declared by one project's plugins has no business
+   * running on another project's calls.
+   */
   constructor(private readonly guards: GuardRegistry = new GuardRegistry()) {}
+
+  private guardsForNewSession(): GuardRegistry {
+    return this.byKey.size === 0 ? this.guards : new GuardRegistry();
+  }
 
   get size(): number {
     return this.byKey.size;
@@ -173,7 +196,7 @@ export class SessionRegistry {
     }
 
     const name = this.uniqueName(input.name ?? project.projectName ?? DEFAULT_SESSION_NAME);
-    const session = new EditorSession(name, key, project, this.guards);
+    const session = new EditorSession(name, key, project, this.guardsForNewSession());
     this.byKey.set(key, session);
     if (input.makeActive || this.activeKey === null) this.activeKey = key;
     this.noteSharedPorts(session);

--- a/src/tool-search.ts
+++ b/src/tool-search.ts
@@ -73,7 +73,7 @@ const DEPRIORITIZE = new Set(["execute_python", "run_python_file", "execute_comm
 
 /**
  * Search every registered tool + action for a keyword/intent query.
- * ALL_TOOLS is imported lazily to avoid a load-time circular dependency
+ * The tool graph is imported lazily to avoid a load-time circular dependency
  * (tools.ts imports the project tool, which imports this).
  */
 export async function searchTools(query: string, limit = 20): Promise<ToolSearchHit[]> {
@@ -83,10 +83,13 @@ export async function searchTools(query: string, limit = 20): Promise<ToolSearch
   if (rawTerms.length === 0) return [];
   const terms = expandTerms(rawTerms);
 
-  const { ALL_TOOLS } = await import("./tools.js");
+  // The live graph, not the pristine declaration: discovery has to see the
+  // Epic and plugin actions the server actually advertises, and with one graph
+  // per editor session those are no longer the same objects (#817).
+  const { getLiveToolGraph } = await import("./tools.js");
   const hitsByHandler = new Map<string, ToolSearchHit>();
 
-  for (const tool of ALL_TOOLS as Array<{ name: string; actions?: Record<string, { description?: string; bridge?: string }> }>) {
+  for (const tool of getLiveToolGraph() as Array<{ name: string; actions?: Record<string, { description?: string; bridge?: string }> }>) {
     for (const [actionName, spec] of Object.entries(tool.actions ?? {})) {
       if (DEPRIORITIZE.has(actionName)) continue;
       const desc = spec?.description ?? "";

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -59,6 +59,31 @@ export const ALL_TOOLS: ToolDef[] = [
   fabTool,
 ];
 
+/**
+ * The graph the running server actually advertises (#817).
+ *
+ * `ALL_TOOLS` is the pristine declaration. Plugin injection and Epic
+ * enrichment used to mutate it in place, which is how `searchTools` and the
+ * feedback router came to observe the enriched surface: same objects, same
+ * module. With one graph per editor session that stops being true, so the
+ * server publishes the union of its sessions' graphs here and the consumers
+ * that want "what does this server actually expose" read it from one place.
+ *
+ * Defaults to `ALL_TOOLS`, so anything running with no server (the CLI,
+ * scripts, tests) sees exactly what it saw before.
+ */
+let liveToolGraph: ToolDef[] = ALL_TOOLS;
+
+/** Publish the graph the server advertises. Called once construction is done. */
+export function setLiveToolGraph(tools: ToolDef[]): void {
+  liveToolGraph = tools;
+}
+
+/** The graph the server advertises, or the pristine declaration off-server. */
+export function getLiveToolGraph(): ToolDef[] {
+  return liveToolGraph;
+}
+
 /** Flatten to (toolName, actionName, bridgeMethod) triples for every action
  *  that dispatches to a C++ bridge method (i.e. has `bridge` set). Local-only
  *  actions (those with a custom `handler`) are excluded. */

--- a/src/tools/asset.ts
+++ b/src/tools/asset.ts
@@ -2,6 +2,21 @@ import { z } from "zod";
 import { categoryTool, bp, type ToolDef } from "../types.js";
 import { Vec3, Rotator } from "../schemas.js";
 import { SESSION_ID } from "../locking.js";
+import type { ToolContext } from "../types.js";
+
+/**
+ * Who a lock belongs to: the addressed editor, or this process when there is
+ * no session behind the call (#817).
+ *
+ * The lock registry lives in the bridge, which is per editor, so the owner has
+ * to match whatever `withAssetLocks` used on the dispatch path or an explicit
+ * asset(unlock) would not match the lock asset(lock) took. Both read this.
+ */
+function lockOwner(ctx: ToolContext, params: Record<string, unknown>): string {
+  const explicit = params.sessionId;
+  if (typeof explicit === "string" && explicit.trim() !== "") return explicit;
+  return ctx.session?.lockOwnerId ?? SESSION_ID;
+}
 
 export const assetTool: ToolDef = categoryTool(
   "asset",
@@ -155,10 +170,29 @@ export const assetTool: ToolDef = categoryTool(
     // lives in the bridge (the shared editor), keyed by asset path with a TTL
     // so a crashed session never wedges an asset. sessionId defaults to this
     // server process; pass it explicitly to coordinate across processes.
-    lock:                 bp("Acquire an exclusive lock on an asset for this session. Returns acquired=true, or acquired=false with holder{sessionId,ttlSecondsRemaining} when another session holds it. Params: assetPath, ttlSeconds? (default 300), sessionId?", "acquire_lock", (p) => ({ path: p.assetPath ?? p.path, sessionId: p.sessionId ?? SESSION_ID, ttlSeconds: p.ttlSeconds })),
-    unlock:               bp("Release an asset lock held by this session (or force=true to break any holder's lock). Params: assetPath, force?, sessionId?", "release_lock", (p) => ({ path: p.assetPath ?? p.path, sessionId: p.sessionId ?? SESSION_ID, force: p.force })),
+    lock: {
+      description: "Acquire an exclusive lock on an asset for this editor. Returns acquired=true, or acquired=false with holder{sessionId,ttlSecondsRemaining} when another session holds it. Params: assetPath, ttlSeconds? (default 300), sessionId?",
+      handler: async (ctx, p) => ctx.bridge.call("acquire_lock", {
+        path: p.assetPath ?? p.path,
+        sessionId: lockOwner(ctx, p),
+        ttlSeconds: p.ttlSeconds,
+      }),
+    },
+    unlock: {
+      description: "Release an asset lock held by this editor (or force=true to break any holder's lock). Params: assetPath, force?, sessionId?",
+      handler: async (ctx, p) => ctx.bridge.call("release_lock", {
+        path: p.assetPath ?? p.path,
+        sessionId: lockOwner(ctx, p),
+        force: p.force,
+      }),
+    },
     list_locks:           bp("List all currently-held asset locks with holder session id, acquiredAt, and ttlSecondsRemaining.", "list_locks"),
-    unlock_all:           bp("Release every lock held by one session in a single call, returning the number released. Defaults to this server process's session; pass sessionId to clear a different one (for example after a crashed session left assets wedged). Params: sessionId?", "release_session_locks", (p) => ({ sessionId: p.sessionId ?? SESSION_ID })),
+    unlock_all: {
+      description: "Release every lock held by one session in a single call, returning the number released. Defaults to the addressed editor's own session; pass sessionId to clear a different one (for example after a crashed session left assets wedged). Params: sessionId?",
+      handler: async (ctx, p) => ctx.bridge.call("release_session_locks", {
+        sessionId: lockOwner(ctx, p),
+      }),
+    },
     diff:                 bp("Semantic structural diff between two assets of any type, dispatching on the asset's class. Blueprints are diffed structurally (parent class, variables, functions, components, per-graph node and connection deltas); other asset types report that diffing is not supported yet rather than failing opaquely. Params: assetPath, otherPath", "diff_asset", (p) => ({ assetPath: p.assetPath ?? p.path, otherPath: p.otherPath })),
   },
   undefined,

--- a/src/tools/editor.ts
+++ b/src/tools/editor.ts
@@ -121,7 +121,7 @@ export const editorTool: ToolDef = categoryTool(
           }
           const unresolved = candidates.filter((c) => !ruled.has(c.action));
           if (unresolved.length > 0) {
-            pushWorkaround({ code, timestamp: new Date().toISOString(), taskSummary, suggestedTool: candidates.map((c) => `${c.tool}(${c.action})`).join(", ") });
+            pushWorkaround({ code, timestamp: new Date().toISOString(), taskSummary, suggestedTool: candidates.map((c) => `${c.tool}(${c.action})`).join(", ") }, ctx);
             return {
               blocked: true,
               reason: "candidates_not_ruled_out",
@@ -144,7 +144,7 @@ export const editorTool: ToolDef = categoryTool(
           ? JSON.stringify(result).slice(0, 200)
           : String(result).slice(0, 200);
         const entry = { code, timestamp: new Date().toISOString(), resultSnippet: snippet, taskSummary };
-        pushWorkaround(entry);
+        pushWorkaround(entry, ctx);
         try {
           const os = await import("node:os");
           const fs = await import("node:fs");
@@ -157,7 +157,7 @@ export const editorTool: ToolDef = categoryTool(
           // side-channel is best-effort; primary tracking is the in-memory stack
         }
 
-        const n = workaroundCount();
+        const n = workaroundCount(ctx);
         return directive(
           [
             `[AGENT DIRECTIVE - MANDATORY]`,

--- a/src/tools/feedback.ts
+++ b/src/tools/feedback.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { categoryTool, directive, type ToolDef, type ToolContext } from "../types.js";
 import { submitFeedback } from "../github-app.js";
 import { readUserAuth } from "../auth.js";
-import { getWorkarounds, clearWorkarounds } from "../workaround-tracker.js";
+import { getWorkarounds, clearWorkarounds, type WorkaroundScopeSource } from "../workaround-tracker.js";
 import { scrubSecrets } from "../secret-scrub.js";
 import { privacyScrub } from "../privacy-scrub.js";
 import { deferSubmission } from "../feedback-deferred.js";
@@ -187,6 +187,29 @@ interface AssembledPayload {
 interface PrivacyInputs {
   projectRoot?: string;
   projectName?: string;
+  /** Roots of the other editors this server drives, scrubbed defensively. */
+  otherProjectRoots?: string[];
+  /** Names of the other editors this server drives, scrubbed defensively. */
+  otherProjectNames?: string[];
+}
+
+/**
+ * Roots and names of every editor this server drives except the submitting
+ * one. Fed to the privacy scrub so a body that somehow carried another
+ * project's identifiers cannot post them to a public tracker (#817).
+ */
+function otherSessionIdentifiers(ctx: ToolContext): {
+  otherProjectRoots: string[];
+  otherProjectNames: string[];
+} {
+  const roots: string[] = [];
+  const names: string[] = [];
+  for (const other of ctx.sessions?.list() ?? []) {
+    if (other === ctx.session) continue;
+    if (other.project.projectDir) roots.push(other.project.projectDir);
+    if (other.project.projectName) names.push(other.project.projectName);
+  }
+  return { otherProjectRoots: roots, otherProjectNames: names };
 }
 
 function assemblePayload(
@@ -196,6 +219,8 @@ function assemblePayload(
   idealTool: string | undefined,
   privacy: PrivacyInputs,
   routing: RoutingDecision | null = null,
+  /** Which editor is submitting. Its workaround log is the only one bundled. */
+  scope?: WorkaroundScopeSource,
 ): AssembledPayload {
   const sections: string[] = ["## Summary", summary];
 
@@ -213,7 +238,7 @@ function assemblePayload(
     );
   }
 
-  const sessionWorkarounds = getWorkarounds();
+  const sessionWorkarounds = getWorkarounds(scope);
   if (sessionWorkarounds.length > 0) {
     sections.push("", "## Session Workaround Log", `${sessionWorkarounds.length} execute_python call(s) this session:`, "");
     for (const w of sessionWorkarounds) {
@@ -244,15 +269,9 @@ function assemblePayload(
   // server-side before the body ever appears on the elicitation prompt or
   // crosses the GitHub API boundary.
   const secretsBody = scrubSecrets(rawBody);
-  const privacyBody = privacyScrub(secretsBody.text, {
-    projectRoot: privacy.projectRoot,
-    projectName: privacy.projectName,
-  });
+  const privacyBody = privacyScrub(secretsBody.text, privacy);
   const secretsTitle = scrubSecrets(title);
-  const privacyTitle = privacyScrub(secretsTitle.text, {
-    projectRoot: privacy.projectRoot,
-    projectName: privacy.projectName,
-  });
+  const privacyTitle = privacyScrub(secretsTitle.text, privacy);
 
   const allHits = [
     ...secretsBody.hits,
@@ -380,7 +399,7 @@ export const feedbackTool: ToolDef = categoryTool(
         // Enum, default "user" per the schema. Missing == "user".
         const author: AuthorIntent = params.author === "bot" ? "bot" : "user";
 
-        const sessionWorkarounds = getWorkarounds();
+        const sessionWorkarounds = getWorkarounds(ctx);
         const rejection = validateSubmission(
           title,
           summary,
@@ -389,7 +408,7 @@ export const feedbackTool: ToolDef = categoryTool(
           sessionWorkarounds.length,
         );
         if (rejection) {
-          clearWorkarounds();
+          clearWorkarounds(ctx);
           return directive(
             [
               `[FEEDBACK REJECTED - DO NOT RETRY]`,
@@ -462,8 +481,10 @@ export const feedbackTool: ToolDef = categoryTool(
           {
             projectRoot: ctx.project?.projectDir ?? undefined,
             projectName: ctx.project?.projectName ?? undefined,
+            ...otherSessionIdentifiers(ctx),
           },
           routing,
+          ctx,
         );
 
         // Two independent checks: (1) capture intent above, (2) validate
@@ -522,7 +543,7 @@ export const feedbackTool: ToolDef = categoryTool(
             ctx.project?.projectName ?? null,
             useBotForSubmit ? "bot" : "user",
           );
-          clearWorkarounds();
+          clearWorkarounds(ctx);
           return {
             message: `Feedback deferred locally for later review (id ${entry.id}), aimed at ${repoSlug(targetRepo)}.`,
             deferred: true,
@@ -607,7 +628,7 @@ export const feedbackTool: ToolDef = categoryTool(
               },
             );
           }
-          clearWorkarounds();
+          clearWorkarounds(ctx);
           return {
             message: `Feedback auto-approved and submitted to ${repoSlug(postedTo)} as ${result.authoredAs === "user" ? `@${result.authoredBy}` : "bot"} (auto-approve mode).`,
             issue_url: result.url,
@@ -951,7 +972,7 @@ export const feedbackTool: ToolDef = categoryTool(
 
         // The body has shipped, drop the session log so a follow-up doesn't
         // re-bundle the same execute_python calls into a second issue.
-        clearWorkarounds();
+        clearWorkarounds(ctx);
 
         return {
           message: `Feedback submitted to ${repoSlug(targetRepo)} as ${result.authoredAs === "user" ? `@${result.authoredBy}` : "bot"}`,

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -589,8 +589,8 @@ export const projectTool: ToolDef = categoryTool(
     },
     execute_python_report: {
       description: "Measurement for #704: reads this session's execute_python calls and, for each, runs its taskSummary back through search_tools to flag calls that OVERLAPPED an existing dedicated action ('you used Python for X, but tool Y does X'). Returns totalCalls, overlapping[] and an overlapRate. Params: none (#704)",
-      handler: async () => {
-        const entries = getWorkarounds();
+      handler: async (ctx) => {
+        const entries = getWorkarounds(ctx);
         const overlapping: Array<{ taskSummary: string; suggestion: ToolSearchHit; codeSnippet: string }> = [];
         for (const e of entries) {
           const q = (e.taskSummary ?? "").trim();

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,12 +46,15 @@ export interface ToolContext {
   sessions?: SessionRegistry;
   /** Lazy accessor for the active flow registry. Returns the merged
    *  built-in + ue-mcp.yml flows. Used by project(get_status) so agents
-   *  see which canonical sequences are pre-encoded for this project. */
-  getFlows?: () => Array<{ name: string; description?: string }>;
+   *  see which canonical sequences are pre-encoded for this project.
+   *  Takes the session to read, because flows are declared in each project's
+   *  own ue-mcp.yml; omitted means this context's session. */
+  getFlows?: (forSession?: EditorSession) => Array<{ name: string; description?: string }>;
   /** Lazy accessor for the loaded plugin set. Returns one PluginInfo per
    *  entry in the user's `plugins:` array, active or skipped. Used by the
-   *  `plugins` introspection category. */
-  getPlugins?: () => PluginInfo[];
+   *  `plugins` introspection category. Session-scoped for the same reason
+   *  as getFlows: `plugins:` is per project. */
+  getPlugins?: (forSession?: EditorSession) => PluginInfo[];
   /** MCP elicitation gate. When defined, calling this blocks the active
    *  tool invocation until the user responds in their MCP client UI. When
    *  undefined, the connected client does not declare the elicitation
@@ -116,6 +119,51 @@ export interface ToolDef {
    *  Dispatch reads it to know whether an `editor` param is a routing
    *  instruction (strip it) or one of the tool's own params (forward it). */
   injectedEditorParam?: boolean;
+  /**
+   * Build an independent copy of this tool (#817).
+   *
+   * Epic enrichment and plugin injection mutate `actions`, `schema` and
+   * `description` in place, so two editors sharing one ToolDef share whatever
+   * either of them was enriched with: a project with a toolset the other does
+   * not have would advertise that toolset on both. Each session therefore
+   * gets its own graph, cloned from the pristine one before anything touches
+   * it.
+   *
+   * Set by `categoryTool`, which is the only thing that can rebuild the
+   * dispatch closure so the copy reads its OWN actions rather than the
+   * original's. A tool built by hand carries no rebuilder and is copied
+   * structurally instead.
+   */
+  rebuild?: (actions: Record<string, ActionSpec>) => ToolDef;
+}
+
+/**
+ * An independent copy of one tool. Prefers the rebuilder so the copy's
+ * handler dispatches against the copy's actions; falls back to a structural
+ * copy of the mutated containers for hand-written tools, whose handlers do
+ * not read `actions` at all.
+ */
+export function cloneToolDef(tool: ToolDef): ToolDef {
+  // An action-less tool cannot go back through categoryTool: the action enum
+  // it builds needs at least one name. Nothing enriches such a tool either, so
+  // the structural copy below is sufficient.
+  if (tool.rebuild && Object.keys(tool.actions).length > 0) {
+    const copy = tool.rebuild({ ...tool.actions });
+    copy.description = tool.description;
+    copy.schema = { ...tool.schema };
+    copy.injectedEditorParam = tool.injectedEditorParam;
+    return copy;
+  }
+  return {
+    ...tool,
+    schema: { ...tool.schema },
+    actions: { ...tool.actions },
+  };
+}
+
+/** An independent copy of a whole tool graph. */
+export function cloneToolGraph(tools: ToolDef[]): ToolDef[] {
+  return tools.map(cloneToolDef);
 }
 
 export interface ActionSpec {
@@ -245,6 +293,11 @@ export function categoryTool(
       throw new McpError(ErrorCode.NO_HANDLER, `Action '${action}' has no handler or bridge method`);
     },
   };
+  // Rebuilding through the same constructor is what makes a per-session copy
+  // real: the handler closes over `actions`, so a copy that only replaced the
+  // record would still dispatch against the original's.
+  def.rebuild = (nextActions) =>
+    categoryTool(name, summary, nextActions, actionDocs, extraSchema, options);
   return def;
 }
 
@@ -259,7 +312,18 @@ function stripAction(params: Record<string, unknown>): Record<string, unknown> {
  * another project's editor.
  */
 export function sessionContext(ctx: ToolContext, session: EditorSession): ToolContext {
-  return { ...ctx, bridge: session.guarded, project: session.project, session };
+  const { getFlows, getPlugins } = ctx;
+  return {
+    ...ctx,
+    bridge: session.guarded,
+    project: session.project,
+    session,
+    // Rebound, not copied: these read per-project config, so leaving them
+    // pointed at the context's previous session would report one editor's
+    // flows and plugins under another editor's name.
+    getFlows: getFlows ? () => getFlows(session) : undefined,
+    getPlugins: getPlugins ? () => getPlugins(session) : undefined,
+  };
 }
 
 /** Drop the routing parameter from a param bag. */

--- a/src/uninstall-hooks.ts
+++ b/src/uninstall-hooks.ts
@@ -12,11 +12,20 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { uninstallAllRegisteredHooks } from "./hook-installer.js";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, fail, info, ok, warn } from "./ui/ansi.js";
+import { takeEditorTarget, EditorFlagError } from "./editor-flag.js";
 
 function resolveProjectDir(): string | null {
   // index.ts splices the "uninstall-hooks" arg out before this module loads,
-  // so a user-supplied project dir lands at argv[2].
-  const arg = process.argv[2];
+  // so a user-supplied project dir lands at argv[2]. --editor names one of the
+  // editors this server drives and wins over it.
+  let arg: string | undefined;
+  try {
+    const target = takeEditorTarget(process.argv.slice(2));
+    arg = target.projectPath ?? target.rest[0];
+  } catch (e) {
+    fail(e instanceof EditorFlagError ? e.message : String(e));
+    return null;
+  }
   if (arg) {
     if (!fs.existsSync(arg)) {
       fail(`Path does not exist: ${arg}`);

--- a/src/update.ts
+++ b/src/update.ts
@@ -4,6 +4,7 @@ import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { collectDoctor, formatDoctor } from "./doctor.js";
+import { takeEditorTarget, EditorFlagError } from "./editor-flag.js";
 
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
@@ -53,10 +54,17 @@ function runSelfCli(scriptBase: string, projectArg: string | undefined): boolean
 }
 
 async function update() {
-  const args = process.argv.slice(2);
+  let target: { projectPath?: string; rest: string[] };
+  try {
+    target = takeEditorTarget(process.argv.slice(2));
+  } catch (e) {
+    fail(e instanceof EditorFlagError ? e.message : String(e));
+    process.exit(1);
+  }
+  const args = target.rest;
   const shouldBuild = args.includes("--build");
   const shouldDeploy = shouldBuild || args.includes("--deploy");
-  const projectArg = args.find((a) => !a.startsWith("-"));
+  const projectArg = target.projectPath ?? args.find((a) => !a.startsWith("-"));
 
   console.log("");
   console.log(`  ${BOLD}${CYAN}UE-MCP Update${shouldBuild ? " --build" : ""}${RESET}`);

--- a/src/workaround-tracker.ts
+++ b/src/workaround-tracker.ts
@@ -1,6 +1,18 @@
 /**
- * Session-level tracker for execute_python workaround calls.
- * Both the editor tool (to push) and feedback tool (to read/flush) import this.
+ * Tracker for execute_python workaround calls, partitioned per editor session.
+ *
+ * The contents of this tracker are assembled into feedback(submit) payloads and
+ * posted to a public issue tracker, and `clearWorkarounds()` fires on every
+ * submit. While the stack was a single module-level array, both of those were
+ * cross-project: a submit from one editor would carry another project's Python
+ * source into a public issue, and would truncate the other editor's record on
+ * the way out. So the stack is keyed by session (#817, plan item 6.4).
+ *
+ * The key is the session's registry key (its normalized project root). A
+ * context with no session resolves to the empty key, which is also the key the
+ * project-less default session uses and the one the bare module-level
+ * functions read, so a single-editor server and a direct caller land on the
+ * same partition they always did.
  */
 
 export interface WorkaroundEntry {
@@ -13,20 +25,47 @@ export interface WorkaroundEntry {
   suggestedTool?: string;
 }
 
-const stack: WorkaroundEntry[] = [];
-
-export function pushWorkaround(entry: WorkaroundEntry): void {
-  stack.push(entry);
+/** Anything carrying an editor session. Structural so this module stays free of
+ *  a cycle through types.ts, which imports the tool graph. */
+export interface WorkaroundScopeSource {
+  session?: { key: string } | undefined;
 }
 
-export function getWorkarounds(): readonly WorkaroundEntry[] {
+const DEFAULT_SCOPE = "";
+
+const stacks = new Map<string, WorkaroundEntry[]>();
+
+/** The partition key for a tool context. Undefined context means the default. */
+export function workaroundScope(ctx?: WorkaroundScopeSource): string {
+  return ctx?.session?.key ?? DEFAULT_SCOPE;
+}
+
+function stackFor(scope: string): WorkaroundEntry[] {
+  let stack = stacks.get(scope);
+  if (!stack) {
+    stack = [];
+    stacks.set(scope, stack);
+  }
   return stack;
 }
 
-export function clearWorkarounds(): void {
-  stack.length = 0;
+export function pushWorkaround(entry: WorkaroundEntry, ctx?: WorkaroundScopeSource): void {
+  stackFor(workaroundScope(ctx)).push(entry);
 }
 
-export function workaroundCount(): number {
-  return stack.length;
+export function getWorkarounds(ctx?: WorkaroundScopeSource): readonly WorkaroundEntry[] {
+  return stackFor(workaroundScope(ctx));
+}
+
+export function clearWorkarounds(ctx?: WorkaroundScopeSource): void {
+  stackFor(workaroundScope(ctx)).length = 0;
+}
+
+export function workaroundCount(ctx?: WorkaroundScopeSource): number {
+  return stackFor(workaroundScope(ctx)).length;
+}
+
+/** Drop every partition. Test-only; production never wants a global reset. */
+export function resetAllWorkarounds(): void {
+  stacks.clear();
 }

--- a/tests/fake-bridge.ts
+++ b/tests/fake-bridge.ts
@@ -78,6 +78,16 @@ export class FakeBridge {
 
         this.calls.push({ method: msg.method, params });
 
+        // The lock registry is the one piece of editor state this stands in
+        // for rather than stubs, because per-editor lock ownership is exactly
+        // what the multi-editor tier is asserting. It lives in the bridge in
+        // production too, so one registry per fake bridge is faithful.
+        const lockReply = this.serveLock(msg.method, params);
+        if (lockReply !== undefined) {
+          ws.send(JSON.stringify({ id: msg.id, result: lockReply }));
+          return;
+        }
+
         const handler = this.handlers[msg.method];
         if (handler) {
           ws.send(JSON.stringify({ id: msg.id, result: handler(params) }));
@@ -131,6 +141,53 @@ export class FakeBridge {
       }),
       "utf-8",
     );
+  }
+
+  /** Asset path to the session id holding its lock. */
+  private readonly locks = new Map<string, string>();
+
+  /** Answer the lock methods, or undefined for anything else. */
+  private serveLock(method: string, params: Record<string, unknown>): unknown | undefined {
+    const owner = String(params.sessionId ?? "");
+    const assetPath = String(params.path ?? params.assetPath ?? "");
+    switch (method) {
+      case "acquire_lock": {
+        const holder = this.locks.get(assetPath);
+        // Re-entrant for the same owner, refused for anybody else. That
+        // asymmetry is the whole reason the owner id has to be per editor.
+        if (holder !== undefined && holder !== owner) {
+          return { acquired: false, holder: { sessionId: holder, ttlSecondsRemaining: 60 } };
+        }
+        this.locks.set(assetPath, owner);
+        return { acquired: true };
+      }
+      case "release_lock": {
+        const holder = this.locks.get(assetPath);
+        if (holder === owner || params.force === true) {
+          this.locks.delete(assetPath);
+          return { released: true };
+        }
+        return { released: false, holder: { sessionId: holder } };
+      }
+      case "release_session_locks": {
+        let released = 0;
+        for (const [asset, holder] of [...this.locks]) {
+          if (holder !== owner) continue;
+          this.locks.delete(asset);
+          released++;
+        }
+        return { released };
+      }
+      case "list_locks":
+        return { locks: [...this.locks].map(([path, sessionId]) => ({ path, sessionId })) };
+      default:
+        return undefined;
+    }
+  }
+
+  /** Who currently holds a lock on an asset here, if anyone. */
+  lockHolder(assetPath: string): string | undefined {
+    return this.locks.get(assetPath);
   }
 
   /** Methods this bridge was asked for, in order. */

--- a/tests/fake-bridge.ts
+++ b/tests/fake-bridge.ts
@@ -1,0 +1,146 @@
+/**
+ * A stand-in for one editor's bridge, on a real loopback socket (#817, plan 7.1).
+ *
+ * The two-editor cases the plan calls for are about routing: a call addressed
+ * to one editor has to arrive at that editor and nowhere else. Proving that
+ * needs two bridges answering independently, which is exactly what CI cannot
+ * provide - the runners have no Unreal engine, so there is no second editor to
+ * start. What CI can provide is two sockets.
+ *
+ * This speaks the wire protocol the client speaks: a WebSocket carrying
+ * `{id, method, params}` requests and `{id, result}` or `{id, error}` replies,
+ * plus the port lockfile the client discovers a bridge through. Everything
+ * about identity and routing is therefore exercised for real; only the engine
+ * behind the handler is fake.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { WebSocketServer, type WebSocket } from "ws";
+
+/** One call this bridge received. */
+export interface RecordedCall {
+  method: string;
+  params: Record<string, unknown>;
+}
+
+export interface FakeBridgeOptions {
+  /** Project root this bridge claims. A lockfile is published under it. */
+  projectDir: string;
+  /** Methods this bridge knows. Anything else answers as an unknown method. */
+  handlers?: Record<string, (params: Record<string, unknown>) => unknown>;
+  /** Answer every unlisted method with a generic success instead of an error. */
+  answerAnything?: boolean;
+}
+
+export class FakeBridge {
+  private server: WebSocketServer;
+  private sockets = new Set<WebSocket>();
+  readonly calls: RecordedCall[] = [];
+  readonly projectDir: string;
+  private readonly handlers: Record<string, (params: Record<string, unknown>) => unknown>;
+  private readonly answerAnything: boolean;
+
+  private constructor(server: WebSocketServer, opts: FakeBridgeOptions) {
+    this.server = server;
+    this.projectDir = opts.projectDir;
+    this.handlers = opts.handlers ?? {};
+    this.answerAnything = opts.answerAnything ?? true;
+
+    server.on("connection", (ws) => {
+      this.sockets.add(ws);
+      ws.on("close", () => this.sockets.delete(ws));
+      ws.on("message", (data) => {
+        let msg: { id?: string; method?: string; params?: Record<string, unknown> };
+        try {
+          msg = JSON.parse(data.toString());
+        } catch {
+          return;
+        }
+        if (!msg.id || !msg.method) return;
+        const params = msg.params ?? {};
+
+        // The capability handshake is part of connecting, not of routing, and
+        // the client sends it before any caller has asked for anything. It is
+        // answered but not recorded, so `methods` reads as the calls a test
+        // actually made.
+        if (msg.method === "get_bridge_capabilities") {
+          ws.send(JSON.stringify({
+            id: msg.id,
+            result: {
+              protocolVersion: 2,
+              projectName: path.basename(this.projectDir),
+              port: this.port,
+              pid: process.pid,
+            },
+          }));
+          return;
+        }
+
+        this.calls.push({ method: msg.method, params });
+
+        const handler = this.handlers[msg.method];
+        if (handler) {
+          ws.send(JSON.stringify({ id: msg.id, result: handler(params) }));
+          return;
+        }
+        if (this.answerAnything) {
+          // Echo the project so a caller can prove which editor answered.
+          ws.send(JSON.stringify({
+            id: msg.id,
+            result: { ok: true, servedBy: this.projectDir, method: msg.method },
+          }));
+          return;
+        }
+        ws.send(JSON.stringify({
+          id: msg.id,
+          error: { code: -32601, message: `Unknown method: ${msg.method}` },
+        }));
+      });
+    });
+  }
+
+  /** Bind an ephemeral loopback port and publish this project's lockfile. */
+  static async start(opts: FakeBridgeOptions): Promise<FakeBridge> {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await new Promise<void>((resolve, reject) => {
+      server.once("listening", () => resolve());
+      server.once("error", reject);
+    });
+    const bridge = new FakeBridge(server, opts);
+    bridge.writeLockfile();
+    return bridge;
+  }
+
+  get port(): number {
+    const addr = this.server.address();
+    if (addr === null || typeof addr === "string") throw new Error("fake bridge is not listening on a port");
+    return addr.port;
+  }
+
+  /** Publish the port record the client discovers this bridge through. */
+  writeLockfile(): void {
+    const dir = path.join(this.projectDir, "Saved", "UE_MCP_Bridge");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "port.json"),
+      JSON.stringify({
+        port: this.port,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        apiVersion: 1,
+      }),
+      "utf-8",
+    );
+  }
+
+  /** Methods this bridge was asked for, in order. */
+  get methods(): string[] {
+    return this.calls.map((c) => c.method);
+  }
+
+  async stop(): Promise<void> {
+    for (const ws of this.sockets) ws.terminate();
+    this.sockets.clear();
+    await new Promise<void>((resolve) => this.server.close(() => resolve()));
+  }
+}

--- a/tests/multi-editor/session-isolation.test.ts
+++ b/tests/multi-editor/session-isolation.test.ts
@@ -1,0 +1,134 @@
+/**
+ * State that must not be shared between editors (#817, plan item 4.1).
+ *
+ * Asset locks live in the bridge, which is per editor, and guards wrap the
+ * bridge, which is per editor. Both were process-level: one lock owner id for
+ * the whole server, and one guard pipeline every session shared. The first
+ * makes a lock taken in one editor read as re-entrant in another; the second
+ * lets a guard declared by one project's plugins veto another project's calls.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { FakeBridge } from "../fake-bridge.js";
+import { SessionRegistry, type EditorSession } from "../../src/session.js";
+import { withAssetLocks, SESSION_ID } from "../../src/locking.js";
+import { assetTool } from "../../src/tools/asset.js";
+import type { ToolContext } from "../../src/types.js";
+
+let root: string;
+let alpha: FakeBridge;
+let beta: FakeBridge;
+let sessions: SessionRegistry;
+let a: EditorSession;
+let b: EditorSession;
+
+function makeProject(name: string): string {
+  const dir = path.join(root, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, `${name}.uproject`),
+    JSON.stringify({ FileVersion: 3, EngineAssociation: "5.6" }),
+    "utf-8",
+  );
+  return path.join(dir, `${name}.uproject`);
+}
+
+function ctxFor(session: EditorSession): ToolContext {
+  return { bridge: session.guarded, project: session.project, session, sessions };
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-isolation-"));
+  const alphaProject = makeProject("Alpha");
+  const betaProject = makeProject("Beta");
+  alpha = await FakeBridge.start({ projectDir: path.dirname(alphaProject) });
+  beta = await FakeBridge.start({ projectDir: path.dirname(betaProject) });
+
+  sessions = new SessionRegistry();
+  a = sessions.register({ projectPath: alphaProject });
+  b = sessions.register({ projectPath: betaProject });
+  await a.bridge.connect(5000);
+  await b.bridge.connect(5000);
+});
+
+afterEach(async () => {
+  a.bridge.disconnect();
+  b.bridge.disconnect();
+  await alpha.stop();
+  await beta.stop();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("lock ownership", () => {
+  it("gives each editor its own owner id, distinct from the process id", () => {
+    expect(a.lockOwnerId).not.toBe(b.lockOwnerId);
+    expect(a.lockOwnerId).not.toBe(SESSION_ID);
+  });
+
+  it("acquires and releases under the addressed editor's id", async () => {
+    await withAssetLocks(
+      a.bridge,
+      { enabled: true, ttlSeconds: 60 },
+      "asset.create_data_asset",
+      { assetPath: "/Game/Thing" },
+      async () => "done",
+      a.lockOwnerId,
+    );
+
+    const acquire = alpha.calls.find((c) => c.method === "acquire_lock");
+    const release = alpha.calls.find((c) => c.method === "release_lock");
+    expect(acquire?.params.sessionId).toBe(a.lockOwnerId);
+    expect(release?.params.sessionId).toBe(a.lockOwnerId);
+    // The other editor was not involved at all.
+    expect(beta.calls).toEqual([]);
+  });
+
+  it("sends the addressed editor's id from the explicit lock actions too", async () => {
+    await assetTool.actions.lock.handler!(ctxFor(a), { action: "lock", assetPath: "/Game/Thing" });
+    await assetTool.actions.unlock.handler!(ctxFor(b), { action: "unlock", assetPath: "/Game/Thing" });
+    await assetTool.actions.unlock_all.handler!(ctxFor(b), { action: "unlock_all" });
+
+    expect(alpha.calls.find((c) => c.method === "acquire_lock")!.params.sessionId).toBe(a.lockOwnerId);
+    expect(beta.calls.find((c) => c.method === "release_lock")!.params.sessionId).toBe(b.lockOwnerId);
+    expect(beta.calls.find((c) => c.method === "release_session_locks")!.params.sessionId).toBe(b.lockOwnerId);
+  });
+
+  it("round-trips: what unlock releases is what lock acquired", async () => {
+    await assetTool.actions.lock.handler!(ctxFor(a), { action: "lock", assetPath: "/Game/Thing" });
+    await assetTool.actions.unlock.handler!(ctxFor(a), { action: "unlock", assetPath: "/Game/Thing" });
+
+    const acquired = alpha.calls.find((c) => c.method === "acquire_lock")!.params.sessionId;
+    const released = alpha.calls.find((c) => c.method === "release_lock")!.params.sessionId;
+    expect(released).toBe(acquired);
+  });
+
+  it("still honours an explicitly passed sessionId, for clearing a crashed one", async () => {
+    await assetTool.actions.unlock_all.handler!(ctxFor(a), {
+      action: "unlock_all",
+      sessionId: "some-crashed-session",
+    });
+    expect(alpha.calls.at(-1)!.params.sessionId).toBe("some-crashed-session");
+  });
+});
+
+describe("guard pipelines", () => {
+  it("gives each editor its own registry", () => {
+    expect(a.guards).not.toBe(b.guards);
+  });
+
+  it("keeps one editor's guard off the other editor's calls", async () => {
+    a.guards.register({
+      name: "alpha-veto",
+      before: async () => {
+        throw new Error("vetoed by alpha's guard");
+      },
+    });
+
+    await expect(a.guarded.call("place_actor", {})).rejects.toThrow(/vetoed by alpha's guard/);
+    await expect(b.guarded.call("place_actor", {})).resolves.toBeDefined();
+    expect(beta.methods).toEqual(["place_actor"]);
+    expect(alpha.methods).toEqual([]);
+  });
+});

--- a/tests/multi-editor/two-bridge-harness.test.ts
+++ b/tests/multi-editor/two-bridge-harness.test.ts
@@ -1,0 +1,150 @@
+/**
+ * One test process driving two bridges (#817, plan item 7.1).
+ *
+ * The plan's blocker was the module-global bridge in tests/setup.ts, shared by
+ * every smoke file, which made "two editors" unexpressible in a test. Two real
+ * loopback sockets remove that: each session discovers its own bridge through
+ * its own project's lockfile, and every assertion below is about which of the
+ * two actually received a call.
+ *
+ * No engine is involved, which is deliberate: CI runners have no Unreal
+ * install, so a tier that needs one cannot gate merges. Everything that a
+ * second engine would add is behind the handler; everything routing depends on
+ * (port discovery, socket identity, per-session dispatch) is real here.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { FakeBridge } from "../fake-bridge.js";
+import { SessionRegistry } from "../../src/session.js";
+import { getBridgeFor, resetTestBridges } from "../setup.js";
+
+let root: string;
+let alpha: FakeBridge;
+let beta: FakeBridge;
+let alphaDir: string;
+let betaDir: string;
+
+function makeProject(name: string): { dir: string; uproject: string } {
+  const dir = path.join(root, name);
+  fs.mkdirSync(dir, { recursive: true });
+  const uproject = path.join(dir, `${name}.uproject`);
+  fs.writeFileSync(uproject, JSON.stringify({ FileVersion: 3, EngineAssociation: "5.6" }), "utf-8");
+  return { dir, uproject };
+}
+
+beforeEach(async () => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-two-bridge-"));
+  alphaDir = makeProject("Alpha").dir;
+  betaDir = makeProject("Beta").dir;
+  alpha = await FakeBridge.start({ projectDir: alphaDir });
+  beta = await FakeBridge.start({ projectDir: betaDir });
+});
+
+afterEach(async () => {
+  resetTestBridges();
+  await alpha.stop();
+  await beta.stop();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("two bridges in one process", () => {
+  it("binds two distinct ports and publishes a lockfile each", () => {
+    expect(alpha.port).not.toBe(beta.port);
+    for (const dir of [alphaDir, betaDir]) {
+      const lockfile = path.join(dir, "Saved", "UE_MCP_Bridge", "port.json");
+      expect(fs.existsSync(lockfile)).toBe(true);
+    }
+  });
+
+  it("routes each session's calls to its own editor and to no other", async () => {
+    const sessions = new SessionRegistry();
+    const a = sessions.register({ projectPath: path.join(alphaDir, "Alpha.uproject") });
+    const b = sessions.register({ projectPath: path.join(betaDir, "Beta.uproject") });
+
+    await a.bridge.connect(5000);
+    await b.bridge.connect(5000);
+
+    await a.guarded.call("alpha_only_call", { marker: "a" });
+    await b.guarded.call("beta_only_call", { marker: "b" });
+
+    expect(alpha.methods).toEqual(["alpha_only_call"]);
+    expect(beta.methods).toEqual(["beta_only_call"]);
+
+    a.bridge.disconnect();
+    b.bridge.disconnect();
+  });
+
+  it("resolves a target by name and reaches that editor's socket", async () => {
+    const sessions = new SessionRegistry();
+    sessions.register({ projectPath: path.join(alphaDir, "Alpha.uproject") });
+    sessions.register({ projectPath: path.join(betaDir, "Beta.uproject") });
+
+    for (const s of sessions.list()) await s.bridge.connect(5000);
+
+    // The routing decision the MCP dispatch layer makes, made here directly.
+    const target = sessions.resolve("Beta");
+    await target.guarded.call("place_actor", {});
+
+    expect(beta.methods).toEqual(["place_actor"]);
+    expect(alpha.methods).toEqual([]);
+
+    for (const s of sessions.list()) s.bridge.disconnect();
+  });
+
+  it("keeps the untargeted default on the active session and moves it with use_editor", async () => {
+    const sessions = new SessionRegistry();
+    sessions.register({ projectPath: path.join(alphaDir, "Alpha.uproject") });
+    sessions.register({ projectPath: path.join(betaDir, "Beta.uproject") });
+    for (const s of sessions.list()) await s.bridge.connect(5000);
+
+    await sessions.resolve(undefined).guarded.call("first", {});
+    expect(alpha.methods).toEqual(["first"]);
+
+    sessions.use("Beta");
+    await sessions.resolve(undefined).guarded.call("second", {});
+    expect(beta.methods).toEqual(["second"]);
+    expect(alpha.methods).toEqual(["first"]);
+
+    for (const s of sessions.list()) s.bridge.disconnect();
+  });
+
+  it("leaves one editor answering when the other one goes away", async () => {
+    const sessions = new SessionRegistry();
+    const a = sessions.register({ projectPath: path.join(alphaDir, "Alpha.uproject") });
+    const b = sessions.register({ projectPath: path.join(betaDir, "Beta.uproject") });
+    await a.bridge.connect(5000);
+    await b.bridge.connect(5000);
+
+    await beta.stop();
+
+    const result = await a.guarded.call("still_here", {});
+    expect((result as { servedBy?: string }).servedBy).toBe(alphaDir);
+
+    a.bridge.disconnect();
+    b.bridge.disconnect();
+  });
+});
+
+describe("the smoke harness accessor", () => {
+  it("hands out one bridge per project instead of one per process", async () => {
+    const one = await getBridgeFor({ projectDir: alphaDir, verifyTarget: false });
+    const two = await getBridgeFor({ projectDir: betaDir, verifyTarget: false });
+
+    expect(one).not.toBe(two);
+    expect(one.port).toBe(alpha.port);
+    expect(two.port).toBe(beta.port);
+
+    await one.call("from_one", {});
+    await two.call("from_two", {});
+    expect(alpha.methods).toEqual(["from_one"]);
+    expect(beta.methods).toEqual(["from_two"]);
+  });
+
+  it("reuses the connection for a project it already reached", async () => {
+    const first = await getBridgeFor({ projectDir: alphaDir, verifyTarget: false });
+    const again = await getBridgeFor({ projectDir: alphaDir, verifyTarget: false });
+    expect(again).toBe(first);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { EditorBridge } from "../src/bridge.js";
 import {
   assertLoopbackHost,
@@ -6,8 +7,20 @@ import {
   verifyTestProjectTarget,
 } from "../scripts/bridge-target.mjs";
 
-let _bridge: EditorBridge | null = null;
+// One connection per project, not one per process (#817, plan item 7.1).
+// The single module-global bridge is what made "drive two editors from one
+// test process" unexpressible; keying by project root makes it ordinary.
+const _bridges = new Map<string, EditorBridge>();
 let _targetVerified = false;
+
+/** The key a project's connection is cached under. */
+function bridgeKey(projectDir?: string): string {
+  return (projectDir ?? "")
+    .split(path.sep)
+    .join("/")
+    .replace(/\/+$/, "")
+    .toLowerCase();
+}
 
 // 127.0.0.1 rather than "localhost": on hosts where the IPv6 stack wins DNS,
 // "localhost" resolves to ::1 and the client waits on an empty socket while the
@@ -23,11 +36,41 @@ const ENV_PORT = Number.parseInt(process.env.UE_MCP_TEST_PORT ?? "", 10);
  * project other than tests/ue_mcp aborts the run before a single mutation.
  */
 export async function getBridge(): Promise<EditorBridge> {
-  if (_bridge?.isConnected) return _bridge;
+  return getBridgeFor();
+}
+
+/** Which editor a harness wants, and whether to enforce the test-project guard. */
+export interface BridgeTarget {
+  /**
+   * Project root to find a bridge for. Omitted means the repo's own test
+   * project, which is what every smoke file wants and the only target the
+   * guard below permits.
+   */
+  projectDir?: string;
+  /**
+   * Verify the connected editor has the repo's test project open. On by
+   * default, and only ever turned off for a harness talking to a bridge that
+   * is not an editor at all.
+   */
+  verifyTarget?: boolean;
+}
+
+/**
+ * Connect to one project's bridge. Repeat calls for the same project reuse the
+ * connection; different projects get different ones, so a single test process
+ * can drive several editors at once.
+ */
+export async function getBridgeFor(target: BridgeTarget = {}): Promise<EditorBridge> {
+  const key = bridgeKey(target.projectDir);
+  const cached = _bridges.get(key);
+  if (cached?.isConnected) return cached;
 
   assertLoopbackHost(TEST_BRIDGE_HOST);
+  // UE_MCP_TEST_PORT pins the repo's own test project, so it must not be
+  // applied to a harness that named a different project.
   const { candidates, lockfile } = bridgePortCandidates({
-    explicitPort: Number.isInteger(ENV_PORT) ? ENV_PORT : null,
+    explicitPort: !target.projectDir && Number.isInteger(ENV_PORT) ? ENV_PORT : null,
+    projectDir: target.projectDir,
   });
 
   let lastError: string | null = null;
@@ -40,8 +83,8 @@ export async function getBridge(): Promise<EditorBridge> {
       bridge.disconnect();
       continue;
     }
-    _bridge = bridge;
-    if (!_targetVerified) {
+    _bridges.set(key, bridge);
+    if (target.verifyTarget !== false && !_targetVerified) {
       await verifyTestProjectTarget((method, params) => bridge.call(method, params));
       _targetVerified = true;
     }
@@ -54,8 +97,14 @@ export async function getBridge(): Promise<EditorBridge> {
 }
 
 export function disconnectBridge(): void {
-  _bridge?.disconnect();
-  _bridge = null;
+  for (const bridge of _bridges.values()) bridge.disconnect();
+  _bridges.clear();
+}
+
+/** Drop every cached connection. Test-only; a smoke run wants them kept. */
+export function resetTestBridges(): void {
+  disconnectBridge();
+  _targetVerified = false;
 }
 
 export interface TestResult {
@@ -85,7 +134,7 @@ export async function callBridge(
       const message = e instanceof Error ? e.message : String(e);
       if (message.includes("connection lost") && attempt < 2) {
         await new Promise((r) => setTimeout(r, 2000));
-        try { await _bridge?.connect(5000); } catch { /* retry */ }
+        try { await bridge.connect(5000); } catch { /* retry */ }
         continue;
       }
       return { method, ok: false, ms: Math.round(performance.now() - start), error: message };

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -114,6 +114,31 @@ describe("parseServerInvocation", () => {
   it("returns null for a non-ue-mcp process", () => {
     expect(parseServerInvocation("node /some/other/server.js project")).toBeNull();
   });
+
+  // #817: a server can be launched with more than one project.
+  it("returns every project positional, quoted or bare", () => {
+    const cmd = 'node C:/x/ue-mcp/dist/index.js "C:/proj/Alpha/Alpha.uproject" C:/proj/Beta/Beta.uproject';
+    const r = parseServerInvocation(cmd);
+    expect(r?.projects).toEqual([
+      "C:/proj/Alpha/Alpha.uproject",
+      "C:/proj/Beta/Beta.uproject",
+    ]);
+    // The single-project field still reads as the first, unchanged.
+    expect(r?.project).toBe("C:/proj/Alpha/Alpha.uproject");
+  });
+
+  it("keeps flags out of the project list", () => {
+    const r = parseServerInvocation("node /x/ue-mcp/dist/index.js /proj/Alpha --verbose /proj/Beta");
+    expect(r?.projects).toEqual(["/proj/Alpha", "/proj/Beta"]);
+  });
+
+  // These three subcommands were absent from NON_SERVER_ARGS, so each parsed
+  // as a running server whose project was the subcommand's own name.
+  it("rejects the context, login and logout subcommands", () => {
+    expect(parseServerInvocation("node /x/ue-mcp/dist/index.js context lean")).toBeNull();
+    expect(parseServerInvocation("node /x/ue-mcp/dist/index.js login")).toBeNull();
+    expect(parseServerInvocation("node /x/ue-mcp/dist/index.js logout")).toBeNull();
+  });
 });
 
 describe("formatDoctor verdict", () => {

--- a/tests/unit/editor-flag.test.ts
+++ b/tests/unit/editor-flag.test.ts
@@ -1,0 +1,194 @@
+/**
+ * `--editor <name-or-path>` on the one-shot CLI subcommands (#817, plan 6.2).
+ *
+ * The property that matters is that a name means the same editor to the CLI
+ * that it means to the running server. The CLI has no session registry, so it
+ * has to reach the same answer from the argv recorded in the MCP client
+ * config, using SessionRegistry's own naming rule.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  parseEditorFlag,
+  namesForProjects,
+  discoverConfiguredEditors,
+  resolveEditorFlag,
+  takeEditorTarget,
+  EditorFlagError,
+} from "../../src/editor-flag.js";
+import { SessionRegistry } from "../../src/session.js";
+
+let root: string;
+
+function makeProject(dirName: string, projectName = dirName): string {
+  const dir = path.join(root, dirName);
+  fs.mkdirSync(dir, { recursive: true });
+  const uproject = path.join(dir, `${projectName}.uproject`);
+  fs.writeFileSync(uproject, JSON.stringify({ FileVersion: 3, EngineAssociation: "5.6" }), "utf-8");
+  return uproject;
+}
+
+function writeMcpJson(cwd: string, projects: string[]): void {
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(
+    path.join(cwd, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        "ue-mcp": { command: "npx", args: ["ue-mcp", ...projects.map((p) => p.replace(/\\/g, "/"))] },
+      },
+    }),
+    "utf-8",
+  );
+}
+
+// Discovery reads the user's real client configs, which is the point in
+// production and machine-dependent in a test. Point HOME/APPDATA at the
+// temp root so only the configs this file writes are visible.
+const realEnv = {
+  HOME: process.env.HOME,
+  USERPROFILE: process.env.USERPROFILE,
+  APPDATA: process.env.APPDATA,
+};
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-editorflag-"));
+  const fakeHome = path.join(root, "home");
+  fs.mkdirSync(fakeHome, { recursive: true });
+  process.env.HOME = fakeHome;
+  process.env.USERPROFILE = fakeHome;
+  process.env.APPDATA = path.join(fakeHome, "AppData", "Roaming");
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(realEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("parseEditorFlag", () => {
+  it("takes --editor <value> and leaves everything else in order", () => {
+    const r = parseEditorFlag(["deploy", "--editor", "beta", "--force", "path/x"]);
+    expect(r.editor).toBe("beta");
+    expect(r.rest).toEqual(["deploy", "--force", "path/x"]);
+  });
+
+  it("takes the --editor=<value> spelling", () => {
+    const r = parseEditorFlag(["--editor=alpha", "lean"]);
+    expect(r.editor).toBe("alpha");
+    expect(r.rest).toEqual(["lean"]);
+  });
+
+  it("leaves an argument list without the flag byte-identical", () => {
+    const argv = ["lean", "--ci", "C:/proj/Alpha"];
+    const r = parseEditorFlag(argv);
+    expect(r.editor).toBeUndefined();
+    expect(r.rest).toEqual(argv);
+  });
+
+  it("does not swallow the next flag when --editor has no value", () => {
+    const r = parseEditorFlag(["--editor", "--build"]);
+    expect(r.editor).toBeUndefined();
+    expect(r.rest).toEqual(["--build"]);
+  });
+});
+
+describe("namesForProjects", () => {
+  it("assigns the same names SessionRegistry would", () => {
+    const alpha = makeProject("Alpha");
+    const beta = makeProject("Beta");
+    const registry = new SessionRegistry();
+    const sa = registry.register({ projectPath: alpha });
+    const sb = registry.register({ projectPath: beta });
+
+    expect(namesForProjects([alpha, beta])).toEqual([sa.name, sb.name]);
+  });
+
+  it("de-duplicates a repeated base name the way the registry does", () => {
+    const first = makeProject("one", "Shared");
+    const second = makeProject("two", "Shared");
+    expect(namesForProjects([first, second])).toEqual(["Shared", "Shared-2"]);
+  });
+});
+
+describe("discoverConfiguredEditors", () => {
+  it("reads every project positional out of a project-scoped client config", () => {
+    const alpha = makeProject("Alpha");
+    const beta = makeProject("Beta");
+    const cwd = path.join(root, "workspace");
+    writeMcpJson(cwd, [alpha, beta]);
+
+    const found = discoverConfiguredEditors(cwd);
+    expect(found.map((e) => e.name)).toEqual(["Alpha", "Beta"]);
+    expect(found.map((e) => path.resolve(e.projectPath))).toEqual([
+      path.resolve(alpha),
+      path.resolve(beta),
+    ]);
+  });
+});
+
+describe("resolveEditorFlag", () => {
+  it("resolves a registered session name to its project", () => {
+    const alpha = makeProject("Alpha");
+    const beta = makeProject("Beta");
+    const cwd = path.join(root, "workspace");
+    writeMcpJson(cwd, [alpha, beta]);
+
+    expect(path.resolve(resolveEditorFlag("beta", cwd))).toBe(path.resolve(beta));
+    expect(path.resolve(resolveEditorFlag("Alpha", cwd))).toBe(path.resolve(alpha));
+  });
+
+  it("resolves a path when no name matches", () => {
+    const gamma = makeProject("Gamma");
+    const cwd = path.join(root, "workspace");
+    fs.mkdirSync(cwd, { recursive: true });
+
+    expect(path.resolve(resolveEditorFlag(gamma, cwd))).toBe(path.resolve(gamma));
+    expect(path.resolve(resolveEditorFlag(path.dirname(gamma), cwd))).toBe(path.resolve(gamma));
+  });
+
+  it("prefers a registered name over a same-named directory in cwd", () => {
+    const real = makeProject("Alpha");
+    const cwd = path.join(root, "workspace");
+    writeMcpJson(cwd, [real]);
+    // A decoy directory in cwd with the same name and its own .uproject.
+    const decoyDir = path.join(cwd, "Alpha");
+    fs.mkdirSync(decoyDir, { recursive: true });
+    fs.writeFileSync(path.join(decoyDir, "Alpha.uproject"), "{}", "utf-8");
+
+    expect(path.resolve(resolveEditorFlag("Alpha", cwd))).toBe(path.resolve(real));
+  });
+
+  it("refuses an unknown target and names what is registered", () => {
+    const alpha = makeProject("Alpha");
+    const cwd = path.join(root, "workspace");
+    writeMcpJson(cwd, [alpha]);
+
+    expect(() => resolveEditorFlag("nope", cwd)).toThrow(EditorFlagError);
+    try {
+      resolveEditorFlag("nope", cwd);
+    } catch (e) {
+      expect((e as Error).message).toContain("Alpha");
+    }
+  });
+});
+
+describe("takeEditorTarget", () => {
+  it("returns the untouched argv when the flag is absent", () => {
+    const argv = ["build", "C:/proj/Alpha"];
+    expect(takeEditorTarget(argv, root)).toEqual({ rest: argv });
+  });
+
+  it("returns a project path and the remaining argv when the flag is present", () => {
+    const alpha = makeProject("Alpha");
+    const cwd = path.join(root, "workspace");
+    writeMcpJson(cwd, [alpha]);
+
+    const r = takeEditorTarget(["build", "--editor", "Alpha"], cwd);
+    expect(path.resolve(r.projectPath!)).toBe(path.resolve(alpha));
+    expect(r.rest).toEqual(["build"]);
+  });
+});

--- a/tests/unit/session-surface.test.ts
+++ b/tests/unit/session-surface.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Per-session tool graphs (#817, plan items 4.1 and 4.2).
+ *
+ * The defect these cover: enrichment mutates ToolDefs in place, so while every
+ * editor shared one graph, a toolset present in one project's engine appeared
+ * on every editor, and a call to it in a project that does not have it reached
+ * that project's bridge instead of being refused.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { categoryTool, cloneToolGraph, bp, type ToolDef } from "../../src/types.js";
+import {
+  baseGraphFor,
+  unionSurface,
+  unionKnowledge,
+  explainMissingAction,
+  type SessionSurface,
+} from "../../src/session-surface.js";
+import { enrichToolsWithEpicCatalog, type EpicCatalog } from "../../src/epic-enrich.js";
+import { ALL_TOOLS } from "../../src/tools.js";
+
+function graph(): ToolDef[] {
+  return [
+    categoryTool("alpha", "Alpha category", {
+      list: bp("List things", "alpha_list"),
+    }),
+    categoryTool("beta", "Beta category", {
+      read: bp("Read a thing", "beta_read"),
+    }),
+  ];
+}
+
+function surfaceOf(name: string, tools: ToolDef[], disabled: string[] = []): SessionSurface {
+  return {
+    session: { name } as SessionSurface["session"],
+    tools,
+    disabled: new Set(disabled),
+    pluginRecords: [],
+    knowledgeByCategory: {},
+  };
+}
+
+function catalogWith(toolset: string, toolName: string): EpicCatalog {
+  return {
+    toolsets: [
+      {
+        name: toolset,
+        tools: [{ name: `${toolset}.${toolName}`, description: `Does ${toolName}` }],
+      },
+    ],
+  } as EpicCatalog;
+}
+
+describe("cloneToolGraph", () => {
+  it("gives each copy its own actions, schema and description", () => {
+    const original = graph();
+    const copy = cloneToolGraph(original);
+
+    copy[0].actions.injected = { description: "only on the copy" };
+    copy[0].description += " (copy)";
+    copy[0].schema.extra = z.string().optional();
+
+    expect(Object.keys(original[0].actions)).toEqual(["list"]);
+    expect(original[0].description).not.toContain("(copy)");
+    expect("extra" in original[0].schema).toBe(false);
+  });
+
+  it("makes the copy's handler dispatch against the copy's actions", async () => {
+    const original = graph();
+    const copy = cloneToolGraph(original);
+    const calls: string[] = [];
+    copy[0].actions.only_on_copy = {
+      handler: async () => {
+        calls.push("copy");
+        return "ok";
+      },
+    };
+
+    await copy[0].handler({ bridge: {} as never, project: {} as never }, { action: "only_on_copy" });
+    expect(calls).toEqual(["copy"]);
+
+    // The original still refuses the action it never gained.
+    await expect(
+      original[0].handler({ bridge: {} as never, project: {} as never }, { action: "only_on_copy" }),
+    ).rejects.toThrow(/Unknown action/);
+  });
+
+  it("clones the real tool graph without losing an action", () => {
+    const copy = baseGraphFor(ALL_TOOLS);
+    expect(copy.length).toBe(ALL_TOOLS.length);
+    for (let i = 0; i < ALL_TOOLS.length; i++) {
+      expect(copy[i].name).toBe(ALL_TOOLS[i].name);
+      expect(Object.keys(copy[i].actions).sort()).toEqual(Object.keys(ALL_TOOLS[i].actions).sort());
+    }
+    expect(copy[0]).not.toBe(ALL_TOOLS[0]);
+  });
+});
+
+describe("per-session Epic enrichment", () => {
+  it("keeps one project's toolset off the other project's graph", () => {
+    // The real graph, because routing sends a toolset to a named category and
+    // falls back to the `epic` umbrella, neither of which a synthetic graph has.
+    const a = baseGraphFor(ALL_TOOLS);
+    const b = baseGraphFor(ALL_TOOLS);
+
+    enrichToolsWithEpicCatalog(a, catalogWith("Niagara", "spawn"), {});
+    enrichToolsWithEpicCatalog(b, catalogWith("Landscape", "sculpt"), {});
+
+    const epicActionsIn = (g: ToolDef[]) =>
+      g.flatMap((t) => Object.keys(t.actions)).filter((k) => k.startsWith("epic_"));
+
+    const aEpic = epicActionsIn(a);
+    const bEpic = epicActionsIn(b);
+    expect(aEpic.length).toBeGreaterThan(0);
+    expect(bEpic.length).toBeGreaterThan(0);
+    expect(aEpic.some((k) => k.includes("spawn"))).toBe(true);
+    expect(aEpic.some((k) => k.includes("sculpt"))).toBe(false);
+    expect(bEpic.some((k) => k.includes("sculpt"))).toBe(true);
+    expect(bEpic.some((k) => k.includes("spawn"))).toBe(false);
+  });
+
+  it("leaves the pristine declaration untouched", () => {
+    const before = ALL_TOOLS.map((t) => Object.keys(t.actions).length);
+    const session = baseGraphFor(ALL_TOOLS);
+    enrichToolsWithEpicCatalog(session, catalogWith("Niagara", "spawn"), {});
+    const after = ALL_TOOLS.map((t) => Object.keys(t.actions).length);
+    expect(after).toEqual(before);
+  });
+});
+
+describe("unionSurface", () => {
+  it("advertises the union and records which editor provides each action", () => {
+    const a = graph();
+    const b = graph();
+    b[0].actions.beta_only = { description: "only in B" };
+
+    const union = unionSurface([surfaceOf("Alpha", a), surfaceOf("Beta", b)]);
+    const alphaCategory = union.tools.find((t) => t.name === "alpha")!;
+
+    expect(Object.keys(alphaCategory.actions).sort()).toEqual(["beta_only", "list"]);
+    expect(union.providers.get("alpha.list")!.providers).toEqual(["Alpha", "Beta"]);
+    expect(union.providers.get("alpha.beta_only")!.providers).toEqual(["Beta"]);
+  });
+
+  it("does not fold the union back into either session's own graph", () => {
+    const a = graph();
+    const b = graph();
+    b[0].actions.beta_only = { description: "only in B" };
+
+    unionSurface([surfaceOf("Alpha", a), surfaceOf("Beta", b)]);
+
+    expect(Object.keys(a[0].actions)).toEqual(["list"]);
+  });
+
+  it("rebuilds the action enum so a merged action is accepted", () => {
+    const a = graph();
+    const b = graph();
+    b[0].actions.beta_only = { description: "only in B" };
+
+    const union = unionSurface([surfaceOf("Alpha", a), surfaceOf("Beta", b)]);
+    const enumSchema = union.tools.find((t) => t.name === "alpha")!.schema.action;
+    expect(enumSchema.safeParse("beta_only").success).toBe(true);
+  });
+
+  it("keeps a category one editor disabled in the union and records where", () => {
+    const union = unionSurface([
+      surfaceOf("Alpha", graph(), ["beta"]),
+      surfaceOf("Beta", graph()),
+    ]);
+    expect(union.tools.map((t) => t.name)).toContain("beta");
+    expect(union.providers.get("beta.read")!.disabledIn).toEqual(["Alpha"]);
+  });
+});
+
+describe("explainMissingAction", () => {
+  it("names the editors that provide an action the addressed one lacks", () => {
+    const a = graph();
+    const b = graph();
+    b[0].actions.beta_only = { description: "only in B" };
+    const union = unionSurface([surfaceOf("Alpha", a), surfaceOf("Beta", b)]);
+
+    const msg = explainMissingAction(union, "alpha.beta_only", "Alpha", false);
+    expect(msg).toContain("not available in editor 'Alpha'");
+    expect(msg).toContain("Beta");
+  });
+
+  it("refuses a disabled category for the editor that disabled it, naming the config", () => {
+    const union = unionSurface([
+      surfaceOf("Alpha", graph(), ["beta"]),
+      surfaceOf("Beta", graph()),
+    ]);
+    const msg = explainMissingAction(union, "beta.read", "Alpha", true);
+    expect(msg).toContain("disabled for editor 'Alpha'");
+    expect(msg).toContain("ue-mcp.yml");
+    expect(msg).toContain("Beta");
+  });
+
+  it("says nothing when the addressed editor can serve the action", () => {
+    const union = unionSurface([surfaceOf("Alpha", graph()), surfaceOf("Beta", graph())]);
+    expect(explainMissingAction(union, "alpha.list", "Alpha", true)).toBeNull();
+  });
+});
+
+describe("unionKnowledge", () => {
+  it("merges each editor's plugin knowledge and de-duplicates shared blobs", () => {
+    const a = surfaceOf("Alpha", graph());
+    a.knowledgeByCategory = { alpha: ["shared", "from A"] };
+    const b = surfaceOf("Beta", graph());
+    b.knowledgeByCategory = { alpha: ["shared"], beta: ["from B"] };
+
+    expect(unionKnowledge([a, b])).toEqual({
+      alpha: ["shared", "from A"],
+      beta: ["from B"],
+    });
+  });
+});

--- a/tests/unit/workaround-partition.test.ts
+++ b/tests/unit/workaround-partition.test.ts
@@ -1,0 +1,138 @@
+/**
+ * The workaround log is partitioned per editor (#817, plan item 6.4).
+ *
+ * Two properties are load-bearing, and both are privacy properties rather than
+ * correctness ones: a submit from one editor must not carry another editor's
+ * Python source into a public issue, and a submit from one editor must not
+ * truncate another editor's log on its way out. Both were broken while the
+ * stack was a single module-level array.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ToolContext, ElicitFn } from "../../src/types.js";
+import {
+  pushWorkaround,
+  getWorkarounds,
+  clearWorkarounds,
+  workaroundCount,
+  resetAllWorkarounds,
+} from "../../src/workaround-tracker.js";
+import { SessionRegistry } from "../../src/session.js";
+
+const mockSubmitFeedback = vi.fn();
+vi.mock("../../src/github-app.js", () => ({
+  submitFeedback: (...args: unknown[]) => mockSubmitFeedback(...args),
+}));
+
+const mockReadUserAuth = vi.fn();
+vi.mock("../../src/auth.js", () => ({
+  readUserAuth: () => mockReadUserAuth(),
+}));
+
+const { feedbackTool } = await import("../../src/tools/feedback.js");
+
+let root: string;
+
+function makeProject(name: string): string {
+  const dir = path.join(root, name);
+  fs.mkdirSync(dir, { recursive: true });
+  const uproject = path.join(dir, `${name}.uproject`);
+  fs.writeFileSync(uproject, JSON.stringify({ FileVersion: 3, EngineAssociation: "5.6" }), "utf-8");
+  return uproject;
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-workaround-"));
+  resetAllWorkarounds();
+  process.env.UE_MCP_FEEDBACK_ROUTING = "off";
+  mockSubmitFeedback.mockReset();
+  mockReadUserAuth.mockReset();
+  mockReadUserAuth.mockResolvedValue({
+    token: "ghu_abc",
+    login: "tester",
+    authorized_at: "2026-05-20T00:00:00Z",
+  });
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+  resetAllWorkarounds();
+  delete process.env.UE_MCP_FEEDBACK_ROUTING;
+});
+
+describe("workaround tracker partitioning", () => {
+  it("keeps each session's entries to itself", () => {
+    const a = { session: { key: "c:/proj/alpha" } };
+    const b = { session: { key: "c:/proj/beta" } };
+
+    pushWorkaround({ code: "alpha_only()", timestamp: "t1" }, a);
+    pushWorkaround({ code: "beta_only()", timestamp: "t2" }, b);
+    pushWorkaround({ code: "beta_again()", timestamp: "t3" }, b);
+
+    expect(workaroundCount(a)).toBe(1);
+    expect(workaroundCount(b)).toBe(2);
+    expect(getWorkarounds(a).map((w) => w.code)).toEqual(["alpha_only()"]);
+  });
+
+  it("clears only the session that submitted", () => {
+    const a = { session: { key: "c:/proj/alpha" } };
+    const b = { session: { key: "c:/proj/beta" } };
+    pushWorkaround({ code: "alpha_only()", timestamp: "t1" }, a);
+    pushWorkaround({ code: "beta_only()", timestamp: "t2" }, b);
+
+    clearWorkarounds(a);
+
+    expect(workaroundCount(a)).toBe(0);
+    expect(workaroundCount(b)).toBe(1);
+  });
+
+  it("routes a context with no session to the same partition as a bare call", () => {
+    pushWorkaround({ code: "bare()", timestamp: "t1" });
+    expect(workaroundCount({})).toBe(1);
+    expect(getWorkarounds().map((w) => w.code)).toEqual(["bare()"]);
+  });
+});
+
+describe("feedback(submit) payload isolation", () => {
+  it("bundles only the submitting editor's workarounds and scrubs the other's identifiers", async () => {
+    const alpha = makeProject("Alpha");
+    const beta = makeProject("BetaProjectName");
+    const sessions = new SessionRegistry();
+    const sa = sessions.register({ projectPath: alpha });
+    const sb = sessions.register({ projectPath: beta });
+
+    pushWorkaround({ code: "unreal.alpha_secret_call()", timestamp: "t1" }, { session: sa });
+    pushWorkaround({ code: "unreal.beta_secret_call()", timestamp: "t2" }, { session: sb });
+
+    let prompted = "";
+    const elicit: ElicitFn = async (p) => {
+      prompted = p.message;
+      return { action: "decline" };
+    };
+
+    const ctx: ToolContext = {
+      bridge: {} as never,
+      project: sa.project,
+      session: sa,
+      sessions,
+      elicit,
+    };
+
+    await feedbackTool.actions.submit.handler!(ctx, {
+      action: "submit",
+      title: "blueprint.set_class_default does not save the asset it edits",
+      summary:
+        "blueprint.set_class_default marks the asset dirty but never saves it, so every call needs an execute_python flush afterwards to persist.",
+      pythonWorkaround: "import unreal\nunreal.do_thing()",
+    });
+
+    expect(prompted).toContain("unreal.alpha_secret_call()");
+    // The other editor's Python never reaches the body that gets posted.
+    expect(prompted).not.toContain("unreal.beta_secret_call()");
+    // Nor does the other editor's project name or root.
+    expect(prompted).not.toContain("BetaProjectName");
+    expect(prompted).not.toContain(path.dirname(beta));
+  });
+});


### PR DESCRIPTION
Closes the phases of `plans/multi-editor.md` that #850 left process-level, and the two the closing comment named as remaining: per-session plugin loading and Epic catalog, and the knowledge block.

### 4.1 / 4.2 Per-session state and union surface

Plugin loading and Epic enrichment ran once, against one module-level tool graph, from the first session's project. Both are project-scoped facts, so a second editor inherited the first one's plugins and toolsets and a call to an action only the first project's engine has reached the second project's bridge and failed there as "Unknown method".

Each session now clones the pristine graph, loads its own plugins into the clone and enriches the clone from its own catalog. `categoryTool` gains a rebuilder because the dispatch closure captures its actions record. Each session also gets its own task registry, its own guards, its own asset-lock owner id and its own flow config source.

The advertised surface beyond one editor is the union, with each action recording its providers. Dispatch to a session that lacks an action is refused naming the editors that have it. A category one project disabled stays advertised for the others and is refused for that one, naming its config.

### 6.2 `--editor` on the CLI

`deploy`, `build`, `init`, `plugin`, `context`, `doctor`, `resolve`, `update`, `feedback` and `uninstall-hooks` accept `--editor <name-or-path>`, resolved as a session name first and a path second. A one-shot CLI has no session registry, so names resolve from the argv recorded in the MCP client config using `SessionRegistry`'s own naming rule.

Two prerequisites this needed: `context-cli` dropped every flag wholesale, and `doctor`'s `NON_SERVER_ARGS` omitted `context`, `login` and `logout` so `ue-mcp context lean` parsed as a server whose project was "context". `parseServerInvocation` also now returns every positional instead of the first.

### 6.4 Feedback partitioning

The `execute_python` workaround stack was one module-level array whose contents are posted to a public issue and whose `clearWorkarounds()` fires on every submit. It is now keyed by session, and the privacy scrub redacts the other registered roots and names defensively.

### 7.1 / 7.2 Multi-editor test tier

`tests/setup.ts` held one bridge shared by all 38 smoke files, which made "two editors" unexpressible. The accessor is keyed by project root; `getBridge()` is unchanged. `tests/multi-editor` drives two bridges on two real loopback sockets from one process and asserts routing, targeting by name, the untargeted default following `use_editor`, per-editor lock ownership and per-editor guard pipelines. CI runs it on every push and pull request.

The engine-dependent half of item 7.2, a live golden diff and lifecycle matrix, is not included: every CI job is `ubuntu-latest` with no Unreal install, so there is no editor to start and no second one to address. That half needs a self-hosted runner with an engine.

### Single-editor behaviour

Verified byte-identical: the server built from this branch and from `main`, started against the same single project, produce identical startup output. The union is skipped entirely at one editor, the advertised list is that session's own objects, and every refusal path is gated on more than one session being registered.

`npx tsc --noEmit` clean, 646 unit and multi-editor tests pass. No `plugin/` files touched, so no C++ build is needed.
