### PR TITLE
Multi-editor Phase 0: instance records, the requested-port channel, the param echo, and a spec module (#817)

### DIFF
--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeParamEcho.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeParamEcho.cpp
@@ -1,0 +1,124 @@
+#include "BridgeParamEcho.h"
+#include "UE_MCP_BridgeModule.h"
+#include "Dom/JsonValue.h"
+#include "HAL/PlatformMisc.h"
+#include "Misc/CommandLine.h"
+#include "Misc/Parse.h"
+#include "Misc/ScopeLock.h"
+
+FMCPParamEcho& FMCPParamEcho::Get()
+{
+	static FMCPParamEcho Instance;
+	return Instance;
+}
+
+bool FMCPParamEcho::ResolveEnabledFromEnvironment()
+{
+	if (FParse::Param(FCommandLine::Get(), TEXT("MCPParamEcho")))
+	{
+		return true;
+	}
+
+	const FString EnvValue = FPlatformMisc::GetEnvironmentVariable(TEXT("UE_MCP_PARAM_ECHO"));
+	return EnvValue == TEXT("1") || EnvValue.Equals(TEXT("true"), ESearchCase::IgnoreCase)
+		|| EnvValue.Equals(TEXT("yes"), ESearchCase::IgnoreCase);
+}
+
+void FMCPParamEcho::SetEnabled(bool bInEnabled)
+{
+	const bool bWasEnabled = bEnabled;
+	bEnabled = bInEnabled;
+
+	if (bInEnabled && !bWasEnabled)
+	{
+		UE_LOG(LogMCPBridge, Warning,
+			TEXT("[UE-MCP] Parameter echo is on. The bridge will remember the parameter NAMES of the last %d dispatches and hand them to any client that asks. This is a test facility; do not leave it on."),
+			MaxEntries);
+	}
+
+	if (!bInEnabled)
+	{
+		Clear();
+	}
+}
+
+void FMCPParamEcho::Record(const FString& Method, const TSharedPtr<FJsonObject>& Params)
+{
+	// Checked before the lock so a bridge with the echo off pays one atomic
+	// read per dispatch and nothing else.
+	if (!bEnabled)
+	{
+		return;
+	}
+
+	FMCPParamEchoEntry Entry;
+	Entry.Method = Method;
+	Entry.ReceivedAtUtc = FDateTime::UtcNow();
+
+	if (Params.IsValid())
+	{
+		for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : Params->Values)
+		{
+			// The key, never the value. See the header.
+			Entry.ParamNames.Add(Pair.Key);
+		}
+		Entry.ParamNames.Sort();
+	}
+
+	FScopeLock Lock(&Mutex);
+	Entries.Add(MoveTemp(Entry));
+	if (Entries.Num() > MaxEntries)
+	{
+		Entries.RemoveAt(0, Entries.Num() - MaxEntries);
+	}
+}
+
+TArray<FMCPParamEchoEntry> FMCPParamEcho::Snapshot() const
+{
+	FScopeLock Lock(&Mutex);
+	return Entries;
+}
+
+void FMCPParamEcho::Clear()
+{
+	FScopeLock Lock(&Mutex);
+	Entries.Reset();
+}
+
+TSharedPtr<FJsonObject> FMCPParamEcho::BuildPayload() const
+{
+	TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+	Payload->SetBoolField(TEXT("success"), true);
+	Payload->SetBoolField(TEXT("servedWithoutGameThread"), true);
+
+	// Answered rather than refused when the echo is off, so a caller that has
+	// checked the capability and a caller that has not both get a shape they
+	// can read instead of an error they have to special-case.
+	Payload->SetBoolField(TEXT("enabled"), bEnabled);
+
+	const TArray<FMCPParamEchoEntry> Recorded = Snapshot();
+
+	TArray<TSharedPtr<FJsonValue>> EntryValues;
+	EntryValues.Reserve(Recorded.Num());
+	for (const FMCPParamEchoEntry& Entry : Recorded)
+	{
+		TSharedPtr<FJsonObject> EntryObject = MakeShared<FJsonObject>();
+		EntryObject->SetStringField(TEXT("method"), Entry.Method);
+		EntryObject->SetStringField(TEXT("receivedAt"), Entry.ReceivedAtUtc.ToIso8601());
+
+		TArray<TSharedPtr<FJsonValue>> NameValues;
+		NameValues.Reserve(Entry.ParamNames.Num());
+		for (const FString& Name : Entry.ParamNames)
+		{
+			NameValues.Add(MakeShared<FJsonValueString>(Name));
+		}
+		EntryObject->SetArrayField(TEXT("params"), NameValues);
+
+		EntryValues.Add(MakeShared<FJsonValueObject>(EntryObject));
+	}
+
+	Payload->SetNumberField(TEXT("entryCount"), Recorded.Num());
+	Payload->SetArrayField(TEXT("entries"), EntryValues);
+	Payload->SetNumberField(TEXT("maxEntries"), MaxEntries);
+	return Payload;
+}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeParamEcho.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeParamEcho.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+#include "HAL/CriticalSection.h"
+#include "HAL/ThreadSafeBool.h"
+#include "Misc/DateTime.h"
+
+/**
+ * What the bridge was actually handed, so a test can assert it.
+ *
+ * Handlers read the fields they know about through the helpers in
+ * HandlerUtils.h and ignore everything else. That is the right behaviour on the
+ * wire (an older bridge must not choke on a newer client's extra field) and it
+ * means a parameter the client leaked into a call is completely invisible: the
+ * call succeeds, the result is correct, and nothing anywhere reports that a
+ * routing key travelled to the editor.
+ *
+ * Multi-editor addressing turns that from untidy into load-bearing. The
+ * `editor` parameter selects which session a call goes to and must be consumed
+ * by the client; forwarding it to a handler is a bug that no assertion on the
+ * response can see. This records the parameter names each dispatch arrived
+ * with, which gives that assertion something to read.
+ *
+ * Names only, never values. The point is which keys arrived, and a bridge that
+ * remembered values would be a bridge that could be asked to read back asset
+ * paths, prompts and file contents from calls it has already answered.
+ *
+ * Off unless the process was started with it asked for. It is a test facility,
+ * so it is enabled from the command line or the environment at construction and
+ * there is deliberately no way to turn it on over the socket.
+ */
+struct FMCPParamEchoEntry
+{
+	FString Method;
+	/** Sorted, so an assertion does not depend on JSON field order. */
+	TArray<FString> ParamNames;
+	FDateTime ReceivedAtUtc;
+};
+
+class FMCPParamEcho
+{
+public:
+	/** How many dispatches to remember. Oldest are dropped first. */
+	static constexpr int32 MaxEntries = 256;
+
+	static FMCPParamEcho& Get();
+
+	bool IsEnabled() const { return bEnabled; }
+	void SetEnabled(bool bInEnabled);
+
+	/** True when -MCPParamEcho or UE_MCP_PARAM_ECHO asked for the echo. */
+	static bool ResolveEnabledFromEnvironment();
+
+	/** Note one dispatch. A no-op, and lock-free, while disabled. */
+	void Record(const FString& Method, const TSharedPtr<FJsonObject>& Params);
+
+	TArray<FMCPParamEchoEntry> Snapshot() const;
+	void Clear();
+
+	/** The answer to get_param_echo, built without touching the game thread. */
+	TSharedPtr<FJsonObject> BuildPayload() const;
+
+private:
+	mutable FCriticalSection Mutex;
+	TArray<FMCPParamEchoEntry> Entries;
+	FThreadSafeBool bEnabled{false};
+};

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -1,4 +1,5 @@
 #include "BridgeServer.h"
+#include "BridgeStateFiles.h"
 #include "UE_MCP_BridgeModule.h"
 #include "MCPEngineStatus.h"
 #include "MCPHandlerRegistration.h"
@@ -400,6 +401,17 @@ uint32 FMCPBridgeServer::Run()
 	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Bridge listening on ws://127.0.0.1:%d (loopback only)"), ServerPort);
 	bIsRunning = true;
 
+	// #817: this instance's own record first. It is written before port.json
+	// because port.json may legitimately decline to name this bridge (another
+	// live editor of the same project owns it), and in that case the instance
+	// record is the only published address this editor has.
+	WriteInstanceRecord(TEXT("listening"), ServerPort);
+
+	// Records left by processes that are gone. Swept here, once, by the next
+	// process that can prove them stale rather than by a timer, so a machine
+	// that crashes repeatedly does not accumulate a directory of dead editors.
+	ReapStaleInstanceRecords();
+
 	// #492: publish the bound port to <Project>/Saved/UE_MCP_Bridge/port.json
 	// so the npm client (which was started against this project's .uproject)
 	// can find us even when the default port was already taken by another editor.
@@ -479,6 +491,12 @@ void FMCPBridgeServer::Exit()
 	// Run(), the bind-failure path included, so an unconditional delete here
 	// let an editor that never listened remove a running editor's record.
 	DeletePortLockfileIfOwned();
+
+	// #817: and this instance's own record. Exit() runs on the bind-failure
+	// path too, where the record says "bind-failed" and has to survive: it is
+	// the only thing that will still be on disk to explain why an editor that
+	// is plainly running has no bridge. DeleteOwnInstanceRecord knows that.
+	DeleteOwnInstanceRecord();
 }
 
 // #492: per-project port lockfile. Multiple editors can run side-by-side as
@@ -499,46 +517,17 @@ FString FMCPBridgeServer::GetBridgeErrorFilePath()
 
 namespace
 {
-	/**
-	 * Publish JSON by writing a temporary file and renaming it over the target.
-	 *
-	 * The client polls these files every couple of seconds while it waits for
-	 * an editor. Writing in place means a poll can land mid-write, read a torn
-	 * document, fail to parse it and silently fall back to a guessed port. A
-	 * rename is the one step a reader cannot catch halfway through.
-	 */
+	/** Publish JSON by temp-and-rename. See FMCPBridgeStateFiles::PublishJson. */
 	bool PublishJsonAtomically(const FString& FilePath, const TSharedPtr<FJsonObject>& Payload)
 	{
-		IFileManager::Get().MakeDirectory(*FPaths::GetPath(FilePath), /*Tree*/ true);
-
-		FString Serialized;
-		TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Serialized);
-		FJsonSerializer::Serialize(Payload.ToSharedRef(), Writer);
-
-		const FString TempPath = FString::Printf(TEXT("%s.%u.tmp"), *FilePath, FPlatformProcess::GetCurrentProcessId());
-		if (!FFileHelper::SaveStringToFile(Serialized, *TempPath))
-		{
-			return false;
-		}
-		if (!IFileManager::Get().Move(*FilePath, *TempPath, /*Replace*/ true))
-		{
-			IFileManager::Get().Delete(*TempPath);
-			return false;
-		}
-		return true;
+		return FMCPBridgeStateFiles::PublishJson(FilePath, Payload);
 	}
 
 	/** Read the instanceId out of a record, or empty when there is not one. */
 	FString ReadRecordInstanceId(const FString& FilePath)
 	{
-		FString Raw;
-		if (!FFileHelper::LoadFileToString(Raw, *FilePath))
-		{
-			return FString();
-		}
-		TSharedPtr<FJsonObject> Parsed;
-		TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Raw);
-		if (!FJsonSerializer::Deserialize(Reader, Parsed) || !Parsed.IsValid())
+		const TSharedPtr<FJsonObject> Parsed = FMCPBridgeStateFiles::LoadJson(FilePath);
+		if (!Parsed.IsValid())
 		{
 			return FString();
 		}
@@ -546,11 +535,54 @@ namespace
 		Parsed->TryGetStringField(TEXT("instanceId"), Value);
 		return Value;
 	}
