### PR TITLE
Make the release pipeline safe for prerelease versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,8 @@ jobs:
         #   1. Attach the tarball.
         #   2. Replace the body with the frontmatter-stripped version so the
         #      published release page renders clean markdown.
-        #   3. Flip draft=false to publish.
+        #   3. Flip draft=false to publish, marking it prerelease or latest to
+        #      match the channel the npm publish used.
         #   4. Post the landing/headline commit status using the validated,
         #      ` · `-joined string from the step output. CI authors the
         #      status itself - releasers no longer post it manually.
@@ -268,15 +269,28 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
           VERSION: ${{ steps.version.outputs.local }}
+          PRERELEASE: ${{ steps.channel.outputs.prerelease }}
           HEADLINE: ${{ steps.release_inputs.outputs.HEADLINE }}
           BODY_PATH: ${{ steps.release_inputs.outputs.BODY_PATH }}
         run: |
           set -euo pipefail
           gh release upload "v$VERSION" ue-mcp.tar.gz --clobber
+
+          # Both flags are set explicitly in both directions. Leaving them off
+          # hands the repo's "Latest" badge to whatever was promoted last, so a
+          # beta would present itself as the current stable release on the
+          # releases page and in the GitHub API's /releases/latest.
+          if [ "$PRERELEASE" = "true" ]; then
+            CHANNEL_FLAGS=(--prerelease --latest=false)
+          else
+            CHANNEL_FLAGS=(--prerelease=false --latest)
+          fi
+
           gh release edit "v$VERSION" \
             --notes-file "$BODY_PATH" \
             --draft=false \
-            --tag "v$VERSION"
+            --tag "v$VERSION" \
+            "${CHANNEL_FLAGS[@]}"
           gh api -X POST "repos/$REPO/statuses/$SHA" \
             -f state=success \
             -f context=landing/headline \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,27 @@ jobs:
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve release channel
+        # Derives the npm dist-tag and the prerelease flag from the version
+        # itself. A plain X.Y.Z owns `latest`; a prerelease owns the tag named
+        # by its first prerelease identifier (1.2.0-beta and 1.2.0-beta.2 to
+        # `beta`, 1.3.0-rc.1 to `rc`).
+        #
+        # The rules live in scripts/release-version.mjs, under unit test in
+        # tests/unit/release-version.test.ts, because YAML cannot be tested and
+        # the failure mode here is silent: a prerelease published without a tag
+        # becomes the default install for everyone running `npx ue-mcp`.
+        #
+        # Outputs:
+        #   dist_tag   - the npm tag to publish under
+        #   prerelease - true/false, consumed by the Promote step
+        if: steps.version.outputs.should_publish == 'true'
+        id: channel
+        run: |
+          set -euo pipefail
+          node scripts/release-version.mjs --version "${{ steps.version.outputs.local }}" \
+            | tee -a "$GITHUB_OUTPUT"
+
       - name: Validate release inputs
         # Single required pre-publish input: a draft release tagged vX.Y.Z
         # whose body begins with YAML frontmatter containing a `headline:`
@@ -218,8 +239,14 @@ jobs:
         # GitHub Actions OIDC token from the runner and exchanges it with
         # npmjs.org under the trusted-publisher config bound to this repo
         # and workflow. `id-token: write` on the job is required (set above).
+        #
+        # --tag is always passed explicitly. npm defaults to `latest`, so
+        # omitting it would point every `npx ue-mcp` at a prerelease the moment
+        # one is published.
         if: steps.version.outputs.should_publish == 'true'
-        run: npm publish --access public --provenance
+        env:
+          DIST_TAG: ${{ steps.channel.outputs.dist_tag }}
+        run: npm publish --access public --provenance --tag "$DIST_TAG"
 
       - name: Package tarball
         if: steps.version.outputs.should_publish == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,17 +94,44 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Check if version changed
+      - name: Check whether this version is already published
         id: version
         run: |
+          set -euo pipefail
           LOCAL=$(node -p "require('./package.json').version")
-          PUBLISHED=$(npm view ue-mcp version 2>/dev/null || echo "0.0.0")
           echo "local=$LOCAL" >> "$GITHUB_OUTPUT"