+
+	/**
+	 * Is the instance that published this port.json still there?
+	 *
+	 * Only ever asked about a record this process did not write, and only to
+	 * decide whether overwriting it would take a working editor's address away
+	 * from the client that depends on it.
+	 */
+	bool PortLockfileOwnerIsLive(const TSharedPtr<FJsonObject>& Record)
+	{
+		FMCPInstanceRecord Owner;
+		double NumberValue = 0.0;
+		if (Record->TryGetNumberField(TEXT("pid"), NumberValue))
+		{
+			Owner.Pid = (uint32)NumberValue;
+		}
+		if (Record->TryGetNumberField(TEXT("port"), NumberValue))
+		{
+			Owner.Port = (int32)NumberValue;
+		}
+		Record->TryGetStringField(TEXT("status"), Owner.State);
+		return FMCPBridgeStateFiles::IsInstanceLive(Owner);
+	}
 }
 
 void FMCPBridgeServer::WritePortLockfile(int32 PortValue)
 {
 	const FString FilePath = GetPortLockfilePath();
+	const FString OurId = InstanceId.ToString(EGuidFormats::DigitsWithHyphens);
+
+	// #817: the write is owner-checked, the same way the delete already was.
+	// One project directory has one port.json and two editors of that project
+	// have two ports, so the second editor to boot used to publish its own
+	// address over a perfectly healthy first editor's, and every client reading
+	// the file was silently re-aimed at the newcomer. The newcomer's address is
+	// in its own instance record, where it cannot displace anyone.
+	{
+		const TSharedPtr<FJsonObject> Existing = FMCPBridgeStateFiles::LoadJson(FilePath);
+		FString ExistingOwner;
+		if (Existing.IsValid() && Existing->TryGetStringField(TEXT("instanceId"), ExistingOwner)
+			&& !ExistingOwner.IsEmpty() && ExistingOwner != OurId && PortLockfileOwnerIsLive(Existing))
+		{
+			UE_LOG(LogMCPBridge, Warning,
+				TEXT("[UE-MCP] Another editor of this project (instance %s) is still listening and owns %s, so this bridge did not publish over it. This bridge is on port %d and its address is in %s. Clients reading port.json will reach the other editor."),
+				*ExistingOwner, *FilePath, PortValue, *FMCPBridgeStateFiles::RecordPath(FMCPBridgeStateFiles::InstancesDir(), FPlatformProcess::GetCurrentProcessId()));
+			return;
+		}
+	}
 
 	TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
 	Obj->SetNumberField(TEXT("port"), PortValue);
@@ -599,6 +631,51 @@ void FMCPBridgeServer::WriteBindFailureRecord(int32 FirstPort, int32 LastPort, i
 	{
 		UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Failed to write bridge error record: %s"), *FilePath);
 	}
+
+	// #817: and again as this instance's own record, so a failed start is
+	// visible in the same place a successful one is. bridge-error.json is one
+	// file per project and a second editor's failure would overwrite the first
+	// editor's; the per-pid record cannot be overwritten by anyone.
+	WriteInstanceRecord(TEXT("bind-failed"), /*PortValue*/ 0);
+}
+
+void FMCPBridgeServer::WriteInstanceRecord(const FString& State, int32 PortValue)
+{
+	FMCPInstanceRecord Record;
+	Record.Port = PortValue;
+	Record.Pid = FPlatformProcess::GetCurrentProcessId();
+	Record.InstanceId = InstanceId.ToString(EGuidFormats::DigitsWithHyphens);
+	Record.ProjectRoot = FMCPBridgeStateFiles::ThisProjectRoot();
+	Record.StartedAtUtc = StartedAtUtc.ToIso8601();
+	Record.EngineVersion = FEngineVersion::Current().ToString();
+	Record.ProtocolVersion = UEMCP_BRIDGE_PROTOCOL_VERSION;
+	Record.HandlerApiVersion = UEMCP_BRIDGE_API_VERSION;
+	Record.State = State;
+
+	if (FMCPBridgeStateFiles::WriteInstanceRecord(FMCPBridgeStateFiles::InstancesDir(), Record))
+	{
+		UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Instance record published: %s (state=%s, port=%d)"),
+			*FMCPBridgeStateFiles::RecordPath(FMCPBridgeStateFiles::InstancesDir(), Record.Pid), *State, PortValue);
+	}
+}
+
+void FMCPBridgeServer::DeleteOwnInstanceRecord()
+{
+	FMCPBridgeStateFiles::DeleteOwnInstanceRecord(
+		FMCPBridgeStateFiles::InstancesDir(),
+		FPlatformProcess::GetCurrentProcessId(),
+		InstanceId.ToString(EGuidFormats::DigitsWithHyphens));
+}
+
+void FMCPBridgeServer::ReapStaleInstanceRecords()
+{
+	const int32 Removed = FMCPBridgeStateFiles::ReapStaleInstanceRecords(
+		FMCPBridgeStateFiles::InstancesDir(),
+		InstanceId.ToString(EGuidFormats::DigitsWithHyphens));
+	if (Removed > 0)
+	{
+		UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Removed %d stale bridge instance record(s)."), Removed);
+	}
 }
 
 void FMCPBridgeServer::DeletePortLockfileIfOwned()
@@ -634,13 +711,10 @@ void FMCPBridgeServer::DeletePortLockfileIfOwned()
 // no extra dependency; the hash only spreads ports, it is not security.
 int32 FMCPBridgeServer::DeriveProjectPort(const FString& ProjectRootDir)
 {
-	FString Norm = ProjectRootDir;
-	Norm.ReplaceInline(TEXT("\\"), TEXT("/"));
-	while (Norm.EndsWith(TEXT("/")))
-	{
-		Norm = Norm.LeftChop(1);
-	}
-	Norm.ToLowerInline();
+	// One implementation of the normalization, shared with the instance records
+	// and requested.json, all of which compare these strings against the ones
+	// the client writes. Two copies is how the two sides drift apart.
+	const FString Norm = FMCPBridgeStateFiles::NormalizeProjectRoot(ProjectRootDir);
 
 	FTCHARToUTF8 Utf8(*Norm);
 	uint8 Hash[20];

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -2147,6 +2147,11 @@ void FMCPBridgeServer::ProcessWebSocketMessages(FMCPSocketHandle ClientSocketFD,
 	}
 }
 
+int64 FMCPBridgeServer::MaxMessageBytes()
+{
+	return kMaxWebSocketMessageBytes;
+}
+
 TArray<uint8> FMCPBridgeServer::CreateWebSocketFrame(const FString& Message)
 {
 	// Simple WebSocket frame creation (text frame, no masking)

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -1230,9 +1230,52 @@ FMCPBridgePortChoice FMCPBridgeServer::ResolveConfiguredPort()
 			TEXT("[UE-MCP] UE_MCP_PORT is '%s', which is not a port number. Ignoring it."), *EnvPort);
 	}
 
-	// 3. `ue-mcp.bridge.port` from the project's layered config (#819). The
+	// 3. The port the client published for this project in
+	//    Saved/UE_MCP_Bridge/requested.json (#817).
+	//
+	//    The pin the client uses is a four-layer config merge plus environment,
+	//    resolved in TypeScript. An editor launched from Explorer sees none of
+	//    that: it has no UE_MCP_PORT in its environment and no way to apply the
+	//    same precedence, so the two halves ended up on different ports for
+	//    exactly the users who had asked for a specific one. The client writes
+	//    the integer it resolved; the bridge reads it and binds it.
+	//
+	//    Above the bridge's own config read because it is the same answer with
+	//    more inputs. Below the two explicit overrides, because a human typing
+	//    -MCPPort= or UE_MCP_PORT for this launch means this launch.
+	//
+	//    The file exists only while a pin exists (the client removes it when the
+	//    pin goes away), so an unpinned install finds nothing here, logs
+	//    nothing, and resolves byte-identically to how it did before.
+	{
+		FString RequestDetail;
+		const int32 RequestedPort = FMCPBridgeStateFiles::ReadRequestedPort(
+			FMCPBridgeStateFiles::RequestedPortPath(),
+			FMCPBridgeStateFiles::ThisProjectRoot(),
+			RequestDetail);
+
+		if (RequestedPort != INDEX_NONE)
+		{
+			UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Using port %d requested by the ue-mcp client in %s"),
+				RequestedPort, *FMCPBridgeStateFiles::RequestedPortPath());
+			Choice.Port = RequestedPort;
+			Choice.Source = TEXT("requested.json published by the ue-mcp client");
+			Choice.bPinned = true;
+			return Choice;
+		}
+		if (!RequestDetail.IsEmpty())
+		{
+			// A file that is present and unusable is a pin that silently did not
+			// take, which is the failure this whole channel exists to remove.
+			UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] %s"), *RequestDetail);
+		}
+	}
+
+	// 4. `ue-mcp.bridge.port` from the project's layered config (#819). The
 	//    client reads the same key, so skipping it here is how a pinned project
-	//    ends up with the two halves on different ports.
+	//    ends up with the two halves on different ports. This stays as the
+	//    answer for a project the client has never been run against, which is
+	//    the case where requested.json does not exist yet.
 	FString ConfigFile;
 	const int32 ConfigPort = ReadConfiguredBridgePort(ConfigFile);
 	if (ConfigPort != INDEX_NONE)
@@ -1244,7 +1287,7 @@ FMCPBridgePortChoice FMCPBridgeServer::ResolveConfiguredPort()
 		return Choice;
 	}
 
-	// 4. Deterministic per-worktree port derived from the project root path.
+	// 5. Deterministic per-worktree port derived from the project root path.
 	const FString ProjectRoot = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
 	const int32 Derived = DeriveProjectPort(ProjectRoot);
 	UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Derived per-project port %d from %s"), Derived, *ProjectRoot);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -1,4 +1,5 @@
 #include "BridgeServer.h"
+#include "BridgeParamEcho.h"
 #include "BridgeStateFiles.h"
 #include "UE_MCP_BridgeModule.h"
 #include "MCPEngineStatus.h"
@@ -119,6 +120,12 @@ FMCPBridgeServer::FMCPBridgeServer(int32 Port, const FString& InPortSource, bool
 	, InstanceId(FGuid::NewGuid())
 	, StartedAtUtc(FDateTime::UtcNow())
 {
+	// #817: construction-gated, from the command line or the environment only.
+	// There is deliberately no way to turn this on over the socket: it is a
+	// test facility, and a facility a caller can enable remotely is a facility
+	// an attacker can enable remotely.
+	FMCPParamEcho::Get().SetEnabled(FMCPParamEcho::ResolveEnabledFromEnvironment());
+
 	// Register core handlers
 	FEditorHandlers::RegisterHandlers(HandlerRegistry);
 	FAssetHandlers::RegisterHandlers(HandlerRegistry);
@@ -1381,6 +1388,13 @@ TSharedPtr<FJsonObject> FMCPBridgeServer::BuildCapabilitiesPayload()
 		TEXT("capability-handshake"),
 		TEXT("exclusive-port-claim"),
 		TEXT("owned-port-record"),
+		// #817. Both are always compiled in and always advertised: a caller has
+		// to be able to tell "this bridge cannot do that" from "this bridge can
+		// and the facility is switched off", and only the first of those two is
+		// grounds for skipping a test.
+		TEXT("instance-records"),
+		TEXT("requested-port-file"),
+		TEXT("param-echo"),
 	};
 	TArray<TSharedPtr<FJsonValue>> FeatureValues;
 	for (const TCHAR* Feature : Features)
@@ -1388,6 +1402,11 @@ TSharedPtr<FJsonObject> FMCPBridgeServer::BuildCapabilitiesPayload()
 		FeatureValues.Add(MakeShared<FJsonValueString>(Feature));
 	}
 	Payload->SetArrayField(TEXT("features"), FeatureValues);
+
+	// Whether the echo is currently recording, which is a runtime fact and not
+	// a capability. A test asserting on forwarded parameters needs both: the
+	// feature name says the method exists, this says the answer will be real.
+	Payload->SetBoolField(TEXT("paramEcho"), FMCPParamEcho::Get().IsEnabled());
 
 	// The registered action list, from the running binary. This is the only
 	// answer to "does the plugin I reached have this method" that a stale DLL
@@ -1440,6 +1459,19 @@ FString FMCPBridgeServer::ProcessMessage(const FString& Message)
 		Params = MakeShared<FJsonObject>();
 	}
 
+	// #817: note what this dispatch was handed, before anything decides what to
+	// do with it. Recorded for unknown methods too: a leaked parameter on a
+	// method the bridge does not have is still a leaked parameter, and it is
+	// the case a stale-plugin test is most likely to hit.
+	//
+	// The two echo methods are excluded so reading the log does not append to
+	// it, which would make a second read return a different answer from the
+	// first for reasons that have nothing to do with the call under test.
+	if (Method != TEXT("get_param_echo") && Method != TEXT("clear_param_echo"))
+	{
+		FMCPParamEcho::Get().Record(Method, Params);
+	}
+
 	// Served here, on the socket thread, deliberately. Every other method waits
 	// on the game thread, so when the game thread is inside a modal dialog, a
 	// slow task, or a hang, this is the only question the bridge can still
@@ -1459,6 +1491,25 @@ FString FMCPBridgeServer::ProcessMessage(const FString& Message)
 	if (Method == TEXT("get_bridge_capabilities"))
 	{
 		return CreateJsonRpcResponse(Request, MakeShared<FJsonValueObject>(BuildCapabilitiesPayload()));
+	}
+
+	// #817: the parameter-name log, and its reset. Served off the game thread
+	// for the same reason the handshake is: the assertion that reads it runs
+	// straight after the call it is about, and making it queue behind the game
+	// thread would let an unrelated slow handler decide whether a leak test
+	// passes.
+	if (Method == TEXT("get_param_echo"))
+	{
+		return CreateJsonRpcResponse(Request, MakeShared<FJsonValueObject>(FMCPParamEcho::Get().BuildPayload()));
+	}
+	if (Method == TEXT("clear_param_echo"))
+	{
+		FMCPParamEcho::Get().Clear();
+		TSharedPtr<FJsonObject> Cleared = MakeShared<FJsonObject>();
+		Cleared->SetBoolField(TEXT("success"), true);
+		Cleared->SetBoolField(TEXT("servedWithoutGameThread"), true);
+		Cleared->SetBoolField(TEXT("enabled"), FMCPParamEcho::Get().IsEnabled());
+		return CreateJsonRpcResponse(Request, MakeShared<FJsonValueObject>(Cleared));
 	}
 
 	// Execute handler on game thread

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
@@ -224,6 +224,38 @@ public:
 	 */
 	TSharedPtr<FJsonObject> BuildCapabilitiesPayload();
 
+	// ── Framing ──────────────────────────────────────────────────────────────
+	//
+	// Public because they are pure functions over a byte buffer with no server
+	// state behind them, and because the automation spec in
+	// Private/Tests/BridgeProtocolTests.cpp is the only thing that can prove
+	// them. The alternative was befriending the test class, which encodes a
+	// test's name into the header and breaks whenever the test is renamed.
+
+	/**
+	 * Decode at most one frame from the front of Buffer.
+	 *
+	 * On Decoded the frame's bytes (header, mask and payload) are consumed from
+	 * Buffer and whatever follows is left in place, so a read that delivered two
+	 * pipelined requests yields both instead of dropping the second. On
+	 * NeedMoreData nothing is consumed and the caller reads again.
+	 *
+	 * On ProtocolError OutCloseCode carries the status the peer should be closed
+	 * with: 1002 for framing the bridge cannot follow, 1009 when the frame is
+	 * merely too large. The caller sends that code, so the client can tell a
+	 * size refusal from a broken stream.
+	 */
+	static EMCPFrameDecode DecodeWebSocketFrame(TArray<uint8>& Buffer, FMCPWebSocketFrame& OutFrame, FString& OutError, uint16& OutCloseCode);
+
+	/** Frame a text message for the wire. Server to client, so never masked. */
+	static TArray<uint8> CreateWebSocketFrame(const FString& Message);
+
+	/** Frame a control opcode (close, ping, pong) with its payload. */
+	static TArray<uint8> CreateControlFrame(EMCPWebSocketOpcode Opcode, const TArray<uint8>& Payload);
+
+	/** The largest assembled message the bridge will hold for one connection. */
+	static int64 MaxMessageBytes();
+
 private:
 	// Server port
 	int32 ServerPort;
@@ -270,25 +302,6 @@ private:
 	static void SendHttpError(FMCPSocketHandle SocketFD, int32 StatusCode, const FString& StatusText, const FString& Detail);
 
 	FString CreateWebSocketAcceptKey(const FString& ClientKey);
-	TArray<uint8> CreateWebSocketFrame(const FString& Message);
-
-	/**
-	 * Decode at most one frame from the front of Buffer.
-	 *
-	 * On Decoded the frame's bytes (header, mask and payload) are consumed from
-	 * Buffer and whatever follows is left in place, so a read that delivered two
-	 * pipelined requests yields both instead of dropping the second. On
-	 * NeedMoreData nothing is consumed and the caller reads again.
-	 *
-	 * On ProtocolError OutCloseCode carries the status the peer should be closed
-	 * with: 1002 for framing the bridge cannot follow, 1009 when the frame is
-	 * merely too large. The caller sends that code, so the client can tell a
-	 * size refusal from a broken stream.
-	 */
-	static EMCPFrameDecode DecodeWebSocketFrame(TArray<uint8>& Buffer, FMCPWebSocketFrame& OutFrame, FString& OutError, uint16& OutCloseCode);
-
-	/** Frame a control opcode (close, ping, pong) with its payload. */
-	static TArray<uint8> CreateControlFrame(EMCPWebSocketOpcode Opcode, const TArray<uint8>& Payload);
 
 	/** Send a close frame carrying a status code and a human-readable reason. */
 	static void SendCloseFrame(FMCPSocketHandle SocketFD, uint16 StatusCode, const FString& Reason);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
@@ -192,12 +192,19 @@ public:
 	static int32 DeriveProjectPort(const FString& ProjectRootDir);
 
 	// Resolve the base port to bind: -MCPPort= command line > UE_MCP_PORT env >
+	// the port the client published in Saved/UE_MCP_Bridge/requested.json >
 	// `ue-mcp.bridge.port` from the project's config files > deterministic
 	// derived port. That order is the client's (see src/bridge.ts); both sides
 	// have to walk it identically or a pinned project ends up with a client
 	// aimed at one port and an editor listening on another (#819). The probe
 	// loop in Run() walks upward from here on collision, and the actual bound
 	// port is published to the lockfile.
+	//
+	// requested.json (#817) sits above the config read because it is the same
+	// answer computed from more inputs: the client merges four config layers
+	// and the environment, none of which an editor launched from Explorer can
+	// see. It exists only while a pin exists, so an unpinned install resolves
+	// exactly as it did before that channel was added.
 	static FMCPBridgePortChoice ResolveConfiguredPort();
 
 	// Get handler registry

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.h
@@ -171,6 +171,20 @@ public:
 	 *  own path so a failed start can never overwrite a live editor's record. */
 	void WriteBindFailureRecord(int32 FirstPort, int32 LastPort, int32 ErrorCode);
 
+	// #817: this process's own record under Saved/UE_MCP_Bridge/instances/.
+	//
+	// port.json names one bridge for a whole project directory, which is the
+	// right answer for one editor and no answer at all for two. A per-pid file
+	// has exactly one writer by construction, so a second editor of the same
+	// project describes itself instead of overwriting the first, and a record
+	// left by a crash is provably stale instead of merely suspicious.
+	void WriteInstanceRecord(const FString& State, int32 PortValue);
+	void DeleteOwnInstanceRecord();
+
+	/** Remove records whose process is gone. Runs once, at startup, on the
+	 *  server thread; the sweep never touches this instance's own record. */
+	void ReapStaleInstanceRecords();
+
 	// Deterministic per-worktree base port. Derived from a hash of the project
 	// root path so every checkout gets a stable, launch-order-independent port
 	// that the Node client computes identically (see src/port.ts). Keep the two

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeStateFiles.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeStateFiles.cpp
@@ -1,0 +1,419 @@
+#include "BridgeStateFiles.h"
+#include "UE_MCP_BridgeModule.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformProcess.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+
+#if PLATFORM_WINDOWS
+#include "Windows/AllowWindowsPlatformTypes.h"
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include "Windows/HideWindowsPlatformTypes.h"
+#pragma comment(lib, "ws2_32.lib")
+#elif PLATFORM_LINUX || PLATFORM_MAC
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/select.h>
+#endif
+
+FString FMCPBridgeStateFiles::NormalizeProjectRoot(const FString& Dir)
+{
+	FString Norm = Dir;
+	Norm.ReplaceInline(TEXT("\\"), TEXT("/"));
+	while (Norm.EndsWith(TEXT("/")))
+	{
+		Norm = Norm.LeftChop(1);
+	}
+	Norm.ToLowerInline();
+	return Norm;
+}
+
+FString FMCPBridgeStateFiles::ThisProjectRoot()
+{
+	return NormalizeProjectRoot(FPaths::ConvertRelativePathToFull(FPaths::ProjectDir()));
+}
+
+FString FMCPBridgeStateFiles::StateDir()
+{
+	return FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("UE_MCP_Bridge"));
+}
+
+FString FMCPBridgeStateFiles::InstancesDir()
+{
+	return FPaths::Combine(StateDir(), TEXT("instances"));
+}
+
+FString FMCPBridgeStateFiles::RequestedPortPath()
+{
+	return FPaths::Combine(StateDir(), TEXT("requested.json"));
+}
+
+bool FMCPBridgeStateFiles::PublishJson(const FString& FilePath, const TSharedPtr<FJsonObject>& Payload)
+{
+	if (!Payload.IsValid())
+	{
+		return false;
+	}
+
+	IFileManager::Get().MakeDirectory(*FPaths::GetPath(FilePath), /*Tree*/ true);
+
+	FString Serialized;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Serialized);
+	FJsonSerializer::Serialize(Payload.ToSharedRef(), Writer);
+
+	const FString TempPath = FString::Printf(TEXT("%s.%u.tmp"), *FilePath, FPlatformProcess::GetCurrentProcessId());
+	if (!FFileHelper::SaveStringToFile(Serialized, *TempPath))
+	{
+		return false;
+	}
+	if (!IFileManager::Get().Move(*FilePath, *TempPath, /*Replace*/ true))
+	{
+		IFileManager::Get().Delete(*TempPath);
+		return false;
+	}
+	return true;
+}
+
+TSharedPtr<FJsonObject> FMCPBridgeStateFiles::LoadJson(const FString& FilePath)
+{
+	FString Raw;
+	if (!FFileHelper::LoadFileToString(Raw, *FilePath))
+	{
+		return nullptr;
+	}
+	TSharedPtr<FJsonObject> Parsed;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Raw);
+	if (!FJsonSerializer::Deserialize(Reader, Parsed) || !Parsed.IsValid())
+	{
+		return nullptr;
+	}
+	return Parsed;
+}
+
+FString FMCPBridgeStateFiles::RecordPath(const FString& InInstancesDir, uint32 Pid)
+{
+	return FPaths::Combine(InInstancesDir, FString::Printf(TEXT("%u.json"), Pid));
+}
+
+bool FMCPBridgeStateFiles::WriteInstanceRecord(const FString& InInstancesDir, const FMCPInstanceRecord& Record)
+{
+	TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+	Obj->SetNumberField(TEXT("port"), Record.Port);
+	Obj->SetNumberField(TEXT("pid"), (double)Record.Pid);
+	Obj->SetStringField(TEXT("instanceId"), Record.InstanceId);
+	Obj->SetStringField(TEXT("projectRoot"), Record.ProjectRoot);
+	Obj->SetStringField(TEXT("startedAt"), Record.StartedAtUtc);
+	Obj->SetStringField(TEXT("engineVersion"), Record.EngineVersion);
+	Obj->SetNumberField(TEXT("protocolVersion"), Record.ProtocolVersion);
+	Obj->SetNumberField(TEXT("handlerApiVersion"), Record.HandlerApiVersion);
+	Obj->SetStringField(TEXT("state"), Record.State);
+
+	const FString FilePath = RecordPath(InInstancesDir, Record.Pid);
+	if (!PublishJson(FilePath, Obj))
+	{
+		UE_LOG(LogMCPBridge, Warning, TEXT("[UE-MCP] Failed to write instance record: %s"), *FilePath);
+		return false;
+	}
+	return true;
+}
+
+bool FMCPBridgeStateFiles::ReadInstanceRecord(const FString& FilePath, FMCPInstanceRecord& OutRecord)
+{
+	const TSharedPtr<FJsonObject> Parsed = LoadJson(FilePath);
+	if (!Parsed.IsValid())
+	{
+		return false;
+	}
+
+	double NumberValue = 0.0;
+	if (Parsed->TryGetNumberField(TEXT("port"), NumberValue))
+	{
+		OutRecord.Port = (int32)NumberValue;
+	}
+	if (Parsed->TryGetNumberField(TEXT("pid"), NumberValue))
+	{
+		OutRecord.Pid = (uint32)NumberValue;
+	}
+	if (Parsed->TryGetNumberField(TEXT("protocolVersion"), NumberValue))
+	{
+		OutRecord.ProtocolVersion = (int32)NumberValue;
+	}
+	if (Parsed->TryGetNumberField(TEXT("handlerApiVersion"), NumberValue))
+	{
+		OutRecord.HandlerApiVersion = (int32)NumberValue;
+	}
+
+	Parsed->TryGetStringField(TEXT("instanceId"), OutRecord.InstanceId);
+	Parsed->TryGetStringField(TEXT("projectRoot"), OutRecord.ProjectRoot);
+	Parsed->TryGetStringField(TEXT("startedAt"), OutRecord.StartedAtUtc);
+	Parsed->TryGetStringField(TEXT("engineVersion"), OutRecord.EngineVersion);
+	Parsed->TryGetStringField(TEXT("state"), OutRecord.State);
+
+	// A record with no pid names no process, so nothing about it can be
+	// verified and nothing about it can be safely reaped either.
+	return OutRecord.Pid > 0;
+}
+
+void FMCPBridgeStateFiles::DeleteOwnInstanceRecord(const FString& InInstancesDir, uint32 Pid, const FString& InstanceId)
+{
+	const FString FilePath = RecordPath(InInstancesDir, Pid);
+	if (!FPaths::FileExists(FilePath))
+	{
+		return;
+	}
+
+	FMCPInstanceRecord Existing;
+	if (!ReadInstanceRecord(FilePath, Existing))
+	{
+		// Unreadable and sitting on this process's own filename. Nobody else can
+		// own it, and leaving it would make the next boot with this pid look
+		// like a stale live editor.
+		IFileManager::Get().Delete(*FilePath, /*RequireExists*/ false, /*EvenReadOnly*/ false, /*Quiet*/ true);
+		return;
+	}
+
+	if (!Existing.InstanceId.IsEmpty() && Existing.InstanceId != InstanceId)
+	{
+		UE_LOG(LogMCPBridge, Log,
+			TEXT("[UE-MCP] Leaving instance record %s alone: it belongs to instance %s, not %s."),
+			*FilePath, *Existing.InstanceId, *InstanceId);
+		return;
+	}
+
+	if (Existing.State == TEXT("bind-failed"))
+	{
+		// The whole point of that record is to outlive the process that wrote
+		// it. Removing it here would delete the answer to the question the user
+		// is about to ask.
+		UE_LOG(LogMCPBridge, Log,
+			TEXT("[UE-MCP] Keeping the bind-failed instance record at %s so the failure stays diagnosable."),
+			*FilePath);
+		return;
+	}
+
+	if (IFileManager::Get().Delete(*FilePath))
+	{
+		UE_LOG(LogMCPBridge, Log, TEXT("[UE-MCP] Instance record removed: %s"), *FilePath);
+	}
+}
+
+bool FMCPBridgeStateFiles::IsPortAccepting(int32 Port, int32 TimeoutMilliseconds)
+{
+	if (Port <= 0 || Port > 65535)
+	{
+		return false;
+	}
+
+#if PLATFORM_WINDOWS
+	// Refcounted per process, so asking again from here is safe even though the
+	// server thread has already asked.
+	WSADATA WsaData;
+	if (WSAStartup(MAKEWORD(2, 2), &WsaData) != 0)
+	{
+		return false;
+	}
+	SOCKET Sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (Sock == INVALID_SOCKET)
+	{
+		WSACleanup();
+		return false;
+	}
+	u_long NonBlocking = 1;
+	ioctlsocket(Sock, FIONBIO, &NonBlocking);
+#else
+	int32 Sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (Sock < 0)
+	{
+		return false;
+	}
+	const int32 Flags = fcntl(Sock, F_GETFL, 0);
+	fcntl(Sock, F_SETFL, Flags | O_NONBLOCK);
+#endif
+
+	sockaddr_in Addr;
+	FMemory::Memset(&Addr, 0, sizeof(Addr));
+	Addr.sin_family = AF_INET;
+	Addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	Addr.sin_port = htons((uint16)Port);
+
+	bool bAccepting = false;
+	const int32 ConnectResult = connect(Sock, (sockaddr*)&Addr, sizeof(Addr));
+	if (ConnectResult == 0)
+	{
+		bAccepting = true;
+	}
+	else
+	{
+#if PLATFORM_WINDOWS
+		const bool bInProgress = WSAGetLastError() == WSAEWOULDBLOCK;
+#else
+		const bool bInProgress = errno == EINPROGRESS;
+#endif
+		if (bInProgress)
+		{
+			fd_set WriteSet;
+			FD_ZERO(&WriteSet);
+			FD_SET(Sock, &WriteSet);
+
+			timeval Timeout;
+			Timeout.tv_sec = TimeoutMilliseconds / 1000;
+			Timeout.tv_usec = (TimeoutMilliseconds % 1000) * 1000;
+
+			const int32 SelectResult = select((int32)(Sock + 1), nullptr, &WriteSet, nullptr, &Timeout);
+			if (SelectResult > 0)
+			{
+				// Writable covers both "connected" and "refused"; the pending
+				// socket error is the only thing that tells them apart.
+				int32 SocketError = 0;
+				socklen_t ErrorLen = sizeof(SocketError);
+				if (getsockopt(Sock, SOL_SOCKET, SO_ERROR, (char*)&SocketError, &ErrorLen) == 0)
+				{
+					bAccepting = SocketError == 0;
+				}
+			}
+		}
+	}
+
+#if PLATFORM_WINDOWS
+	closesocket(Sock);
+	WSACleanup();
+#else
+	close(Sock);
+#endif
+	return bAccepting;
+}
+
+bool FMCPBridgeStateFiles::IsInstanceLive(const FMCPInstanceRecord& Record)
+{
+	if (Record.Pid == 0)
+	{
+		return false;
+	}
+	if (!FPlatformProcess::IsApplicationRunning(Record.Pid))
+	{
+		return false;
+	}
+	if (Record.State == TEXT("bind-failed") || Record.Port <= 0)
+	{
+		// Nothing bound, so there is no address to test. The process being alive
+		// is the whole of what this record claims.
+		return true;
+	}
+	// The pid could have been recycled onto an unrelated process, in which case
+	// nothing is listening where the record says.
+	return IsPortAccepting(Record.Port, /*TimeoutMilliseconds*/ 250);
+}
+
+int32 FMCPBridgeStateFiles::ReapStaleInstanceRecords(const FString& InInstancesDir, const FString& OwnInstanceId)
+{
+	return ReapStaleInstanceRecords(InInstancesDir, OwnInstanceId,
+		[](const FMCPInstanceRecord& Record) { return FMCPBridgeStateFiles::IsInstanceLive(Record); });
+}
+
+int32 FMCPBridgeStateFiles::ReapStaleInstanceRecords(
+	const FString& InInstancesDir,
+	const FString& OwnInstanceId,
+	TFunctionRef<bool(const FMCPInstanceRecord&)> IsLive)
+{
+	TArray<FString> FileNames;
+	IFileManager::Get().FindFiles(FileNames, *FPaths::Combine(InInstancesDir, TEXT("*.json")), /*Files*/ true, /*Directories*/ false);
+
+	int32 Removed = 0;
+	for (const FString& FileName : FileNames)
+	{
+		const FString FilePath = FPaths::Combine(InInstancesDir, FileName);
+
+		FMCPInstanceRecord Record;
+		if (!ReadInstanceRecord(FilePath, Record))
+		{
+			// Not a record this bridge wrote, or corrupt. Either way there is no
+			// owner to check against, so leave it where it is and say so once.
+			UE_LOG(LogMCPBridge, Verbose,
+				TEXT("[UE-MCP] Ignoring unreadable instance record %s during the staleness sweep."), *FilePath);
+			continue;
+		}
+
+		if (!Record.InstanceId.IsEmpty() && Record.InstanceId == OwnInstanceId)
+		{
+			continue;
+		}
+
+		if (IsLive(Record))
+		{
+			continue;
+		}
+
+		if (IFileManager::Get().Delete(*FilePath, /*RequireExists*/ false, /*EvenReadOnly*/ false, /*Quiet*/ true))
+		{
+			++Removed;
+			UE_LOG(LogMCPBridge, Log,
+				TEXT("[UE-MCP] Removed the stale instance record for pid %u (port %d): that process is gone."),
+				Record.Pid, Record.Port);
+		}
+	}
+
+	return Removed;
+}
+
+int32 FMCPBridgeStateFiles::ReadRequestedPort(const FString& FilePath, const FString& NormalizedProjectRoot, FString& OutDetail)
+{
+	OutDetail.Reset();
+
+	if (FilePath.IsEmpty() || !FPaths::FileExists(FilePath))
+	{
+		// No pin was ever published for this project. Say nothing: an install
+		// that never used this channel has to resolve its port exactly as it did
+		// before the channel existed, log lines included.
+		return INDEX_NONE;
+	}
+
+	const TSharedPtr<FJsonObject> Parsed = LoadJson(FilePath);
+	if (!Parsed.IsValid())
+	{
+		OutDetail = FString::Printf(TEXT("%s is not readable JSON, so the port it asks for was ignored."), *FilePath);
+		return INDEX_NONE;
+	}
+
+	double PortValue = 0.0;
+	if (!Parsed->TryGetNumberField(TEXT("port"), PortValue))
+	{
+		OutDetail = FString::Printf(TEXT("%s has no numeric 'port', so it was ignored."), *FilePath);
+		return INDEX_NONE;
+	}
+
+	const int32 Port = (int32)PortValue;
+	if (Port < 1 || Port > 65535)
+	{
+		OutDetail = FString::Printf(TEXT("%s asks for port %d, outside the range 1-65535, so it was ignored."), *FilePath, Port);
+		return INDEX_NONE;
+	}
+
+	FString RecordedRoot;
+	if (!Parsed->TryGetStringField(TEXT("projectRoot"), RecordedRoot) || RecordedRoot.IsEmpty())
+	{
+		OutDetail = FString::Printf(
+			TEXT("%s names no project root, so there is no way to tell whether it was written for this project. Ignoring it."),
+			*FilePath);
+		return INDEX_NONE;
+	}
+
+	if (NormalizeProjectRoot(RecordedRoot) != NormalizedProjectRoot)
+	{
+		// A Saved directory that was copied between checkouts carries the
+		// original's pin. Honouring it would aim two projects at one port.
+		OutDetail = FString::Printf(
+			TEXT("%s was written for project root '%s', not '%s', so the port it asks for was ignored."),
+			*FilePath, *RecordedRoot, *NormalizedProjectRoot);
+		return INDEX_NONE;
+	}
+
+	return Port;
+}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeStateFiles.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeStateFiles.h
@@ -132,6 +132,10 @@ public:
 	 * still occupied", which is all a staleness sweep needs. Deciding that a
 	 * given editor is the right editor is the client's job and it has the
 	 * capability handshake to do it with.