-          echo "published=$PUBLISHED" >> "$GITHUB_OUTPUT"
-          if [ "$LOCAL" != "$PUBLISHED" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+
+          # Ask whether THIS EXACT version exists on the registry, not whether
+          # it differs from the `latest` dist-tag. `npm view ue-mcp version`
+          # reports only `latest`, so once a prerelease publishes under its own
+          # tag `latest` stops tracking the repo: every later push would see a
+          # difference, retry the publish, and fail on npm refusing to replace
+          # an existing version. That failure never clears on its own.
+          #
+          # Retried a few times because a registry blip here would otherwise
+          # decide the release.
+          VERSIONS=""
+          for attempt in 1 2 3; do
+            if VERSIONS=$(npm view ue-mcp versions --json 2>/dev/null); then break; fi
+            VERSIONS=""
+            echo "npm view attempt $attempt failed; retrying in 5s"
+            sleep 5
+          done
+
+          # An empty payload fails the step by design. Reading an unreachable
+          # registry as "not published yet" would publish blind.
+          ALREADY=$(node scripts/release-version.mjs --version "$LOCAL" --published-in "$VERSIONS" \
+            | sed -n 's/^published=//p')
+          echo "already_published=$ALREADY" >> "$GITHUB_OUTPUT"
+
+          if [ "$ALREADY" = "true" ]; then
+            # Clean skip, not a failure: re-running main after a release is
+            # normal and every publish step below is gated on this output.
+            echo "ue-mcp@$LOCAL is already on the registry. Nothing to publish."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "ue-mcp@$LOCAL is not on the registry. Publishing."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Validate release inputs
@@ -121,7 +148,7 @@ jobs:
         #   HEADLINE  - the joined ` · ` string posted as the landing/headline status
         #   BODY_PATH - path to a temp file containing the frontmatter-stripped body,
         #               used by the Promote step to update the published release body
-        if: steps.version.outputs.changed == 'true'
+        if: steps.version.outputs.should_publish == 'true'
         id: release_inputs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -155,7 +182,7 @@ jobs:
           printf '%s' "$DRAFT_BODY" | node scripts/release-headline.mjs >> "$GITHUB_OUTPUT"
 
       - name: Install & Build
-        if: steps.version.outputs.changed == 'true'
+        if: steps.version.outputs.should_publish == 'true'
         # See note on the build job's Install step re: the rollup
         # optional-deps bug.
         run: |
@@ -164,7 +191,7 @@ jobs:
           npx tsc
 
       - name: Verify build output
-        if: steps.version.outputs.changed == 'true'
+        if: steps.version.outputs.should_publish == 'true'
         run: |
           # Fail loud if prepublishOnly's output is missing or empty - a
           # broken publish is very hard to retract, so we stop here.
@@ -173,7 +200,7 @@ jobs:
           test -s dist/update.js || (echo "dist/update.js missing or empty" && exit 1)
 
       - name: Tag release (before publish)
-        if: steps.version.outputs.changed == 'true'
+        if: steps.version.outputs.should_publish == 'true'
         run: |
           # Create and push the tag BEFORE publishing to npm. If the tag push
           # fails (network / permissions), we have not yet stranded a live
@@ -191,11 +218,11 @@ jobs:
         # GitHub Actions OIDC token from the runner and exchanges it with
         # npmjs.org under the trusted-publisher config bound to this repo
         # and workflow. `id-token: write` on the job is required (set above).
-        if: steps.version.outputs.changed == 'true'
+        if: steps.version.outputs.should_publish == 'true'
         run: npm publish --access public --provenance
 
       - name: Package tarball
-        if: steps.version.outputs.changed == 'true'
+        if: steps.version.outputs.should_publish == 'true'
         run: tar czf ue-mcp.tar.gz dist/ plugin/ package.json package-lock.json README.md LICENSE
 
       - name: Promote draft release
@@ -208,7 +235,7 @@ jobs:
         #   4. Post the landing/headline commit status using the validated,
         #      ` · `-joined string from the step output. CI authors the
         #      status itself - releasers no longer post it manually.
-        if: steps.version.outputs.changed == 'true'
+        if: steps.version.outputs.should_publish == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,17 @@ CI **gates the publish job** on a single pre-staged input: the draft GitHub rele
 
 Release notes structure (below the frontmatter): one-line summary, then `### Server` / `### Bug fixes` / `### Internals` sections. See prior releases on GitHub for the style. (The `docs/release-notes-*.md` files in the repo predate this flow and are kept as references only.)
 
+### Prereleases
+
+A version with a prerelease suffix (`1.2.0-beta`, `1.2.0-beta.2`, `1.3.0-rc.1`) goes through the exact same flow: draft release with headline frontmatter, bump, push. CI routes it to its own channel automatically.
+
+- **npm dist-tag** comes from the first prerelease identifier, so `1.2.0-beta` and `1.2.0-beta.2` publish under `beta` and `1.3.0-rc.1` under `rc`. `npx ue-mcp` keeps resolving to the newest plain `X.Y.Z`; testers opt in with `ue-mcp@beta`.
+- **The GitHub release** is marked as a prerelease, so it does not take the "Latest" badge or answer `/releases/latest`.
+- **The publish gate** asks whether that exact version is already on the registry, so a prerelease does not wedge every later push.
+- The rules live in `scripts/release-version.mjs` (unit tested in `tests/unit/release-version.test.ts`), mirrored for the shipped CLI in `src/version-check.ts`. Change one and the parity test will tell you to change the other.
+
+The tag name still has to match the version exactly: `gh release create v1.2.0-beta --draft --notes-file ...`.
+
 ## Issue handling
 
 - **Never close an issue without shipping code that resolves it.** Not "out of scope for this patch", not "prerequisite shipped", not "follow-up". Issues close only when the fix ships.

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -1,0 +1,166 @@
+/**
+ * Release channel maths for the publish pipeline.
+ *
+ * The publish job has to answer three questions about the version in
+ * package.json, and getting any of them wrong ships a prerelease at everyone
+ * who runs `npx ue-mcp`:
+ *
+ *   1. Which npm dist-tag does this version belong under? A plain X.Y.Z owns
+ *      `latest`; a prerelease owns the tag named by its first prerelease
+ *      identifier (1.2.0-beta and 1.2.0-beta.2 both go to `beta`,
+ *      1.3.0-rc.1 goes to `rc`).
+ *   2. Is this a prerelease, so the GitHub release is marked as one instead of
+ *      taking the repo's "Latest" badge?
+ *   3. Is this exact version already on the registry? Asking `npm view ue-mcp
+ *      version` only reports the `latest` dist-tag, which stops moving the
+ *      moment a prerelease is published under its own tag, so that question
+ *      has to be asked against the full version list.
+ *
+ * Lives in scripts/ rather than src/ because the publish job calls it before
+ * `npx tsc` has produced dist/. Kept as pure functions plus a thin CLI so the
+ * behaviour is unit tested rather than buried in YAML.
+ *
+ * No shebang: vitest re-imports this file and its loader rejects the shebang
+ * line as "Invalid or unexpected token". Invoke as
+ * `node scripts/release-version.mjs <version>`.
+ *
+ * CLI output is GITHUB_OUTPUT key=value form:
+ *
+ *   dist_tag=beta
+ *   prerelease=true
+ */
+import { pathToFileURL } from "node:url";
+
+/** Semver with optional prerelease and build metadata. */
+export const SEMVER_RE =
+  /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z][0-9A-Za-z.-]*))?(?:\+([0-9A-Za-z][0-9A-Za-z.-]*))?$/;
+
+/**
+ * npm rejects a dist-tag that parses as a semver range, so a tag has to start
+ * with a letter. A numeric-only prerelease identifier (1.2.0-1) therefore
+ * cannot name its own tag.
+ */
+export const SAFE_TAG_RE = /^[A-Za-z][0-9A-Za-z._-]*$/;
+
+/** Where prereleases go when their identifier cannot be used as a tag. */
+export const FALLBACK_TAG = "next";
+
+/** The tag a plain X.Y.Z owns, and the one no prerelease may ever take. */
+export const STABLE_TAG = "latest";
+
+export class VersionError extends Error {}
+
+/**
+ * Splits a version string. Throws VersionError on anything that is not plain
+ * semver, so a typo in package.json fails the job instead of publishing under
+ * a surprise tag.
+ */
+export function parseVersion(version) {
+  if (typeof version !== "string") {
+    throw new VersionError(`Version must be a string (got ${typeof version}).`);
+  }
+  const m = SEMVER_RE.exec(version.trim());
+  if (!m) {
+    throw new VersionError(
+      `'${version}' is not a valid semver version. Expected X.Y.Z with an optional ` +
+        `-prerelease suffix, for example 1.1.44, 1.2.0-beta, or 1.3.0-rc.1.`
+    );
+  }
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    prerelease: m[4] ?? null,
+    build: m[5] ?? null,
+  };
+}
+
+/** True when the version carries a prerelease identifier. */
+export function isPrerelease(version) {
+  return parseVersion(version).prerelease !== null;
+}
+
+/**
+ * The npm dist-tag this version should publish under.
+ *
+ * A plain X.Y.Z keeps `latest`. A prerelease takes the first dot-separated
+ * identifier of its prerelease suffix, falling back to `next` when that
+ * identifier cannot legally be a tag, or when it would collide with the
+ * stable tag (1.2.0-latest must not hijack `latest`).
+ */
+export function distTag(version) {
+  const { prerelease } = parseVersion(version);
+  if (prerelease === null) return STABLE_TAG;
+  const first = prerelease.split(".")[0];
+  if (!SAFE_TAG_RE.test(first)) return FALLBACK_TAG;
+  if (first.toLowerCase() === STABLE_TAG) return FALLBACK_TAG;
+  return first;
+}
+
+/**
+ * Membership test against the output of `npm view <pkg> versions --json`.
+ *
+ * npm prints a bare JSON string when exactly one version exists and an array
+ * otherwise, so both shapes are accepted. Throws VersionError when the payload
+ * is empty or unparseable: an unreachable registry must fail the job loudly
+ * rather than be read as "not published yet" and trigger a blind publish.
+ */
+export function isPublished(versionsJson, version) {
+  const raw = typeof versionsJson === "string" ? versionsJson.trim() : "";
+  if (raw === "") {
+    throw new VersionError(
+      "Empty response from `npm view ue-mcp versions --json`. The registry was " +
+        "unreachable or the package name is wrong; refusing to guess whether this " +
+        "version is published."
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new VersionError(`Could not parse the npm versions payload as JSON: ${raw.slice(0, 200)}`);
+  }
+  const list = Array.isArray(parsed) ? parsed : [parsed];
+  const target = version.trim();
+  return list.some((v) => typeof v === "string" && v.trim() === target);
+}
+
+/** Every CLI output for one version, in GITHUB_OUTPUT key=value form. */
+export function outputsFor(version) {
+  return [`dist_tag=${distTag(version)}`, `prerelease=${isPrerelease(version)}`];
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  let version = null;
+  let versionsJson = null;
+  let mode = "outputs";
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--version") version = args[++i];
+    else if (args[i] === "--published-in") {
+      mode = "published";
+      versionsJson = args[++i];
+    } else if (!args[i].startsWith("-")) version = args[i];
+  }
+  if (!version) {
+    console.error("::error::Usage: node scripts/release-version.mjs <version> [--published-in <json>]");
+    process.exit(2);
+  }
+  try {
+    if (mode === "published") {
+      console.log(`published=${isPublished(versionsJson, version)}`);
+    } else {
+      for (const line of outputsFor(version)) console.log(line);
+    }
+  } catch (e) {
+    if (e instanceof VersionError) {
+      console.error(`::error::${e.message}`);
+      process.exit(1);
+    }
+    throw e;
+  }
+}
+
+const invokedAsScript =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedAsScript) main();

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -12,6 +12,7 @@ import * as path from "node:path";
 import { execSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { takeEditorTarget, EditorFlagError } from "./editor-flag.js";
+import { isNewer } from "./version-check.js";
 
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
@@ -326,6 +327,18 @@ function row(label: string, value: string): string {
   return `  ${label.padEnd(16)}${value}`;
 }
 
+/**
+ * True when `version` is older than the registry's stable `latest`.
+ *
+ * Every alignment verdict below asks this rather than "differs from latest".
+ * A prerelease install is ahead of the stable line, not behind it, so plain
+ * inequality would flag a beta tester's entire setup as stale and tell them to
+ * update onto an older release.
+ */
+function behindLatest(version: string | null | undefined, latest: string | null): boolean {
+  return !!latest && !!version && isNewer(latest, version);
+}
+
 export function formatDoctor(d: DoctorReport): string {
   const latest = d.registryLatest;
   const lines: string[] = [];
@@ -345,7 +358,7 @@ export function formatDoctor(d: DoctorReport): string {
   }
 
   const effLabel = d.effectiveNpx ?? "unknown";
-  const effMismatch = latest && d.effectiveNpx && d.effectiveNpx !== latest;
+  const effMismatch = behindLatest(d.effectiveNpx, latest);
   lines.push(row("effective (npx):", effMismatch ? `${RED}${effLabel}  (behind latest ${latest})${RESET}` : `${GREEN}${effLabel}${RESET}`));
 
   // Show servers, putting the one serving the target project first and naming
@@ -366,7 +379,7 @@ export function formatDoctor(d: DoctorReport): string {
           ? `${BOLD}this project${RESET} ${DIM}(with ${names.length - 1} more: ${proj})${RESET}`
           : `${BOLD}this project${RESET}`
         : `${DIM}${proj}${RESET}`;
-      const mismatch = latest && s.version && s.version !== latest;
+      const mismatch = behindLatest(s.version, latest);
       const tag = deleted
         ? `${RED}(running pruned files - relaunch)${RESET}`
         : mismatch
@@ -384,13 +397,13 @@ export function formatDoctor(d: DoctorReport): string {
   lines.push("");
 
   const problems: string[] = [];
-  if (d.localShadow && latest && d.localShadow.version !== latest) {
+  if (d.localShadow && behindLatest(d.localShadow.version, latest)) {
     problems.push(
       `A project-local node_modules/ue-mcp@${d.localShadow.version} shadows the global install. ` +
       `npx runs it, so global updates do nothing. Fix: remove the dependency from package.json and delete node_modules/ue-mcp, ` +
       `or pin .mcp.json to \`npx -y ue-mcp@latest\`. Then run \`ue-mcp update --build\`.`,
     );
-  } else if (latest && d.npmGlobal.version && d.npmGlobal.version !== latest) {
+  } else if (behindLatest(d.npmGlobal.version, latest)) {
     // No shadow, but the global package is behind latest: a bare `npx ue-mcp`
     // (or any fresh launch) would run an old version next time. This must keep
     // the verdict from claiming "aligned" even when the running server happens
@@ -413,7 +426,7 @@ export function formatDoctor(d: DoctorReport): string {
     const label = s.servesTarget && d.bridgePlugin ? `for ${path.basename(d.bridgePlugin.project)}` : "(this project)";
     if (s.version === null) {
       problems.push(`Running server (pid ${s.pid}) ${label} is executing pruned/old files - a stale process the file deletion did not kill. Quit your MCP client fully (not --resume) and relaunch so a fresh ${latest ?? "latest"} server spawns.`);
-    } else if (latest && s.version !== latest) {
+    } else if (behindLatest(s.version, latest)) {
       problems.push(`Running server (pid ${s.pid}) ${label} is ${s.version}, not ${latest}. Quit your MCP client and relaunch to swap it.`);
     }
   }

--- a/src/update.ts
+++ b/src/update.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { collectDoctor, formatDoctor } from "./doctor.js";
 import { takeEditorTarget, EditorFlagError } from "./editor-flag.js";
+import { distTagForVersion, isPrereleaseVersion, resolveUpdateTarget } from "./version-check.js";
 
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
@@ -23,6 +24,7 @@ function getInstalledVersion(): string {
   return require("../package.json").version;
 }
 
+/** The version behind the `latest` dist-tag, which is the stable line. */
 function getLatestVersion(): string | null {
   try {
     return execSync("npm view ue-mcp version", { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
@@ -30,6 +32,7 @@ function getLatestVersion(): string | null {
     return null;
   }
 }
+
 
 function isGlobalInstall(): boolean {
   try {
@@ -82,16 +85,25 @@ async function update() {
   console.log("");
 
   // 1. Update the package this CLI lives in (global or local).
-  if (installed === latest) {
+  const wanted = resolveUpdateTarget(installed, latest);
+  // Everything below aligns to the version this install ends on, not to the
+  // stable line, so a prerelease tester's copies stay on the version they run.
+  const aligned = wanted ?? installed;
+  if (!wanted) {
     ok("Package already up to date");
+    if (isPrereleaseVersion(installed)) {
+      const tag = distTagForVersion(installed);
+      step(`You are on the ${tag} prerelease channel, ahead of the stable line (${latest}).`);
+      step(`Newer prereleases: npm install -g ue-mcp@${tag}. Back to stable: npm install -g ue-mcp@latest.`);
+    }
   } else {
-    console.log(`  ${YELLOW}Updating ue-mcp ${installed} -> ${latest}...${RESET}`);
+    console.log(`  ${YELLOW}Updating ue-mcp ${installed} -> ${wanted}...${RESET}`);
     console.log("");
-    const cmd = isGlobalInstall() ? `npm install -g ue-mcp@${latest}` : `npm install ue-mcp@${latest}`;
+    const cmd = isGlobalInstall() ? `npm install -g ue-mcp@${wanted}` : `npm install ue-mcp@${wanted}`;
     try {
       execSync(cmd, { stdio: "inherit" });
       console.log("");
-      ok(`Updated to ${latest}`);
+      ok(`Updated to ${wanted}`);
     } catch {
       console.log("");
       fail(`npm install failed. Try manually: ${cmd}`);
@@ -100,17 +112,17 @@ async function update() {
   }
 
   // 2. Detect a project-local node_modules/ue-mcp that would shadow the global
-  //    install (npx prefers it). If it is behind, align it to latest so the
-  //    server actually runs the new version. (#550)
+  //    install (npx prefers it). If it differs, align it to the version this
+  //    install ended on so the server actually runs that version. (#550)
   const preDoctor = collectDoctor(projectArg);
-  if (preDoctor.localShadow && preDoctor.localShadow.version !== latest) {
+  if (preDoctor.localShadow && preDoctor.localShadow.version !== aligned) {
     const shadowProjectRoot = path.dirname(path.dirname(preDoctor.localShadow.dir));
     console.log("");
     console.log(`  ${YELLOW}Local shadow detected: node_modules/ue-mcp@${preDoctor.localShadow.version} (npx runs this, not the global).${RESET}`);
-    step(`Aligning the local copy to ${latest} in ${shadowProjectRoot}...`);
+    step(`Aligning the local copy to ${aligned} in ${shadowProjectRoot}...`);
     try {
-      execSync(`npm install ue-mcp@${latest}`, { stdio: "inherit", cwd: shadowProjectRoot });
-      ok(`Local copy aligned to ${latest}`);
+      execSync(`npm install ue-mcp@${aligned}`, { stdio: "inherit", cwd: shadowProjectRoot });
+      ok(`Local copy aligned to ${aligned}`);
       console.log(`  ${DIM}Cleaner long-term: drop ue-mcp from this project's package.json and pin .mcp.json to \`npx -y ue-mcp@latest\`.${RESET}`);
     } catch {
       fail(`Could not update the local copy. Remove node_modules/ue-mcp manually, or pin .mcp.json to \`npx -y ue-mcp@latest\`.`);

--- a/src/version-check.ts
+++ b/src/version-check.ts
@@ -72,6 +72,45 @@ async function fetchLatest(): Promise<string | null> {
   }
 }
 
+/**
+ * Release channel helpers.
+ *
+ * These mirror the rules in scripts/release-version.mjs, which the publish job
+ * uses to pick the npm dist-tag. The two cannot be one module: the publish job
+ * runs before tsc has produced dist/, and the package ships only dist/ and
+ * plugin/, so neither side can import the other. The parity test in
+ * tests/unit/release-channel-parity.test.ts holds them together.
+ *
+ * Both degrade to the stable channel on an unparseable version instead of
+ * throwing. These sit in CLI and startup paths where a crash is worse than a
+ * conservative answer.
+ */
+const CHANNEL_SEMVER_RE =
+  /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z][0-9A-Za-z.-]*))?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
+const SAFE_TAG_RE = /^[A-Za-z][0-9A-Za-z._-]*$/;
+const FALLBACK_TAG = "next";
+const STABLE_TAG = "latest";
+
+function prereleaseIdOf(version: string): string | null {
+  const m = CHANNEL_SEMVER_RE.exec(String(version ?? "").trim());
+  return m ? (m[4] ?? null) : null;
+}
+
+/** True when the version carries a prerelease identifier (1.2.0-beta.2). */
+export function isPrereleaseVersion(version: string): boolean {
+  return prereleaseIdOf(version) !== null;
+}
+
+/** The npm dist-tag a version belongs to: `latest` for X.Y.Z, else its channel. */
+export function distTagForVersion(version: string): string {
+  const pre = prereleaseIdOf(version);
+  if (pre === null) return STABLE_TAG;
+  const first = pre.split(".")[0];
+  if (!SAFE_TAG_RE.test(first)) return FALLBACK_TAG;
+  if (first.toLowerCase() === STABLE_TAG) return FALLBACK_TAG;
+  return first;
+}
+
 function parseVersion(v: string): [number, number, number, string] {
   const m = /^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/.exec(v.trim());
   if (!m) return [0, 0, 0, ""];
@@ -88,6 +127,20 @@ export function isNewer(latest: string, current: string): boolean {
   if (lp === "" && cp !== "") return true;
   if (lp !== "" && cp === "") return false;
   return lp > cp;
+}
+
+/**
+ * The version an install should move to, or null when it is already there.
+ *
+ * Only ever moves forward, and never crosses from the stable line onto a
+ * prerelease. Comparing installed against latest for plain inequality treats
+ * "ahead of the stable line" as "out of date", which rolls a prerelease tester
+ * back onto an older stable on their next update, and it would install a
+ * prerelease on every stable user the moment `latest` pointed at one.
+ */
+export function resolveUpdateTarget(installed: string, latest: string): string | null {
+  if (isPrereleaseVersion(latest) && !isPrereleaseVersion(installed)) return null;
+  return isNewer(latest, installed) ? latest : null;
 }
 
 function buildNotice(current: string, latest: string): string {
@@ -126,7 +179,14 @@ export function startVersionCheck(currentVersion: string): void {
         debug("update", `fetched latest=${latest ?? "null"}`);
       }
 
-      if (latest && isNewer(latest, currentVersion)) {
+      // A stable install is never nudged onto a prerelease. The registry's
+      // `latest` should only ever name a plain X.Y.Z, but this is the one
+      // place the answer reaches the user as an instruction, so the check does
+      // not rely on that holding. A prerelease install still gets told about a
+      // newer stable, which is the release that supersedes it.
+      if (latest && isPrereleaseVersion(latest) && !isPrereleaseVersion(currentVersion)) {
+        debug("update", `registry latest ${latest} is a prerelease; not offering it to a stable install`);
+      } else if (latest && isNewer(latest, currentVersion)) {
         pendingNotice = buildNotice(currentVersion, latest);
         warn(
           "update",

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -169,6 +169,20 @@ describe("formatDoctor verdict", () => {
     expect(out).toContain("pid 9");
   });
 
+  it("does not call a prerelease install stale for being ahead of the stable line", () => {
+    // registryLatest is the `latest` dist-tag, which is the stable line. A
+    // tester on a prerelease is ahead of it, not behind it, and must not be
+    // told to update onto an older release.
+    const out = stripAnsi(formatDoctor(baseReport({
+      selfVersion: "1.1.0-beta.2",
+      npmGlobal: { version: "1.1.0-beta.2", dir: "/g/ue-mcp" },
+      effectiveNpx: "1.1.0-beta.2",
+      runningServers: [{ pid: 1, version: "1.1.0-beta.2", script: "x", project: "C:/proj/Vale", servesTarget: true }],
+    })));
+    expect(out).toContain("Everything aligned");
+    expect(out).not.toContain("behind latest");
+  });
+
   it("does not let a server for another project produce a false aligned", () => {
     // Only an unrelated-project server is running; nothing serves the target.
     const out = stripAnsi(formatDoctor(baseReport({

--- a/tests/unit/release-channel-parity.test.ts
+++ b/tests/unit/release-channel-parity.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { distTag, isPrerelease } from "../../scripts/release-version.mjs";
+import { distTagForVersion, isPrereleaseVersion } from "../../src/version-check.js";
+
+/**
+ * The channel rule exists twice on purpose: the publish job runs before tsc has
+ * produced dist/, and the package ships only dist/ and plugin/, so neither copy
+ * can import the other. This pins them together, and pins the one deliberate
+ * difference (the runtime copy degrades instead of throwing).
+ */
+const CASES: Array<{ version: string; tag: string; pre: boolean }> = [
+  { version: "1.1.44", tag: "latest", pre: false },
+  { version: "1.2.0-beta", tag: "beta", pre: true },
+  { version: "1.2.0-beta.2", tag: "beta", pre: true },
+  { version: "1.3.0-rc.1", tag: "rc", pre: true },
+  { version: "0.1.0", tag: "latest", pre: false },
+  { version: "2.0.0-alpha.7", tag: "alpha", pre: true },
+  { version: "1.2.0-1", tag: "next", pre: true },
+  { version: "1.2.0-latest", tag: "next", pre: true },
+];
+
+describe("release channel parity between the pipeline and the shipped CLI", () => {
+  for (const { version, tag, pre } of CASES) {
+    it(`${version} -> tag ${tag}, prerelease ${pre}`, () => {
+      expect(distTag(version)).toBe(tag);
+      expect(distTagForVersion(version)).toBe(tag);
+      expect(isPrerelease(version)).toBe(pre);
+      expect(isPrereleaseVersion(version)).toBe(pre);
+    });
+  }
+
+  it("degrades to the stable channel at runtime instead of throwing", () => {
+    // The pipeline copy fails the job on a malformed version. The runtime copy
+    // sits in a CLI path where a crash is worse than a conservative answer.
+    expect(() => distTag("garbage")).toThrow();
+    expect(distTagForVersion("garbage")).toBe("latest");
+    expect(isPrereleaseVersion("garbage")).toBe(false);
+  });
+});

--- a/tests/unit/release-headline.test.ts
+++ b/tests/unit/release-headline.test.ts
@@ -136,4 +136,13 @@ describe("release-headline processBody", () => {
     const body = wrap("headline:\n  - First: feature");
     expect(() => processBody(body)).toThrowError(ValidationError);
   });
+
+  it("does not care about the version shape, so a prerelease tag validates", () => {
+    // The publish gate reads only the headline frontmatter. A v1.2.0-beta
+    // draft must clear it exactly like a v1.1.44 draft does.
+    const body = wrap("headline:\n  - Prerelease publishing", "## v1.2.0-beta\n\nbeta body\n");
+    const out = processBody(body);
+    expect(out.headline).toBe("Prerelease publishing");
+    expect(out.strippedBody.startsWith("## v1.2.0-beta")).toBe(true);
+  });
 });

--- a/tests/unit/release-version.test.ts
+++ b/tests/unit/release-version.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  FALLBACK_TAG,
+  STABLE_TAG,
+  VersionError,
+  distTag,
+  isPrerelease,
+  isPublished,
+  outputsFor,
+  parseVersion,
+} from "../../scripts/release-version.mjs";
+
+const SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "scripts",
+  "release-version.mjs",
+);
+
+/** The versions the release pipeline has to get right. */
+const CASES: Array<{ version: string; tag: string; pre: boolean }> = [
+  { version: "1.1.44", tag: "latest", pre: false },
+  { version: "1.2.0-beta", tag: "beta", pre: true },
+  { version: "1.2.0-beta.2", tag: "beta", pre: true },
+  { version: "1.3.0-rc.1", tag: "rc", pre: true },
+];
+
+describe("parseVersion", () => {
+  it("splits a plain release", () => {
+    expect(parseVersion("1.1.44")).toEqual({
+      major: 1,
+      minor: 1,
+      patch: 44,
+      prerelease: null,
+      build: null,
+    });
+  });
+
+  it("splits a dotted prerelease", () => {
+    expect(parseVersion("1.3.0-rc.1")).toMatchObject({ major: 1, minor: 3, patch: 0, prerelease: "rc.1" });
+  });
+
+  it("keeps build metadata out of the prerelease field", () => {
+    expect(parseVersion("1.2.0-beta+sha.abc")).toMatchObject({ prerelease: "beta", build: "sha.abc" });
+  });
+
+  it("rejects non-semver input rather than guessing a channel", () => {
+    for (const bad of ["", "v1.2.0", "1.2", "1.2.0.1", "latest", "1.2.0-"]) {
+      expect(() => parseVersion(bad)).toThrowError(VersionError);
+    }
+  });
+});
+
+describe("isPrerelease", () => {
+  for (const { version, pre } of CASES) {
+    it(`${version} -> ${pre}`, () => {
+      expect(isPrerelease(version)).toBe(pre);
+    });
+  }
+});
+
+describe("distTag", () => {
+  for (const { version, tag } of CASES) {
+    it(`${version} -> ${tag}`, () => {
+      expect(distTag(version)).toBe(tag);
+    });
+  }
+
+  it("keeps latest for every plain release", () => {
+    expect(distTag("0.1.0")).toBe(STABLE_TAG);
+    expect(distTag("10.20.30")).toBe(STABLE_TAG);
+  });
+
+  it("uses the first identifier, not a substring match on one hardcoded word", () => {
+    expect(distTag("2.0.0-alpha.7")).toBe("alpha");
+    expect(distTag("2.0.0-canary")).toBe("canary");
+    expect(distTag("2.0.0-nightly.20260805")).toBe("nightly");
+  });
+
+  it("falls back when the identifier cannot be an npm tag", () => {
+    // npm rejects a dist-tag that parses as a semver range.
+    expect(distTag("1.2.0-1")).toBe(FALLBACK_TAG);
+    expect(distTag("1.2.0-0.3")).toBe(FALLBACK_TAG);
+  });
+
+  it("never lets a prerelease claim the stable tag", () => {
+    expect(distTag("1.2.0-latest")).toBe(FALLBACK_TAG);
+    expect(distTag("1.2.0-LATEST.1")).toBe(FALLBACK_TAG);
+  });
+});
+
+describe("isPublished", () => {
+  const list = JSON.stringify(["1.1.43", "1.1.44", "1.2.0-beta"]);
+
+  it("finds a version already on the registry", () => {
+    expect(isPublished(list, "1.1.44")).toBe(true);
+    expect(isPublished(list, "1.2.0-beta")).toBe(true);
+  });
+
+  it("reports a genuinely new version as unpublished", () => {
+    expect(isPublished(list, "1.1.45")).toBe(false);
+    expect(isPublished(list, "1.2.0-beta.2")).toBe(false);
+  });
+
+  it("accepts the bare-string shape npm emits for a single version", () => {
+    expect(isPublished('"1.0.0"', "1.0.0")).toBe(true);
+    expect(isPublished('"1.0.0"', "1.0.1")).toBe(false);
+  });
+
+  it("refuses to answer when the registry response is empty or broken", () => {
+    expect(() => isPublished("", "1.1.44")).toThrowError(VersionError);
+    expect(() => isPublished("   ", "1.1.44")).toThrowError(VersionError);
+    expect(() => isPublished("not json", "1.1.44")).toThrowError(VersionError);
+  });
+
+  it("does not treat a prerelease of a published stable as published", () => {
+    // The exact bug that wedged the old `npm view ue-mcp version` check.
+    expect(isPublished(JSON.stringify(["1.1.44"]), "1.2.0-beta")).toBe(false);
+  });
+});
+
+describe("outputsFor", () => {
+  it("emits GITHUB_OUTPUT key=value lines", () => {
+    expect(outputsFor("1.2.0-beta.2")).toEqual(["dist_tag=beta", "prerelease=true"]);
+    expect(outputsFor("1.1.44")).toEqual(["dist_tag=latest", "prerelease=false"]);
+  });
+});
+
+describe("CLI (what the workflow actually runs)", () => {
+  for (const { version, tag, pre } of CASES) {
+    it(`prints both outputs for ${version}`, () => {
+      const out = execFileSync(process.execPath, [SCRIPT, "--version", version], {
+        encoding: "utf8",
+      }).trim();
+      expect(out.split(/\r?\n/)).toEqual([`dist_tag=${tag}`, `prerelease=${pre}`]);
+    });
+  }
+
+  it("answers the published-membership question", () => {
+    const out = execFileSync(
+      process.execPath,
+      [SCRIPT, "--version", "1.2.0-beta", "--published-in", JSON.stringify(["1.1.44"])],
+      { encoding: "utf8" },
+    ).trim();
+    expect(out).toBe("published=false");
+  });
+
+  it("exits non-zero on a malformed version instead of publishing under a guess", () => {
+    expect(() =>
+      execFileSync(process.execPath, [SCRIPT, "--version", "not-a-version"], { stdio: "pipe" }),
+    ).toThrow();
+  });
+});

--- a/tests/unit/version-check.test.ts
+++ b/tests/unit/version-check.test.ts
@@ -47,6 +47,35 @@ describe("version-check", () => {
     });
   });
 
+  describe("resolveUpdateTarget", () => {
+    it("moves a stable install forward on the stable line", async () => {
+      const { resolveUpdateTarget } = await import("../../src/version-check.js");
+      expect(resolveUpdateTarget("1.1.43", "1.1.44")).toBe("1.1.44");
+    });
+
+    it("returns null when already on the target", async () => {
+      const { resolveUpdateTarget } = await import("../../src/version-check.js");
+      expect(resolveUpdateTarget("1.1.44", "1.1.44")).toBeNull();
+    });
+
+    it("never moves a stable install onto a prerelease", async () => {
+      const { resolveUpdateTarget } = await import("../../src/version-check.js");
+      expect(resolveUpdateTarget("1.1.44", "1.2.0-beta")).toBeNull();
+      expect(resolveUpdateTarget("1.1.44", "1.2.0-rc.1")).toBeNull();
+    });
+
+    it("does not roll a prerelease tester back onto an older stable", async () => {
+      const { resolveUpdateTarget } = await import("../../src/version-check.js");
+      expect(resolveUpdateTarget("1.2.0-beta.2", "1.1.44")).toBeNull();
+    });
+
+    it("moves a prerelease onto the stable release that supersedes it", async () => {
+      const { resolveUpdateTarget } = await import("../../src/version-check.js");
+      expect(resolveUpdateTarget("1.2.0-rc.1", "1.2.0")).toBe("1.2.0");
+      expect(resolveUpdateTarget("1.2.0-beta.2", "1.3.0")).toBe("1.3.0");
+    });
+  });
+
   describe("consumeUpgradeNotice", () => {
     it("returns null when nothing pending", async () => {
       const { consumeUpgradeNotice } = await import("../../src/version-check.js");
@@ -98,6 +127,30 @@ describe("version-check", () => {
       startVersionCheck("1.0.0");
       for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
       expect(consumeUpgradeNotice()).toBeNull();
+    });
+
+    it("does not offer a prerelease to a stable install", async () => {
+      // `latest` should never name a prerelease, but this notice reaches the
+      // user as an instruction, so it does not rely on that holding.
+      vi.stubGlobal("fetch", vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ version: "1.2.0-beta" }),
+      })));
+      const { startVersionCheck, consumeUpgradeNotice } = await import("../../src/version-check.js");
+      startVersionCheck("1.1.44");
+      for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+      expect(consumeUpgradeNotice()).toBeNull();
+    });
+
+    it("still offers a newer prerelease to an install already on that line", async () => {
+      vi.stubGlobal("fetch", vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ version: "1.2.0-beta.3" }),
+      })));
+      const { startVersionCheck, consumeUpgradeNotice } = await import("../../src/version-check.js");
+      startVersionCheck("1.2.0-beta.2");
+      for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+      expect(consumeUpgradeNotice()).toContain("1.2.0-beta.3");
     });
 
     it("never throws on network failure", async () => {


### PR DESCRIPTION
Shipping `1.2.0-beta` through the current pipeline breaks three things. All three are fixed here, each in its own commit, with the decision logic pulled out of YAML so it can be unit tested.

### 1. The publish would hijack the `latest` dist-tag

`npm publish --access public --provenance` passes no `--tag`, and npm defaults to `latest`. A beta would become the default install for everyone running `npx ue-mcp`.

The tag is now derived from the version by parsing the prerelease suffix: `1.2.0-beta` and `1.2.0-beta.2` publish under `beta`, `1.3.0-rc.1` under `rc`, and a plain `X.Y.Z` keeps `latest`. Two guards stop a prerelease taking the default channel by another route: an identifier npm would reject as a tag (`1.2.0-1`, which parses as a semver range) and an identifier that spells `latest` both divert to `next`.

### 2. The changed-version check broke permanently after a prerelease

`npm view ue-mcp version` reports the `latest` dist-tag. Publish a beta under `beta` and `latest` stops tracking the repo, so `LOCAL != PUBLISHED` stays true on every later push, the job retries the publish, and npm rejects the duplicate version. The failure never clears.

The gate now asks whether this exact version is on the registry, using membership in `npm view ue-mcp versions --json`. A new version publishes; an already-published one is a clean skip with the job green. An unreachable registry fails the step loudly rather than being read as "not published yet", which would publish blind.

### 3. The GitHub release would be marked as the latest stable

`gh release edit --draft=false` leaves the prerelease flag unset, so a beta would take the repo's "Latest" badge and answer `/releases/latest`. The promote step now sets `--prerelease --latest=false` or `--prerelease=false --latest`, from the same channel resolution the npm publish uses.

### Also checked

- **`scripts/release-headline.mjs` and the validate step**: no version-shape assumption. The gate reads only the headline frontmatter, and `gh release view "v$VERSION"` treats the tag as an opaque name. A regression test pins that a `v1.2.0-beta` draft validates.
- **`src/update.ts` and `src/version-check.ts`**: both decided what to do by comparing installed against `npm view ue-mcp version` for inequality, in either direction. That would tell a stable user to install whatever `latest` names, and would run `npm install ue-mcp@1.1.44` on a tester sitting on `1.2.0-beta`, rolling back the build they were testing. Comparison is now forward-only and refuses to cross from stable onto a prerelease. A prerelease install is still offered the stable release that supersedes it, and `ue-mcp update` prints how to move within a channel or return to stable.
- **`src/doctor.ts`**: every alignment verdict compared against `latest` with string inequality, so a prerelease install had its global, npx, and running server all reported stale with advice to update onto an older release. Those checks now ask whether a version is behind.

### Tests

`tests/unit/release-version.test.ts` covers the dist-tag derivation and prerelease detection over `1.1.44`, `1.2.0-beta`, `1.2.0-beta.2`, `1.3.0-rc.1`, plus the fallback and stable-tag-collision guards, the published-membership test, and the CLI the workflow actually invokes. `tests/unit/release-channel-parity.test.ts` pins the pipeline copy of the rule against the shipped CLI copy, since the publish job runs before `tsc` and the package ships only `dist/` and `plugin/`, so neither side can import the other.

Full suite: 69 files, 678 tests, all passing. `npx tsc --noEmit` clean. No plugin files touched, so no C++ build is needed.