+	 *
+	 * The probe connects and hangs up without upgrading, so the editor on the
+	 * other end logs one line about a connection that closed before its upgrade
+	 * request arrived. That line is this function, once per sweep per record.
 	 */
 	static bool IsPortAccepting(int32 Port, int32 TimeoutMilliseconds);
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeStateFiles.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeStateFiles.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+#include "Templates/Function.h"
+
+/**
+ * Everything the bridge keeps under <Project>/Saved/UE_MCP_Bridge/.
+ *
+ * There were two files here before #817 and both of them are single-writer by
+ * assumption rather than by construction: `port.json` names one port for the
+ * whole project directory, and `bridge-error.json` names one failed start. Two
+ * editors of one project therefore had no way to describe themselves, and the
+ * second one to boot simply overwrote the first one's address.
+ *
+ * `instances/<pid>.json` is the fix. Every process writes exactly one file,
+ * named after itself, and removes only that file. Nothing is shared, so nothing
+ * can be clobbered, and a record left behind by a crash is provably stale
+ * rather than indistinguishable from a live one.
+ *
+ * `requested.json` runs the other way: the client writes it and the bridge
+ * reads it. It exists because the port pin is resolved on the client (four
+ * config layers plus environment) and an editor launched from Explorer cannot
+ * see that resolution. It carries an integer, not a policy.
+ */
+
+/** One editor's record of the bridge it is running, or failed to run. */
+struct FMCPInstanceRecord
+{
+	/** The bound port, or 0 when the bind never succeeded. */
+	int32 Port = 0;
+
+	/** The editor process. Named in the filename too, so the two can be compared. */
+	uint32 Pid = 0;
+
+	/**
+	 * The server object that wrote this. Pids are recycled and a project can be
+	 * relaunched inside a second, so the pid alone cannot answer "is this the
+	 * record I wrote".
+	 */
+	FString InstanceId;
+
+	/** Normalized project root, so a copied Saved directory is detectable. */
+	FString ProjectRoot;
+
+	FString StartedAtUtc;
+	FString EngineVersion;
+	int32 ProtocolVersion = 0;
+	int32 HandlerApiVersion = 0;
+
+	/** "listening" or "bind-failed". */
+	FString State;
+};
+
+class FMCPBridgeStateFiles
+{
+public:
+	/**
+	 * Canonical form of a project root: forward slashes, no trailing slash,
+	 * lowercased. Identical to normalizeProjectRoot in src/port.ts, because the
+	 * two sides compare these strings to each other.
+	 */
+	static FString NormalizeProjectRoot(const FString& Dir);
+
+	/** This project's normalized root, as the records record it. */
+	static FString ThisProjectRoot();
+
+	/** <Project>/Saved/UE_MCP_Bridge. */
+	static FString StateDir();
+
+	/** <Project>/Saved/UE_MCP_Bridge/instances. */
+	static FString InstancesDir();
+
+	/** <Project>/Saved/UE_MCP_Bridge/requested.json. */
+	static FString RequestedPortPath();
+
+	/**
+	 * Publish JSON by writing a temporary file and renaming it over the target.
+	 *
+	 * The client polls these files while it waits for an editor. Writing in
+	 * place means a poll can land mid-write, read a torn document, fail to
+	 * parse it and fall back to a guessed port. A rename is the one step a
+	 * reader cannot catch halfway through.
+	 */
+	static bool PublishJson(const FString& FilePath, const TSharedPtr<FJsonObject>& Payload);
+
+	/** Parse a JSON object off disk, or null when it is absent or malformed. */
+	static TSharedPtr<FJsonObject> LoadJson(const FString& FilePath);
+
+	/** <InstancesDir>/<Pid>.json. */
+	static FString RecordPath(const FString& InInstancesDir, uint32 Pid);
+
+	static bool WriteInstanceRecord(const FString& InInstancesDir, const FMCPInstanceRecord& Record);
+	static bool ReadInstanceRecord(const FString& FilePath, FMCPInstanceRecord& OutRecord);
+
+	/**
+	 * Remove this process's own record on the way out.
+	 *
+	 * Two things it deliberately will not do. It will not remove a file whose
+	 * instanceId is somebody else's, which is what stops a recycled pid from
+	 * erasing a live editor. And it will not remove a `bind-failed` record,
+	 * because that record is the entire explanation for "the editor is running
+	 * and the bridge is not" and the process that wrote it is exactly the
+	 * process now exiting.
+	 */
+	static void DeleteOwnInstanceRecord(const FString& InInstancesDir, uint32 Pid, const FString& InstanceId);
+
+	/** True when the process and, for a listening record, the port are still there. */
+	static bool IsInstanceLive(const FMCPInstanceRecord& Record);
+
+	/**
+	 * Delete every record in the directory that can be proven dead, skipping the
+	 * one carrying OwnInstanceId. Returns how many were removed.
+	 *
+	 * Proof runs one way only: a record is removed when liveness says no, and
+	 * kept in every ambiguous case. Deleting a live editor's record is a
+	 * connectivity outage; keeping a dead one costs a few hundred bytes until
+	 * the next boot looks again.
+	 */
+	static int32 ReapStaleInstanceRecords(const FString& InInstancesDir, const FString& OwnInstanceId);
+
+	/** Reap with an injected liveness test, so the sweep can be tested offline. */
+	static int32 ReapStaleInstanceRecords(
+		const FString& InInstancesDir,
+		const FString& OwnInstanceId,
+		TFunctionRef<bool(const FMCPInstanceRecord&)> IsLive);
+
+	/**
+	 * Will anything accept a loopback connection on this port right now?
+	 *
+	 * Deliberately weaker than an identity check: it answers "is that address
+	 * still occupied", which is all a staleness sweep needs. Deciding that a
+	 * given editor is the right editor is the client's job and it has the
+	 * capability handshake to do it with.
+	 */
+	static bool IsPortAccepting(int32 Port, int32 TimeoutMilliseconds);
+
+	/**
+	 * The port the client asked this editor to bind, or INDEX_NONE.
+	 *
+	 * OutDetail is filled in only when the file exists and cannot be honoured,
+	 * so an install that never pinned a port produces no file, no detail and no
+	 * log line, and resolves exactly as it did before this channel existed.
+	 */
+	static int32 ReadRequestedPort(const FString& FilePath, const FString& NormalizedProjectRoot, FString& OutDetail);
+};

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/BridgeProtocolTests.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/BridgeProtocolTests.cpp
@@ -1,0 +1,818 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "BridgeParamEcho.h"
+#include "BridgeServer.h"
+#include "BridgeStateFiles.h"
+#include "MCPHandlerRegistration.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformProcess.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/DateTime.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Guid.h"
+#include "Misc/Paths.h"
+
+/**
+ * Phase 0 of the multi-editor plan (#817), scripted.
+ *
+ * The TypeScript tier drives the bridge through a socket and can therefore see
+ * responses and nothing else. It cannot see a frame boundary, a file on disk
+ * that no handler reads, or a parameter that arrived and was ignored, which is
+ * exactly the set of things Phase 0 is about. This module is where those are
+ * asserted.
+ *
+ * Everything here is a pure function over a buffer, a directory, or a
+ * standalone object. Nothing binds a port and nothing writes into the project's
+ * live Saved/UE_MCP_Bridge directory: a test that clobbered port.json would
+ * disconnect the editor it is running inside.
+ *
+ * Two Phase 0 items are deliberately not here. 0.4 (identity answered while a
+ * handler blocks the game thread) and 0.6 (shutdown with a client attached)
+ * are both statements about two threads and a live socket, and a test that
+ * stood one up inside the editor would be asserting on the editor it is hosted
+ * by. Those belong to the live tier in Phase 7.
+ */
+
+namespace
+{
+	/**
+	 * One client frame, framed the way a client must: masked, with the mask
+	 * applied to the payload.
+	 *
+	 * Written out longhand rather than reusing the server's framer, because the
+	 * server's framer is one of the things under test and a test that encodes
+	 * with the same code it decodes with proves only that the code agrees with
+	 * itself.
+	 */
+	TArray<uint8> MakeClientFrame(uint8 Opcode, const TArray<uint8>& Payload, bool bFinal = true)
+	{
+		TArray<uint8> Frame;
+		Frame.Add((uint8)((bFinal ? 0x80 : 0x00) | (Opcode & 0x0F)));
+
+		const int64 Length = Payload.Num();
+		if (Length < 126)
+		{
+			Frame.Add((uint8)(0x80 | (uint8)Length)); // mask bit set
+		}
+		else if (Length < 65536)
+		{
+			Frame.Add((uint8)(0x80 | 126));
+			Frame.Add((uint8)((Length >> 8) & 0xFF));
+			Frame.Add((uint8)(Length & 0xFF));
+		}
+		else
+		{
+			Frame.Add((uint8)(0x80 | 127));
+			for (int32 Index = 7; Index >= 0; --Index)
+			{
+				Frame.Add((uint8)((Length >> (Index * 8)) & 0xFF));
+			}
+		}
+
+		const uint8 MaskKey[4] = { 0x37, 0xFA, 0x21, 0x3D };
+		Frame.Append(MaskKey, 4);
+		for (int32 Index = 0; Index < Payload.Num(); ++Index)
+		{
+			Frame.Add(Payload[Index] ^ MaskKey[Index % 4]);
+		}
+		return Frame;
+	}
+
+	TArray<uint8> TextPayload(const FString& Text)
+	{
+		const FTCHARToUTF8 Utf8(*Text);
+		TArray<uint8> Bytes;
+		Bytes.Append((const uint8*)Utf8.Get(), Utf8.Length());
+		return Bytes;
+	}
+
+	FString PayloadAsText(const TArray<uint8>& Payload)
+	{
+		if (Payload.Num() == 0)
+		{
+			return FString();
+		}
+		const FUTF8ToTCHAR Converted((const char*)Payload.GetData(), Payload.Num());
+		return FString(Converted.Length(), Converted.Get());
+	}
+
+	/** A scratch directory that is not the project's live bridge state. */
+	FString MakeScratchDir(const TCHAR* Leaf)
+	{
+		const FString Dir = FPaths::Combine(
+			FPaths::ProjectIntermediateDir(),
+			TEXT("UE_MCP_BridgeTests"),
+			FString::Printf(TEXT("%s-%s"), Leaf, *FGuid::NewGuid().ToString(EGuidFormats::Digits)));
+		IFileManager::Get().MakeDirectory(*Dir, /*Tree*/ true);
+		return Dir;
+	}
+
+	void RemoveScratchDir(const FString& Dir)
+	{
+		IFileManager::Get().DeleteDirectory(*Dir, /*RequireExists*/ false, /*Tree*/ true);
+	}
+
+	FMCPInstanceRecord MakeRecord(uint32 Pid, int32 Port, const TCHAR* State)
+	{
+		FMCPInstanceRecord Record;
+		Record.Pid = Pid;
+		Record.Port = Port;
+		Record.InstanceId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphens);
+		Record.ProjectRoot = TEXT("c:/projects/example");
+		Record.StartedAtUtc = FDateTime::UtcNow().ToIso8601();
+		Record.EngineVersion = TEXT("5.8.0");
+		Record.ProtocolVersion = UEMCP_BRIDGE_PROTOCOL_VERSION;
+		Record.HandlerApiVersion = UEMCP_BRIDGE_API_VERSION;
+		Record.State = State;
+		return Record;
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 0.1 Inbound frame reassembly
+// ─────────────────────────────────────────────────────────────────────────────
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMCPBridgeFrameReassemblyTest,
+	"UE.MCP.Bridge.Protocol.FrameReassembly",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMCPBridgeFrameReassemblyTest::RunTest(const FString& Parameters)
+{
+	FMCPWebSocketFrame Frame;
+	FString Error;
+	uint16 CloseCode = 0;
+
+	// Two requests in one segment. A decoder that handled one frame per read
+	// answered the first and silently dropped the second, which reads to the
+	// caller as a request the editor never received.
+	{
+		TArray<uint8> Buffer;
+		Buffer.Append(MakeClientFrame(0x1, TextPayload(TEXT("{\"id\":\"one\"}"))));
+		Buffer.Append(MakeClientFrame(0x1, TextPayload(TEXT("{\"id\":\"two\"}"))));
+
+		TestEqual(TEXT("first frame decodes"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::Decoded);
+		TestEqual(TEXT("first payload"), PayloadAsText(Frame.Payload), FString(TEXT("{\"id\":\"one\"}")));
+
+		TestEqual(TEXT("second frame decodes from the same segment"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::Decoded);
+		TestEqual(TEXT("second payload"), PayloadAsText(Frame.Payload), FString(TEXT("{\"id\":\"two\"}")));
+
+		TestEqual(TEXT("both frames were consumed"), Buffer.Num(), 0);
+	}
+
+	// A frame split across reads. Nothing may be consumed until it is whole,
+	// or the tail of the message is decoded as the head of the next one.
+	{
+		const TArray<uint8> Whole = MakeClientFrame(0x1, TextPayload(TEXT("{\"id\":\"split\"}")));
+		TArray<uint8> Partial;
+		Partial.Append(Whole.GetData(), Whole.Num() - 3);
+		const int32 PartialSize = Partial.Num();
+
+		TestEqual(TEXT("a partial frame asks for more data"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Partial, Frame, Error, CloseCode), (int32)EMCPFrameDecode::NeedMoreData);
+		TestEqual(TEXT("a partial frame consumes nothing"), Partial.Num(), PartialSize);
+
+		Partial.Append(Whole.GetData() + Whole.Num() - 3, 3);
+		TestEqual(TEXT("the completed frame decodes"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Partial, Frame, Error, CloseCode), (int32)EMCPFrameDecode::Decoded);
+		TestEqual(TEXT("split payload"), PayloadAsText(Frame.Payload), FString(TEXT("{\"id\":\"split\"}")));
+	}
+
+	// 100 KB inbound, which is past 65535 and so needs the 64-bit extended
+	// length. Round-tripped byte for byte, not merely accepted.
+	{
+		TArray<uint8> Large;
+		Large.SetNumUninitialized(100 * 1024);
+		for (int32 Index = 0; Index < Large.Num(); ++Index)
+		{
+			Large[Index] = (uint8)(Index % 251);
+		}
+
+		TArray<uint8> Buffer = MakeClientFrame(0x1, Large);
+		TestEqual(TEXT("a 100 KB frame decodes"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::Decoded);
+		TestEqual(TEXT("100 KB payload length survives"), Frame.Payload.Num(), Large.Num());
+		TestTrue(TEXT("100 KB payload content survives"), Frame.Payload == Large);
+	}
+
+	// Fragmentation: a data frame with FIN clear, then a continuation. The
+	// reassembly loop in ProcessWebSocketMessages joins these; the decoder's
+	// job is to report the two facts that loop needs.
+	{
+		TArray<uint8> Buffer;
+		Buffer.Append(MakeClientFrame(0x1, TextPayload(TEXT("{\"id\":")), /*bFinal*/ false));
+		Buffer.Append(MakeClientFrame(0x0, TextPayload(TEXT("\"frag\"}")), /*bFinal*/ true));
+
+		TestEqual(TEXT("first fragment decodes"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::Decoded);
+		TestFalse(TEXT("first fragment is not final"), Frame.bFinal);
+		TestEqual(TEXT("first fragment is a text frame"), (int32)Frame.Opcode, (int32)EMCPWebSocketOpcode::Text);
+
+		TestEqual(TEXT("continuation decodes"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::Decoded);
+		TestTrue(TEXT("continuation is final"), Frame.bFinal);
+		TestEqual(TEXT("continuation carries the continuation opcode"), (int32)Frame.Opcode, (int32)EMCPWebSocketOpcode::Continuation);
+	}
+
+	// A close frame is a close frame, not a JSON-RPC parse error. Handing one
+	// to the parser replied to "goodbye" with an error and left the peer
+	// waiting for a close that never came, holding a thread open.
+	{
+		TArray<uint8> ClosePayload;
+		ClosePayload.Add(0x03);
+		ClosePayload.Add(0xE8); // 1000, normal closure
+		TArray<uint8> Buffer = MakeClientFrame(0x8, ClosePayload);
+
+		TestEqual(TEXT("a close frame decodes"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::Decoded);
+		TestEqual(TEXT("a close frame is recognised as one"), (int32)Frame.Opcode, (int32)EMCPWebSocketOpcode::Close);
+		TestEqual(TEXT("the peer's status code survives"), (int32)Frame.Payload.Num(), 2);
+	}
+
+	// Ping is answered with pong, so ping has to be recognised too.
+	{
+		TArray<uint8> Buffer = MakeClientFrame(0x9, TextPayload(TEXT("hb")));
+		TestEqual(TEXT("a ping decodes"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::Decoded);
+		TestEqual(TEXT("a ping is recognised as one"), (int32)Frame.Opcode, (int32)EMCPWebSocketOpcode::Ping);
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMCPBridgeFrameRefusalTest,
+	"UE.MCP.Bridge.Protocol.FrameRefusals",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMCPBridgeFrameRefusalTest::RunTest(const FString& Parameters)
+{
+	FMCPWebSocketFrame Frame;
+	FString Error;
+	uint16 CloseCode = 0;
+
+	// RFC 6455 section 5.1: a client masks every frame. An unmasked one used to
+	// be accepted with its payload read from where the mask key would have been,
+	// which puts the very next frame boundary in the wrong place.
+	{
+		TArray<uint8> Buffer;
+		Buffer.Add(0x81);
+		Buffer.Add(0x02); // mask bit clear
+		Buffer.Add('h');
+		Buffer.Add('i');
+		TestEqual(TEXT("an unmasked client frame is refused"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::ProtocolError);
+		TestEqual(TEXT("refused as a framing violation"), (int32)CloseCode, 1002);
+	}
+
+	// A reserved bit set means the peer is framing to rules that were never
+	// negotiated, so no boundary in the stream can be trusted.
+	{
+		TArray<uint8> Buffer = MakeClientFrame(0x1, TextPayload(TEXT("x")));
+		Buffer[0] |= 0x40; // RSV1
+		TestEqual(TEXT("a reserved bit is refused"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::ProtocolError);
+	}
+
+	// A 64-bit length must accumulate in 64 bits. Folding it into an int32 is
+	// what turns a hostile length into a negative count and a read off the end.
+	{
+		TArray<uint8> Buffer;
+		Buffer.Add(0x81);
+		Buffer.Add((uint8)(0x80 | 127));
+		Buffer.Add(0x80); // high bit set
+		for (int32 Index = 0; Index < 7; ++Index)
+		{
+			Buffer.Add(0x00);
+		}
+		for (int32 Index = 0; Index < 4; ++Index)
+		{
+			Buffer.Add(0x00); // mask key
+		}
+		TestEqual(TEXT("a 64-bit length with the high bit set is refused"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::ProtocolError);
+	}
+
+	// Too large is reported as too large (1009), never as broken framing, so a
+	// caller can tell "you sent more than I hold" from "your stream is corrupt".
+	{
+		const uint64 TooLarge = (uint64)FMCPBridgeServer::MaxMessageBytes() + 1;
+		TArray<uint8> Buffer;
+		Buffer.Add(0x81);
+		Buffer.Add((uint8)(0x80 | 127));
+		for (int32 Index = 7; Index >= 0; --Index)
+		{
+			Buffer.Add((uint8)((TooLarge >> (Index * 8)) & 0xFF));
+		}
+		for (int32 Index = 0; Index < 4; ++Index)
+		{
+			Buffer.Add(0x00); // mask key
+		}
+		TestEqual(TEXT("an oversized frame is refused"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::ProtocolError);
+		TestEqual(TEXT("refused as too big, not as bad framing"), (int32)CloseCode, 1009);
+	}
+
+	// Control frames carry at most 125 bytes and are never fragmented.
+	{
+		TArray<uint8> Payload;
+		Payload.SetNumZeroed(126);
+		TArray<uint8> Buffer = MakeClientFrame(0x9, Payload);
+		TestEqual(TEXT("an oversized control frame is refused"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::ProtocolError);
+	}
+	{
+		TArray<uint8> Buffer = MakeClientFrame(0x9, TextPayload(TEXT("x")), /*bFinal*/ false);
+		TestEqual(TEXT("a fragmented control frame is refused"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::ProtocolError);
+	}
+
+	// An opcode the bridge does not implement is a stream it cannot follow.
+	{
+		TArray<uint8> Buffer = MakeClientFrame(0x3, TextPayload(TEXT("x")));
+		TestEqual(TEXT("an unsupported opcode is refused"),
+			(int32)FMCPBridgeServer::DecodeWebSocketFrame(Buffer, Frame, Error, CloseCode), (int32)EMCPFrameDecode::ProtocolError);
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMCPBridgeOutboundFramingTest,
+	"UE.MCP.Bridge.Protocol.OutboundFraming",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMCPBridgeOutboundFramingTest::RunTest(const FString& Parameters)
+{
+	// Short: a one-byte length, no mask bit (a server never masks).
+	{
+		const TArray<uint8> Frame = FMCPBridgeServer::CreateWebSocketFrame(TEXT("hello"));
+		TestEqual(TEXT("FIN plus text opcode"), (int32)Frame[0], 0x81);
+		TestEqual(TEXT("length in the second byte, unmasked"), (int32)Frame[1], 5);
+		TestEqual(TEXT("header plus payload"), Frame.Num(), 7);
+	}
+
+	// 16-bit extended length.
+	{
+		const FString Message = FString::ChrN(1000, TEXT('a'));
+		const TArray<uint8> Frame = FMCPBridgeServer::CreateWebSocketFrame(Message);
+		TestEqual(TEXT("126 selects the 16-bit length"), (int32)Frame[1], 126);
+		const int32 Declared = ((int32)Frame[2] << 8) | (int32)Frame[3];
+		TestEqual(TEXT("declared length matches the payload"), Declared, 1000);
+		TestEqual(TEXT("frame size"), Frame.Num(), 4 + 1000);
+	}
+
+	// 64-bit extended length. #731: shifting an int32 by 32 or more is
+	// undefined, and the corrupt 8-byte length it produced made every response
+	// at or above 64 KiB unreadable, so the client closed the socket.
+	{
+		const int32 Length = 70000;
+		const FString Message = FString::ChrN(Length, TEXT('b'));
+		const TArray<uint8> Frame = FMCPBridgeServer::CreateWebSocketFrame(Message);
+		TestEqual(TEXT("127 selects the 64-bit length"), (int32)Frame[1], 127);
+
+		uint64 Declared = 0;
+		for (int32 Index = 0; Index < 8; ++Index)
+		{
+			Declared = (Declared << 8) | (uint64)Frame[2 + Index];
+		}
+		TestEqual(TEXT("declared length matches the payload"), (int64)Declared, (int64)Length);
+		TestEqual(TEXT("frame size"), Frame.Num(), 10 + Length);
+	}
+
+	// A close frame carries its status code in the first two payload bytes.
+	{
+		TArray<uint8> Payload;
+		Payload.Add(0x03);
+		Payload.Add(0xF1); // 1009
+		const TArray<uint8> Frame = FMCPBridgeServer::CreateControlFrame(EMCPWebSocketOpcode::Close, Payload);
+		TestEqual(TEXT("FIN plus close opcode"), (int32)Frame[0], 0x88);
+		TestEqual(TEXT("payload length"), (int32)Frame[1], 2);
+		const int32 Code = ((int32)Frame[2] << 8) | (int32)Frame[3];
+		TestEqual(TEXT("status code survives framing"), Code, 1009);
+	}
+
+	return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 0.2 Port derivation, the half of socket exclusivity that is not a syscall
+// ─────────────────────────────────────────────────────────────────────────────
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMCPBridgeDerivedPortTest,
+	"UE.MCP.Bridge.Protocol.DerivedPort",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMCPBridgeDerivedPortTest::RunTest(const FString& Parameters)
+{
+	// The client derives the same number from the same path (src/port.ts). If
+	// these two drift, a project with no lockfile has its halves on different
+	// ports and the failure looks like "no editor is running".
+	const FString Path = TEXT("C:/Users/example/Projects/Demo/");
+	const int32 First = FMCPBridgeServer::DeriveProjectPort(Path);
+
+	TestTrue(TEXT("derived port is inside the ephemeral range"), First >= 49152 && First <= 65535);
+	TestEqual(TEXT("derivation is deterministic"), FMCPBridgeServer::DeriveProjectPort(Path), First);
+
+	// Normalization is what makes the two sides agree despite separators,
+	// trailing slashes and drive-letter casing.
+	TestEqual(TEXT("backslashes normalize"),
+		FMCPBridgeServer::DeriveProjectPort(TEXT("C:\\Users\\example\\Projects\\Demo\\")), First);
+	TestEqual(TEXT("a missing trailing slash normalizes"),
+		FMCPBridgeServer::DeriveProjectPort(TEXT("C:/Users/example/Projects/Demo")), First);
+	TestEqual(TEXT("case normalizes"),
+		FMCPBridgeServer::DeriveProjectPort(TEXT("c:/users/example/projects/demo")), First);
+
+	// Different worktrees have to land on different ports, which is the whole
+	// reason the port is derived rather than fixed.
+	TestTrue(TEXT("a different project derives a different port"),
+		FMCPBridgeServer::DeriveProjectPort(TEXT("C:/Users/example/Projects/Other")) != First);
+
+	TestEqual(TEXT("the shared normalizer agrees"),
+		FMCPBridgeStateFiles::NormalizeProjectRoot(TEXT("C:\\Users\\Example\\Demo\\")),
+		FString(TEXT("c:/users/example/demo")));
+
+	return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 0.3 Instance records
+// ─────────────────────────────────────────────────────────────────────────────
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMCPBridgeInstanceRecordTest,
+	"UE.MCP.Bridge.Protocol.InstanceRecords",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMCPBridgeInstanceRecordTest::RunTest(const FString& Parameters)
+{
+	const FString Dir = MakeScratchDir(TEXT("instances"));
+
+	// Round-trip. Every field a client needs to tell one editor from another
+	// has to survive the write.
+	const FMCPInstanceRecord Written = MakeRecord(4242, 49500, TEXT("listening"));
+	TestTrue(TEXT("a record is written"), FMCPBridgeStateFiles::WriteInstanceRecord(Dir, Written));
+
+	FMCPInstanceRecord ReadBack;
+	TestTrue(TEXT("a record is read back"),
+		FMCPBridgeStateFiles::ReadInstanceRecord(FMCPBridgeStateFiles::RecordPath(Dir, 4242), ReadBack));
+	TestEqual(TEXT("port survives"), ReadBack.Port, Written.Port);
+	TestEqual(TEXT("pid survives"), (int32)ReadBack.Pid, (int32)Written.Pid);
+	TestEqual(TEXT("instance id survives"), ReadBack.InstanceId, Written.InstanceId);
+	TestEqual(TEXT("project root survives"), ReadBack.ProjectRoot, Written.ProjectRoot);
+	TestEqual(TEXT("engine version survives"), ReadBack.EngineVersion, Written.EngineVersion);
+	TestEqual(TEXT("state survives"), ReadBack.State, Written.State);
+	TestEqual(TEXT("protocol version survives"), ReadBack.ProtocolVersion, (int32)UEMCP_BRIDGE_PROTOCOL_VERSION);
+
+	// Two editors of one project write two files, so neither can lose to the
+	// other. This is the whole point of the per-pid name.
+	const FMCPInstanceRecord Second = MakeRecord(4243, 49501, TEXT("listening"));
+	FMCPBridgeStateFiles::WriteInstanceRecord(Dir, Second);
+	TestTrue(TEXT("the first record still exists after the second is written"),
+		FPaths::FileExists(FMCPBridgeStateFiles::RecordPath(Dir, 4242)));
+	TestTrue(TEXT("the second record exists"),
+		FPaths::FileExists(FMCPBridgeStateFiles::RecordPath(Dir, 4243)));
+
+	// A process removes its own record and nobody else's. A recycled pid that
+	// took the other file away would drop a live editor off the map.
+	FMCPBridgeStateFiles::DeleteOwnInstanceRecord(Dir, 4243, TEXT("some-other-instance-id"));
+	TestTrue(TEXT("a record with someone else's instance id is left alone"),
+		FPaths::FileExists(FMCPBridgeStateFiles::RecordPath(Dir, 4243)));
+
+	FMCPBridgeStateFiles::DeleteOwnInstanceRecord(Dir, 4243, Second.InstanceId);
+	TestFalse(TEXT("a record with a matching instance id is removed"),
+		FPaths::FileExists(FMCPBridgeStateFiles::RecordPath(Dir, 4243)));
+
+	// A bind-failure record exists to outlive the process that wrote it. Exit
+	// runs on the bind-failure path, so an unconditional delete there erased
+	// the only explanation for an editor with no bridge.
+	const FMCPInstanceRecord Failed = MakeRecord(4244, 0, TEXT("bind-failed"));
+	FMCPBridgeStateFiles::WriteInstanceRecord(Dir, Failed);
+	FMCPBridgeStateFiles::DeleteOwnInstanceRecord(Dir, 4244, Failed.InstanceId);
+	TestTrue(TEXT("a bind-failed record survives its own writer's exit"),
+		FPaths::FileExists(FMCPBridgeStateFiles::RecordPath(Dir, 4244)));
+
+	RemoveScratchDir(Dir);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMCPBridgeInstanceReapTest,
+	"UE.MCP.Bridge.Protocol.InstanceRecordReaping",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMCPBridgeInstanceReapTest::RunTest(const FString& Parameters)
+{
+	const FString Dir = MakeScratchDir(TEXT("reap"));
+
+	const FMCPInstanceRecord Mine = MakeRecord(5001, 49600, TEXT("listening"));
+	const FMCPInstanceRecord Live = MakeRecord(5002, 49601, TEXT("listening"));
+	const FMCPInstanceRecord Dead = MakeRecord(5003, 49602, TEXT("listening"));
+	const FMCPInstanceRecord Written[] = { Mine, Live, Dead };
+	for (const FMCPInstanceRecord& Record : Written)
+	{
+		FMCPBridgeStateFiles::WriteInstanceRecord(Dir, Record);
+	}
+
+	// Liveness is injected so the sweep is testable without standing up a
+	// listener. The real predicate is asserted separately below.
+	const FString DeadInstanceId = Dead.InstanceId;
+	const int32 Removed = FMCPBridgeStateFiles::ReapStaleInstanceRecords(Dir, Mine.InstanceId,
+		[&DeadInstanceId](const FMCPInstanceRecord& Record) { return Record.InstanceId != DeadInstanceId; });
+
+	TestEqual(TEXT("exactly the dead record is removed"), Removed, 1);
+	TestTrue(TEXT("this instance's own record is never swept"),
+		FPaths::FileExists(FMCPBridgeStateFiles::RecordPath(Dir, 5001)));
+	TestTrue(TEXT("a live instance's record is kept"),
+		FPaths::FileExists(FMCPBridgeStateFiles::RecordPath(Dir, 5002)));
+	TestFalse(TEXT("a dead instance's record is gone"),
+		FPaths::FileExists(FMCPBridgeStateFiles::RecordPath(Dir, 5003)));
+
+	// Something that is not a record this bridge wrote is left where it is.
+	// Proof runs one way: an unreadable file has no owner to check against.
+	const FString Foreign = FPaths::Combine(Dir, TEXT("notes.json"));
+	FFileHelper::SaveStringToFile(TEXT("{\"unrelated\":true}"), *Foreign);
+	FMCPBridgeStateFiles::ReapStaleInstanceRecords(Dir, Mine.InstanceId,
+		[](const FMCPInstanceRecord&) { return false; });
+	TestTrue(TEXT("a file that is not an instance record is left alone"), FPaths::FileExists(Foreign));
+
+	// The real predicate: a pid that cannot be running is not live.
+	FMCPInstanceRecord Impossible = MakeRecord(0, 49603, TEXT("listening"));
+	TestFalse(TEXT("a record naming no process is not live"), FMCPBridgeStateFiles::IsInstanceLive(Impossible));
+
+	// This process is running and nothing is listening on a port it never
+	// bound, so pid liveness alone must not be enough to call a record live.
+	FMCPInstanceRecord RecycledPid = MakeRecord(FPlatformProcess::GetCurrentProcessId(), 1, TEXT("listening"));
+	TestFalse(TEXT("a live pid with nothing on its port is not live"),
+		FMCPBridgeStateFiles::IsInstanceLive(RecycledPid));
+
+	// A bind-failed record claims no port, so the process being alive is the
+	// whole of what it claims and the whole of what can be checked.
+	FMCPInstanceRecord FailedHere = MakeRecord(FPlatformProcess::GetCurrentProcessId(), 0, TEXT("bind-failed"));
+	TestTrue(TEXT("a bind-failed record of a running process is live"),
+		FMCPBridgeStateFiles::IsInstanceLive(FailedHere));
+
+	RemoveScratchDir(Dir);
+	return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 0.4 / 0.5 Off-thread identity and the capability list
+// ─────────────────────────────────────────────────────────────────────────────
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMCPBridgeCapabilitiesTest,
+	"UE.MCP.Bridge.Protocol.Capabilities",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMCPBridgeCapabilitiesTest::RunTest(const FString& Parameters)
+{
+	// Constructed, never started: registering handlers touches no socket and
+	// writes no file, and the payload is built from values snapshotted at
+	// construction, which is exactly why it can be answered off the game thread.
+	FMCPBridgeServer Server(49700, TEXT("automation test"), /*bPinned*/ false);
+
+	const TSharedPtr<FJsonObject> Payload = Server.BuildCapabilitiesPayload();
+	TestTrue(TEXT("a payload is produced"), Payload.IsValid());
+	if (!Payload.IsValid())
+	{
+		return false;
+	}
+
+	TestTrue(TEXT("the answer says it needed no game thread"), Payload->GetBoolField(TEXT("servedWithoutGameThread")));
+
+	double Version = 0.0;
+	TestTrue(TEXT("the protocol version is reported"), Payload->TryGetNumberField(TEXT("protocolVersion"), Version));
+	TestEqual(TEXT("and it is the compiled-in one, not a literal"), (int32)Version, (int32)UEMCP_BRIDGE_PROTOCOL_VERSION);
+	TestTrue(TEXT("the handler ABI version is reported"), Payload->TryGetNumberField(TEXT("handlerApiVersion"), Version));
+	TestEqual(TEXT("and it is the compiled-in one"), (int32)Version, (int32)UEMCP_BRIDGE_API_VERSION);
+
+	// The stale-DLL tell: a header constant cannot say whether the binary was
+	// built from the source on disk, and a compile timestamp can.
+	FString BuiltAt;
+	TestTrue(TEXT("a compile timestamp is reported"), Payload->TryGetStringField(TEXT("builtAt"), BuiltAt));
+	TestTrue(TEXT("the compile timestamp is not empty"), !BuiltAt.IsEmpty());
+
+	FString InstanceId;
+	TestTrue(TEXT("the instance identifies itself"), Payload->TryGetStringField(TEXT("instanceId"), InstanceId));
+	FGuid ParsedInstanceId;
+	TestTrue(TEXT("the instance id is a guid, so a recycled pid cannot impersonate it"),
+		FGuid::Parse(InstanceId, ParsedInstanceId));
+
+	const TArray<TSharedPtr<FJsonValue>>* Features = nullptr;
+	TestTrue(TEXT("named capabilities are reported"), Payload->TryGetArrayField(TEXT("features"), Features));
+	if (Features)
+	{
+		TSet<FString> Named;
+		for (const TSharedPtr<FJsonValue>& Value : *Features)
+		{
+			Named.Add(Value->AsString());
+		}
+		// Named rather than "version N or above", so a client can ask about the
+		// one thing it needs.
+		TestTrue(TEXT("frame reassembly is advertised"), Named.Contains(TEXT("frame-reassembly")));
+		TestTrue(TEXT("control frames are advertised"), Named.Contains(TEXT("control-frames")));
+		TestTrue(TEXT("the handshake advertises itself"), Named.Contains(TEXT("capability-handshake")));
+		TestTrue(TEXT("instance records are advertised"), Named.Contains(TEXT("instance-records")));
+		TestTrue(TEXT("the requested-port file is advertised"), Named.Contains(TEXT("requested-port-file")));
+		TestTrue(TEXT("the parameter echo is advertised"), Named.Contains(TEXT("param-echo")));
+	}
+
+	// The action list from the running binary is the only answer to "does the
+	// plugin I reached have this method" that a stale DLL cannot fake.
+	double ActionCount = 0.0;
+	TestTrue(TEXT("the registered action count is reported"), Payload->TryGetNumberField(TEXT("actionCount"), ActionCount));
+	TestTrue(TEXT("the binary registered some actions"), ActionCount > 0);
+
+	// Advertised whether or not it is recording, so a caller can tell a bridge
+	// that cannot from a bridge that is switched off.
+	bool bEcho = true;
+	TestTrue(TEXT("the echo's runtime state is reported"), Payload->TryGetBoolField(TEXT("paramEcho"), bEcho));
+
+	return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 0.7 The requested-port channel
+// ─────────────────────────────────────────────────────────────────────────────
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMCPBridgeRequestedPortTest,
+	"UE.MCP.Bridge.Protocol.RequestedPort",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMCPBridgeRequestedPortTest::RunTest(const FString& Parameters)
+{
+	const FString Dir = MakeScratchDir(TEXT("requested"));
+	const FString File = FPaths::Combine(Dir, TEXT("requested.json"));
+	const FString Root = TEXT("c:/projects/example");
+
+	auto Write = [&File](const FString& Body)
+	{
+		FFileHelper::SaveStringToFile(Body, *File);
+	};
+
+	FString Detail;
+
+	// Absent is silent. An install that never pinned a port has to resolve
+	// byte-identically to how it did before this channel existed, log lines
+	// included, so there is nothing to say here.
+	TestEqual(TEXT("an absent file yields no port"),
+		FMCPBridgeStateFiles::ReadRequestedPort(FPaths::Combine(Dir, TEXT("nothing.json")), Root, Detail), (int32)INDEX_NONE);
+	TestTrue(TEXT("and says nothing about it"), Detail.IsEmpty());
+
+	// Present and valid.
+	Write(FString::Printf(TEXT("{\"port\":51234,\"projectRoot\":\"%s\",\"source\":\"config\"}"), *Root));
+	TestEqual(TEXT("a matching record yields its port"),
+		FMCPBridgeStateFiles::ReadRequestedPort(File, Root, Detail), 51234);
+	TestTrue(TEXT("a usable record needs no explanation"), Detail.IsEmpty());
+
+	// The root is compared normalized, because the client writes what it has
+	// and the two sides spell paths differently.
+	Write(TEXT("{\"port\":51234,\"projectRoot\":\"C:\\\\Projects\\\\Example\\\\\"}"));
+	TestEqual(TEXT("separators and case do not defeat the root check"),
+		FMCPBridgeStateFiles::ReadRequestedPort(File, Root, Detail), 51234);
+
+	// Present and unusable is said out loud. A pin that silently does not take
+	// is the failure this channel exists to remove, so every refusal is named.
+	Write(FString::Printf(TEXT("{\"port\":70000,\"projectRoot\":\"%s\"}"), *Root));
+	TestEqual(TEXT("an out-of-range port is refused"),
+		FMCPBridgeStateFiles::ReadRequestedPort(File, Root, Detail), (int32)INDEX_NONE);
+	TestTrue(TEXT("and the refusal is explained"), !Detail.IsEmpty());
+
+	Write(TEXT("{\"port\":51234,\"projectRoot\":\"c:/projects/somewhere-else\"}"));
+	TestEqual(TEXT("a record written for another project is refused"),
+		FMCPBridgeStateFiles::ReadRequestedPort(File, Root, Detail), (int32)INDEX_NONE);
+	TestTrue(TEXT("and the refusal is explained"), !Detail.IsEmpty());
+
+	Write(TEXT("{\"port\":51234}"));
+	TestEqual(TEXT("a record naming no project is refused"),
+		FMCPBridgeStateFiles::ReadRequestedPort(File, Root, Detail), (int32)INDEX_NONE);
+	TestTrue(TEXT("and the refusal is explained"), !Detail.IsEmpty());
+
+	Write(FString::Printf(TEXT("{\"projectRoot\":\"%s\"}"), *Root));
+	TestEqual(TEXT("a record with no port is refused"),
+		FMCPBridgeStateFiles::ReadRequestedPort(File, Root, Detail), (int32)INDEX_NONE);
+	TestTrue(TEXT("and the refusal is explained"), !Detail.IsEmpty());
+
+	Write(TEXT("this is not json"));
+	TestEqual(TEXT("an unparseable record is refused"),
+		FMCPBridgeStateFiles::ReadRequestedPort(File, Root, Detail), (int32)INDEX_NONE);
+	TestTrue(TEXT("and the refusal is explained"), !Detail.IsEmpty());
+
+	RemoveScratchDir(Dir);
+	return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 0.8 The parameter echo, which is what 3.3 asserts against
+// ─────────────────────────────────────────────────────────────────────────────
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMCPBridgeParamEchoTest,
+	"UE.MCP.Bridge.Protocol.ParamEcho",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMCPBridgeParamEchoTest::RunTest(const FString& Parameters)
+{
+	// A local recorder, not FMCPParamEcho::Get(). The singleton is what the
+	// dispatch path writes to, and a bridge serving a client while this test
+	// runs would append its own dispatches to whatever the test had recorded.
+	// The assertions here are about the recorder's behaviour, not about which
+	// object ProcessMessage reaches for.
+	FMCPParamEcho Echo;
+
+	auto MakeParams = [](const TArray<FString>& Names)
+	{
+		TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
+		for (const FString& Name : Names)
+		{
+			Params->SetStringField(Name, TEXT("value"));
+		}
+		return Params;
+	};
+
+	// Off by default, and off means nothing is retained. A test facility that
+	// recorded while switched off would be a facility that leaks.
+	Echo.SetEnabled(false);
+	Echo.Record(TEXT("create_blueprint"), MakeParams({ TEXT("path"), TEXT("editor") }));
+	TestEqual(TEXT("nothing is recorded while the echo is off"), Echo.Snapshot().Num(), 0);
+
+	Echo.SetEnabled(true);
+	Echo.Clear();
+
+	// The oracle: which keys arrived, sorted so the assertion does not depend
+	// on JSON field order.
+	Echo.Record(TEXT("create_blueprint"), MakeParams({ TEXT("parentClass"), TEXT("assetPath") }));
+	TArray<FMCPParamEchoEntry> Entries = Echo.Snapshot();
+	TestEqual(TEXT("one dispatch, one entry"), Entries.Num(), 1);
+	if (Entries.Num() == 1)
+	{
+		TestEqual(TEXT("the method is recorded"), Entries[0].Method, FString(TEXT("create_blueprint")));
+		TestEqual(TEXT("both parameter names are recorded"), Entries[0].ParamNames.Num(), 2);
+		TestEqual(TEXT("names come back sorted"), Entries[0].ParamNames[0], FString(TEXT("assetPath")));
+		TestEqual(TEXT("names come back sorted"), Entries[0].ParamNames[1], FString(TEXT("parentClass")));
+	}
+
+	// This is the assertion 3.3 makes: a routing key that reached the bridge is
+	// visible, and one that was consumed on the client is not.
+	Echo.Clear();
+	Echo.Record(TEXT("create_blueprint"), MakeParams({ TEXT("assetPath"), TEXT("editor") }));
+	Entries = Echo.Snapshot();
+	TestTrue(TEXT("a leaked routing parameter is visible"),
+		Entries.Num() == 1 && Entries[0].ParamNames.Contains(TEXT("editor")));
+
+	Echo.Clear();
+	Echo.Record(TEXT("create_blueprint"), MakeParams({ TEXT("assetPath") }));
+	Entries = Echo.Snapshot();
+	TestTrue(TEXT("a consumed routing parameter is absent"),
+		Entries.Num() == 1 && !Entries[0].ParamNames.Contains(TEXT("editor")));
+
+	// A call with no parameters is still a call. Recording it is what lets a
+	// test tell "nothing was forwarded" from "nothing was dispatched".
+	Echo.Clear();
+	Echo.Record(TEXT("get_status"), MakeShared<FJsonObject>());
+	Entries = Echo.Snapshot();
+	TestEqual(TEXT("a parameterless dispatch is still recorded"), Entries.Num(), 1);
+	TestEqual(TEXT("with no names"), Entries.Num() == 1 ? Entries[0].ParamNames.Num() : -1, 0);
+
+	// Bounded. A long session must not turn this into an unbounded buffer.
+	Echo.Clear();
+	for (int32 Index = 0; Index < FMCPParamEcho::MaxEntries + 20; ++Index)
+	{
+		Echo.Record(FString::Printf(TEXT("method_%d"), Index), MakeShared<FJsonObject>());
+	}
+	Entries = Echo.Snapshot();
+	TestEqual(TEXT("the log is bounded"), Entries.Num(), FMCPParamEcho::MaxEntries);
+	TestEqual(TEXT("the oldest entries are the ones dropped"),
+		Entries.Num() > 0 ? Entries[0].Method : FString(),
+		FString::Printf(TEXT("method_%d"), 20));
+
+	// The payload is what the wire carries.
+	const TSharedPtr<FJsonObject> Payload = Echo.BuildPayload();
+	TestTrue(TEXT("the payload reports the echo is on"), Payload->GetBoolField(TEXT("enabled")));
+	TestTrue(TEXT("the payload needs no game thread"), Payload->GetBoolField(TEXT("servedWithoutGameThread")));
+	const TArray<TSharedPtr<FJsonValue>>* PayloadEntries = nullptr;
+	TestTrue(TEXT("the payload carries the entries"), Payload->TryGetArrayField(TEXT("entries"), PayloadEntries));
+	TestEqual(TEXT("all of them"), PayloadEntries ? PayloadEntries->Num() : -1, FMCPParamEcho::MaxEntries);
+
+	// Switching off empties it, so a facility left on by accident stops holding
+	// anything the moment it is turned off.
+	Echo.SetEnabled(false);
+	TestEqual(TEXT("turning the echo off discards what it held"), Echo.Snapshot().Num(), 0);
+	TestFalse(TEXT("and the payload says so"), Echo.BuildPayload()->GetBoolField(TEXT("enabled")));
+
+	// The process-wide recorder is construction-gated and must not be on unless
+	// this editor was started with it asked for.
+	TestTrue(TEXT("the process recorder matches what was asked for at startup"),
+		FMCPParamEcho::Get().IsEnabled() == FMCPParamEcho::ResolveEnabledFromEnvironment());
+
+	return true;
+}
+
+#endif

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
@@ -8,6 +8,7 @@ public class UE_MCP_Bridge : ModuleRules
 	// new .cpp until this file changes.
 	// Private/Handlers/AssetHandlers_BulkUpsert.cpp: UBT caches the module's
 	// file list and will not pick up a new .cpp until this file changes.
+	// Private/BridgeStateFiles.cpp: same reason.
 	public UE_MCP_Bridge(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
@@ -8,7 +8,8 @@ public class UE_MCP_Bridge : ModuleRules
 	// new .cpp until this file changes.
 	// Private/Handlers/AssetHandlers_BulkUpsert.cpp: UBT caches the module's
 	// file list and will not pick up a new .cpp until this file changes.
-	// Private/BridgeStateFiles.cpp and Private/BridgeParamEcho.cpp: same reason.
+	// Private/BridgeStateFiles.cpp, Private/BridgeParamEcho.cpp and
+	// Private/Tests/BridgeProtocolTests.cpp: same reason.
 	public UE_MCP_Bridge(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
@@ -8,7 +8,7 @@ public class UE_MCP_Bridge : ModuleRules
 	// new .cpp until this file changes.
 	// Private/Handlers/AssetHandlers_BulkUpsert.cpp: UBT caches the module's
 	// file list and will not pick up a new .cpp until this file changes.
-	// Private/BridgeStateFiles.cpp: same reason.
+	// Private/BridgeStateFiles.cpp and Private/BridgeParamEcho.cpp: same reason.
 	public UE_MCP_Bridge(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -6,6 +6,7 @@ import { McpError, ErrorCode } from "./errors.js";
 import { debug, warn } from "./log.js";
 import { DEFAULT_BRIDGE_PORT, deriveProjectPort } from "./port.js";
 import { isPidAlive } from "./editor-target.js";
+import { syncRequestedPort } from "./requested-port.js";
 
 /**
  * The wire protocol this client speaks. Must match
@@ -336,6 +337,12 @@ export class EditorBridge implements IBridge {
       this.portSource = "derived";
       debug("bridge", `derived per-project bridge port ${this.port} from ${path.dirname(uprojectPath)}`);
     }
+    // #817: hand the pin to the editor. An editor launched from Explorer
+    // cannot see UE_MCP_PORT or the config merge that produced this number, so
+    // without this file a pinned project has its two halves on different ports.
+    if (uprojectPath) {
+      syncRequestedPort(path.dirname(uprojectPath), this.port, this.portSource);
+    }
   }
 
   /**
@@ -372,6 +379,13 @@ export class EditorBridge implements IBridge {
     } else {
       this.port = deriveProjectPort(path.dirname(resolved));
       this.portSource = "derived";
+    }
+
+    // #817: publish the new target's pin, and only its own. An unverified pin
+    // was chosen for the project we just left, so writing it into this one
+    // would ask this editor to bind a number that says nothing about it.
+    if (!this.unverifiedPin) {
+      syncRequestedPort(path.dirname(resolved), this.port, this.portSource);
     }
 
     debug(

--- a/src/requested-port.ts
+++ b/src/requested-port.ts
@@ -1,0 +1,118 @@
+/**
+ * The port channel that runs client to editor.
+ *
+ * Every other file under `Saved/UE_MCP_Bridge/` is written by the plugin and
+ * read here. This one is the reverse, and it exists because the two sides
+ * resolve the port pin from different amounts of information.
+ *
+ * The client merges four config layers and then the environment on top of them.
+ * An editor launched from Explorer sees none of that: no `UE_MCP_PORT` in its
+ * environment, and no way to reproduce the merge. So the users who had gone out
+ * of their way to pin a port were exactly the users whose client and editor
+ * ended up on different ones.
+ *
+ * The file carries an integer, never a policy. The client does the resolving
+ * and publishes the answer; the bridge reads it and binds it
+ * (FMCPBridgeStateFiles::ReadRequestedPort).
+ *
+ * It exists only while a pin exists. Removing the pin removes the file, so an
+ * unpinned project has nothing here and the bridge resolves its port exactly as
+ * it did before this channel was added.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { debug } from "./log.js";
+import { normalizeProjectRoot } from "./port.js";
+
+/** Where the client publishes the pin, for one project root. */
+export function requestedPortPath(projectDir: string): string {
+  return path.join(projectDir, "Saved", "UE_MCP_Bridge", "requested.json");
+}
+
+export interface RequestedPortRecord {
+  port: number;
+  /** Normalized, so the bridge can compare it without re-normalizing. */
+  projectRoot: string;
+  /** Which layer the pin came from, for a human reading the file. */
+  source: string;
+  writtenBy: number;
+  writtenAt: string;
+}
+
+/**
+ * Publish the pin for `projectDir`.
+ *
+ * Written temp-and-rename for the same reason the bridge writes its records
+ * that way: the reader is a separate process that can arrive at any moment, and
+ * a rename is the one step it cannot catch halfway through.
+ *
+ * Failure is not raised. A project directory that is read-only, or on a share
+ * that refuses the rename, still has every port path that worked before this
+ * one; losing the optimisation is not worth losing the connection.
+ */
+export function publishRequestedPort(projectDir: string, port: number, source: string): void {
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return;
+
+  const file = requestedPortPath(projectDir);
+  const record: RequestedPortRecord = {
+    port,
+    projectRoot: normalizeProjectRoot(projectDir),
+    source,
+    writtenBy: process.pid,
+    writtenAt: new Date().toISOString(),
+  };
+
+  const temp = `${file}.${process.pid}.tmp`;
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(temp, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+    fs.renameSync(temp, file);
+    debug("bridge", `published requested port ${port} (${source}) to ${file}`);
+  } catch (err) {
+    try {
+      fs.unlinkSync(temp);
+    } catch {
+      // The temp file never existed, which is the common case here.
+    }
+    debug("bridge", `could not publish requested port to ${file}: ${(err as Error).message}`);
+  }
+}
+
+/**
+ * Remove the pin for `projectDir`.
+ *
+ * Called whenever the resolved port is not a pin, so a user who deletes
+ * `bridge.port` from their config does not leave the editor bound to it
+ * forever. A missing file is the expected case and is not an error.
+ */
+export function clearRequestedPort(projectDir: string): void {
+  const file = requestedPortPath(projectDir);
+  try {
+    fs.rmSync(file, { force: true });
+  } catch (err) {
+    debug("bridge", `could not remove ${file}: ${(err as Error).message}`);
+  }
+}
+
+/**
+ * Publish or clear in one step, from the port the client resolved and where it
+ * came from.
+ *
+ * Only the three sources that are pins are published. `derived` is the hash of
+ * the project root, which the bridge computes identically on its own, and
+ * `lockfile` is the port an editor already bound, which is an observation
+ * rather than a request. Publishing either would turn a value the bridge
+ * derives into one it is told, for no gain and one more thing to go stale.
+ */
+export function syncRequestedPort(
+  projectDir: string,
+  port: number,
+  source: "lockfile" | "config" | "derived" | "explicit" | "env" | "default",
+): void {
+  if (source === "explicit" || source === "env" || source === "config") {
+    publishRequestedPort(projectDir, port, source);
+    return;
+  }
+  clearRequestedPort(projectDir);
+}

--- a/tests/unit/requested-port.test.ts
+++ b/tests/unit/requested-port.test.ts
@@ -1,0 +1,110 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { normalizeProjectRoot } from "../../src/port.js";
+import {
+  clearRequestedPort,
+  publishRequestedPort,
+  requestedPortPath,
+  syncRequestedPort,
+} from "../../src/requested-port.js";
+
+const temporaryRoots: string[] = [];
+
+function makeProjectDir(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-requested-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function readRecord(projectDir: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(fs.readFileSync(requestedPortPath(projectDir), "utf8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+afterEach(() => {
+  while (temporaryRoots.length > 0) {
+    const root = temporaryRoots.pop()!;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("requested port channel (#817)", () => {
+  it("publishes the pin where the bridge looks for it", () => {
+    const projectDir = makeProjectDir();
+    publishRequestedPort(projectDir, 51234, "config");
+
+    expect(requestedPortPath(projectDir)).toBe(
+      path.join(projectDir, "Saved", "UE_MCP_Bridge", "requested.json"),
+    );
+
+    const record = readRecord(projectDir);
+    expect(record?.port).toBe(51234);
+    expect(record?.source).toBe("config");
+    expect(record?.writtenBy).toBe(process.pid);
+  });
+
+  it("normalizes the project root the way the bridge compares it", () => {
+    const projectDir = makeProjectDir();
+    publishRequestedPort(projectDir, 51234, "config");
+
+    // The bridge refuses a record whose root is not this project's, so the two
+    // sides have to spell the same directory the same way.
+    expect(readRecord(projectDir)?.projectRoot).toBe(normalizeProjectRoot(projectDir));
+  });
+
+  it("refuses to publish a port outside the usable range", () => {
+    const projectDir = makeProjectDir();
+    publishRequestedPort(projectDir, 0, "config");
+    publishRequestedPort(projectDir, 70000, "config");
+    expect(readRecord(projectDir)).toBeNull();
+  });
+
+  it("leaves no file behind when the port is not a pin", () => {
+    const projectDir = makeProjectDir();
+    syncRequestedPort(projectDir, 51234, "derived");
+    expect(readRecord(projectDir)).toBeNull();
+
+    syncRequestedPort(projectDir, 51234, "lockfile");
+    expect(readRecord(projectDir)).toBeNull();
+
+    syncRequestedPort(projectDir, 51234, "default");
+    expect(readRecord(projectDir)).toBeNull();
+  });
+
+  it("publishes each of the three pin sources", () => {
+    for (const source of ["explicit", "env", "config"] as const) {
+      const projectDir = makeProjectDir();
+      syncRequestedPort(projectDir, 51234, source);
+      expect(readRecord(projectDir)?.source).toBe(source);
+    }
+  });
+
+  it("removes the file when the pin goes away", () => {
+    const projectDir = makeProjectDir();
+    syncRequestedPort(projectDir, 51234, "config");
+    expect(readRecord(projectDir)?.port).toBe(51234);
+
+    // A user who deletes bridge.port from their config must not leave the
+    // editor bound to it for the rest of time.
+    syncRequestedPort(projectDir, 49152, "derived");
+    expect(fs.existsSync(requestedPortPath(projectDir))).toBe(false);
+  });
+
+  it("treats an already absent file as nothing to do", () => {
+    const projectDir = makeProjectDir();
+    expect(() => clearRequestedPort(projectDir)).not.toThrow();
+  });
+
+  it("leaves no temporary file behind after a publish", () => {
+    const projectDir = makeProjectDir();
+    publishRequestedPort(projectDir, 51234, "env");
+
+    const stateDir = path.join(projectDir, "Saved", "UE_MCP_Bridge");
+    expect(fs.readdirSync(stateDir)).toEqual(["requested.json"]);
+  });
+});


### PR DESCRIPTION
Closes the C++ bridge remainder of #817 Phase 0: items 0.3, 0.7, 0.8 and 0.9. 0.1 was already done and is left alone.

## 0.1 was already shipped

The reopening comment listed inbound frame reassembly as outstanding. It is not. PR #852 landed it and the code on `main` does all four things 0.1 asks for:

| 0.1 requirement | Where it is on `main` |
|---|---|
| per-connection accumulation buffer | `BridgeServer.cpp:1777` (`PendingBytes`), fed at `:1956`, bounded at `:1961` |
| decode loop that drains the buffer | `BridgeServer.cpp:1796-1923`, `Buffer.RemoveAt` at `:2163` |
| continuation frames | `BridgeServer.cpp:1858-1880` |
| opcode dispatch, close answered with close | `BridgeServer.cpp:1821-1856` |
| 64-bit length that does not fold into int32 | `BridgeServer.cpp:2097-2110` |
| the 64 MiB bound | `BridgeServer.cpp:84` |

Nothing here rewrites it. The new spec module asserts it instead, so the next audit reads a test rather than the source.

## 0.3 Instance records

`port.json` names one bridge for a whole project directory. That is the right answer for one editor and no answer at all for two: the second editor to boot published its address over the first one's, and every client reading the file was silently re-aimed at the newcomer.

Each process now writes `Saved/UE_MCP_Bridge/instances/<pid>.json` with its port, project root, start time, instance id, engine version, protocol and handler ABI versions, and state. One writer per file by construction.

- The bind-failure path writes one too, so a failed start is recorded where a successful one is, in a file a second editor's failure cannot overwrite.
- `Exit()` removes only this instance's own record, and never a `bind-failed` one. That record exists to outlive the process that wrote it.
- Startup sweeps records whose process is gone. Proof runs one way only, so an ambiguous record is kept: deleting a live editor's record is a connectivity outage, keeping a dead one costs a few hundred bytes.
- `port.json`'s write becomes owner-checked the way its delete already was. A bridge that finds a live owner leaves the file alone and logs where its own address is. An old client still reads `port.json` and still reaches an editor.

## 0.7 The requested-port channel

The port pin is resolved on the client: four config layers merged, then environment on top. An editor launched from Explorer sees none of that, so the users who pinned a port were exactly the users whose two halves ended up on different ones.

- Bridge: `ResolveConfiguredPort` reads `Saved/UE_MCP_Bridge/requested.json` between the environment override and its own config read. A project root that does not match is refused and named, which stops a copied `Saved` directory from aiming two checkouts at one port.
- Client (`src/requested-port.ts`): publishes the resolved port when the source is `explicit`, `env` or `config`, and removes the file otherwise. A derived port is a hash the bridge computes itself and a lockfile port is an observation, so neither is published.
- `-MCPPort=` and `UE_MCP_PORT` still win. An unpinned install finds no file, logs nothing, and resolves byte-identically to before.

The client half is deliberately minimal, since the TypeScript remainder of #817 is being done in parallel. It is one new module plus two call sites in `EditorBridge`, and it is expected to rebase.

## 0.8 The param echo

Handlers read the fields they know about and ignore the rest, so a parameter the client leaked into a call is invisible: the call succeeds, the result is correct, and nothing reports that a routing key travelled to the editor. Criterion 3.3 asserts that no dispatch path forwards `editor` or `toEditor`, and it had nothing to assert against.

The bridge now remembers the parameter **names** of its last 256 dispatches and serves them from `get_param_echo`, with `clear_param_echo` to reset. Both answer off the game thread.

- Names only, never values.
- Off unless `-MCPParamEcho` or `UE_MCP_PARAM_ECHO` asked for it at startup. No way to enable it over the socket.
- The methods and the `param-echo` feature are always advertised, and the handshake reports whether recording is on, so a caller can tell "this bridge cannot" from "this bridge can and it is off". Only the first is grounds for skipping a test.

## 0.9 The spec module

`Private/Tests/BridgeProtocolTests.cpp`, eight specs under `UE.MCP.Bridge.Protocol`: FrameReassembly, FrameRefusals, OutboundFraming, DerivedPort, InstanceRecords, InstanceRecordReaping, Capabilities, ParamEcho.

Nothing binds a port and nothing writes into the project's live `Saved/UE_MCP_Bridge` directory. The echo spec drives its own recorder rather than the process-wide one, so a bridge serving a client during a run cannot append to what the test asserts on.

0.4 and 0.6 are deliberately absent: both are statements about two threads and a live socket, and a test standing one up inside the editor would be asserting on the editor hosting it. They belong to the Phase 7 live tier.

## Build

Three new translation units (`BridgeStateFiles.cpp`, `BridgeParamEcho.cpp`, `Tests/BridgeProtocolTests.cpp`). `UE_MCP_Bridge.Build.cs` is touched so UBT rescans the module file list, otherwise they link as "Unknown method" at runtime.

**A C++ build is required before merge.** This branch was written without the build machine, which the orchestrator owns.

## Verification done here

- `npx tsc --noEmit` clean
- `npx vitest run tests/unit`: 68 files, 640 tests, all passing (632 before, plus 8 new for the requested-port channel)
- No em dashes, no competitor names
