### PR TITLE
Record the editor-down golden baseline and guard it in the unit tier (#817)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,15 @@ Edit only under `plugin/ue_mcp_bridge/`. The deployer syncs to `tests/ue_mcp/Plu
 - Smoke tests execute real mutations (create blueprints, delete assets, modify levels). A misrouted run against a real project can corrupt an active editor session.
 - 440+ handlers. Pass = every handler responds either with success or an expected parameter-validation error. Any timeout or `Unknown method` is a real failure.
 
+### Golden baseline - the advertised surface
+
+`tests/golden/editor-down.json` is a recording of what a client is handed at startup with one project and no editor running: the `initialize` instructions and every tool in `tools/list` with its full input schema. `tests/unit/golden-editor-down.test.ts` starts the real server over stdio, records the same thing again, and fails if the two differ. It runs as part of `npm run test:unit`, so CI gates on it.
+
+- **A failure is not automatically a bug.** It says the startup contract moved. Read the diff.
+- **Re-record intentionally** with `npm run golden:record`, then review the diff before committing it. Never edit the JSON by hand.
+- The recording is hermetic: a throwaway project in a temp directory, `UE_MCP_PORT=1` so nothing can be listening, every inherited `UE_MCP_*` variable dropped, and the user-scoped config/state/auth files redirected. Absolute paths are rewritten before serialization and asserted absent, so the file verifies on any machine.
+- Only the editor-down half exists. Plan item 1.10 of #817 also wants the editor-connected half, which needs an Unreal install and therefore cannot live in this tier.
+
 ### Clean plugin rebuild recipe
 
 If new handlers return `"Unknown method"` at runtime even though source + build reported success:
@@ -137,6 +146,7 @@ npm run up:build        # Stop editor, build plugin, relaunch
 npm run build           # Build the UE C++ plugin only
 npx tsc --noEmit        # Type-check TS
 npm run test:smoke      # Live smoke tests (tests/ue_mcp only)
+npm run golden:record   # Re-record tests/golden/editor-down.json (review the diff)
 npm test                # Vitest unit tests
 node scripts/deploy.mjs # Sync plugin/ → tests/ue_mcp/Plugins/
 ```

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test": "vitest run",
     "test:unit": "vitest run tests/unit",
     "test:multi-editor": "vitest run tests/multi-editor",
+    "golden:record": "node scripts/record-golden.mjs",
     "audit:docs": "node scripts/audit-docs.mjs && node scripts/audit-params.mjs",
     "audit:handlers": "node scripts/audit-handlers.mjs",
     "audit": "npm run audit:docs && npm run audit:handlers",

--- a/scripts/record-golden.mjs
+++ b/scripts/record-golden.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Re-record the editor-down golden baseline (#817, plan item 1.10).
+ *
+ * Deliberately the same code path the guard uses: it runs the guard test with
+ * UE_MCP_RECORD_GOLDEN=1, which makes it write tests/golden/editor-down.json
+ * instead of asserting against it. A separate recorder would be a second
+ * implementation of the surface capture, and the baseline would then only
+ * prove the two implementations agree with each other.
+ *
+ * Review the resulting diff before committing. It is the contract every client
+ * sees at startup.
+ */
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const target = "tests/unit/golden-editor-down.test.ts";
+
+const result = spawnSync(
+  process.execPath,
+  [path.join(repoRoot, "node_modules", "vitest", "vitest.mjs"), "run", target],
+  {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: { ...process.env, UE_MCP_RECORD_GOLDEN: "1" },
+  },
+);
+
+if (result.error) {
+  console.error(`[golden] failed to run vitest: ${result.error.message}`);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/tests/golden/capture.ts
+++ b/tests/golden/capture.ts
@@ -1,0 +1,233 @@
+/**
+ * Records the editor-down half of the #817 plan item 1.10 golden corpus.
+ *
+ * The surface a client sees at startup has two legitimate shapes, because
+ * Epic-toolset enrichment picks a live editor, then the project cache, then
+ * the snapshot baked into the package (`src/index.ts`, `buildSessionLoad`).
+ * One baseline therefore cannot tell a regression from a cold start, so the
+ * corpus is recorded twice. This module records the cold half: a real server
+ * process, a real project, and no editor listening anywhere.
+ *
+ * It drives the shipped entry point over stdio rather than reassembling the
+ * surface in-process. A baseline built from a copy of the construction code
+ * only ever proves the copy still agrees with itself; going through
+ * `initialize` and `tools/list` proves what a client is actually handed.
+ *
+ * Everything that varies by machine is either pinned or normalized:
+ *
+ *   - the project lives in a fresh temp directory, and its path is rewritten
+ *     to `<PROJECT_DIR>` wherever it appears;
+ *   - the repository root is rewritten to `<REPO>`;
+ *   - `UE_MCP_PORT=1` guarantees the editor-down branch. Port 1 is privileged
+ *     on every platform we run on, so nothing can be listening there, and the
+ *     connection is refused immediately instead of burning the connect budget;
+ *   - every other `UE_MCP_*` variable inherited from the recording shell is
+ *     dropped, and the three user-scoped files the server reads (global
+ *     config, user state, auth) are redirected into the temp directory so a
+ *     developer's own settings never reach the baseline;
+ *   - the update check is off, so no network call can change what is recorded.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/** Repository root, two levels up from `tests/golden/`. */
+export const REPO_ROOT = path.resolve(here, "..", "..");
+
+/** Where the committed baseline lives. */
+export const GOLDEN_EDITOR_DOWN = path.join(here, "editor-down.json");
+
+/**
+ * Bumped whenever the shape of the snapshot document itself changes (not its
+ * contents). A mismatch means the recorder and the file disagree about the
+ * format, which is a different problem from a surface regression.
+ */
+export const GOLDEN_SCHEMA_VERSION = 1;
+
+/** The project name every recording uses, so it is never machine-derived. */
+const PROJECT_NAME = "GoldenProject";
+
+export interface GoldenTool {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+}
+
+export interface GoldenSurface {
+  schemaVersion: number;
+  scenario: "editor-down";
+  server: { name: string; version: string };
+  instructions: string;
+  toolCount: number;
+  tools: GoldenTool[];
+}
+
+/** Environment variables the recording pins rather than inherits. */
+function recordingEnv(sandbox: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    // Anything UE_MCP_* from the recording shell is a machine setting, and a
+    // baseline that carries one is a baseline only that machine can verify.
+    if (key.startsWith("UE_MCP_")) continue;
+    env[key] = value;
+  }
+  env.HOME = sandbox;
+  env.USERPROFILE = sandbox;
+  env.UE_MCP_HOST = "127.0.0.1";
+  env.UE_MCP_PORT = "1";
+  env.UE_MCP_GLOBAL_CONFIG = path.join(sandbox, "global-config.yml");
+  env.UE_MCP_USER_STATE = path.join(sandbox, "state.json");
+  env.UE_MCP_AUTH_DIR = path.join(sandbox, "auth");
+  env.UE_MCP_DISABLE_UPDATE_CHECK = "1";
+  env.UE_MCP_LOG_LEVEL = "error";
+  return env;
+}
+
+/** A minimal but real `.uproject`, written fresh for every recording. */
+function writeFixtureProject(sandbox: string): string {
+  const projectDir = path.join(sandbox, PROJECT_NAME);
+  fs.mkdirSync(projectDir, { recursive: true });
+  const uproject = path.join(projectDir, `${PROJECT_NAME}.uproject`);
+  fs.writeFileSync(
+    uproject,
+    JSON.stringify({ FileVersion: 3, EngineAssociation: "5.6", Category: "", Description: "" }, null, 2),
+    "utf-8",
+  );
+  return uproject;
+}
+
+/**
+ * Rewrite the two absolute paths that could otherwise be baked in, in every
+ * spelling they can appear in: native separators, forward slashes, and the
+ * JSON-escaped form. Case-insensitive because Windows reports drive letters
+ * both ways.
+ */
+function normalizePaths(text: string, projectDir: string, sandbox: string): string {
+  const substitutions: Array<[string, string]> = [
+    [projectDir, "<PROJECT_DIR>"],
+    [sandbox, "<SANDBOX>"],
+    [REPO_ROOT, "<REPO>"],
+  ];
+  let out = text;
+  for (const [from, to] of substitutions) {
+    for (const spelling of [from, from.replace(/\\/g, "/"), from.replace(/\\/g, "\\\\")]) {
+      out = out.replace(new RegExp(escapeRegExp(spelling), "gi"), to);
+    }
+  }
+  return out;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Deep clone with every object key sorted, so map ordering cannot churn the file. */
+export function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value === null || typeof value !== "object") return value;
+  const source = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(source).sort()) out[key] = sortKeysDeep(source[key]);
+  return out;
+}
+
+/** The exact bytes the baseline file holds for a given surface. */
+export function serializeGolden(surface: GoldenSurface): string {
+  return JSON.stringify(sortKeysDeep(surface), null, 2) + "\n";
+}
+
+/**
+ * One recording, plus the machine-specific directories it used. The caller
+ * needs those to assert that none of them survived into the snapshot; a
+ * baseline that quietly baked one in would pass on the machine that recorded
+ * it and fail everywhere else.
+ */
+export interface GoldenRecording {
+  surface: GoldenSurface;
+  sandbox: string;
+  projectDir: string;
+  repoRoot: string;
+}
+
+/**
+ * Start the shipped server against a throwaway project with no editor
+ * running, and return its `initialize` instructions plus every tool from
+ * `tools/list` with its full input schema.
+ */
+export async function captureEditorDownSurface(): Promise<GoldenRecording> {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-golden-"));
+  const uproject = writeFixtureProject(sandbox);
+  const projectDir = path.dirname(uproject);
+
+  const client = new Client({ name: "ue-mcp-golden-recorder", version: "1.0.0" }, { capabilities: {} });
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["--import", "tsx", path.join(REPO_ROOT, "src", "index.ts"), uproject],
+    cwd: REPO_ROOT,
+    env: recordingEnv(sandbox) as Record<string, string>,
+    stderr: "ignore",
+  });
+
+  try {
+    await client.connect(transport);
+
+    const version = client.getServerVersion();
+    const instructions = client.getInstructions() ?? "";
+    const listed = await client.listTools();
+
+    const tools: GoldenTool[] = listed.tools
+      .map((t) => ({
+        name: t.name,
+        description: t.description ?? "",
+        inputSchema: t.inputSchema as unknown,
+      }))
+      .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+    const surface: GoldenSurface = {
+      schemaVersion: GOLDEN_SCHEMA_VERSION,
+      scenario: "editor-down",
+      server: { name: version?.name ?? "", version: version?.version ?? "" },
+      instructions,
+      toolCount: tools.length,
+      tools,
+    };
+
+    // Normalize once, over the serialized form, so no field is missed.
+    return {
+      surface: JSON.parse(normalizePaths(JSON.stringify(surface), projectDir, sandbox)) as GoldenSurface,
+      sandbox,
+      projectDir,
+      repoRoot: REPO_ROOT,
+    };
+  } finally {
+    await client.close().catch(() => undefined);
+    // The transport owns the child; close() above kills it. Belt and braces
+    // for the case where connect() itself threw.
+    await transport.close().catch(() => undefined);
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Read the committed baseline. Returns null when it has never been recorded.
+ *
+ * CRLF is folded to LF on the way in. `.gitattributes` already pins `*.json`
+ * to `eol=lf`, so this only covers a checkout that arrived some other way; a
+ * line-ending difference is not a surface regression and should not be
+ * reported as one.
+ */
+export function readGoldenBaseline(): string | null {
+  if (!fs.existsSync(GOLDEN_EDITOR_DOWN)) return null;
+  return fs.readFileSync(GOLDEN_EDITOR_DOWN, "utf-8").replace(/\r\n/g, "\n");
+}
+
+/** Write the baseline. Used by `npm run golden:record`. */
+export function writeGoldenBaseline(contents: string): void {
+  fs.mkdirSync(path.dirname(GOLDEN_EDITOR_DOWN), { recursive: true });
+  fs.writeFileSync(GOLDEN_EDITOR_DOWN, contents, "utf-8");
+}

--- a/tests/golden/editor-down.json
+++ b/tests/golden/editor-down.json
@@ -1,0 +1,7945 @@
+{
+  "instructions": "UE-MCP: Unreal Engine editor bridge (C++ plugin) - 24 category tools covering 783 actions, plus 830 official Unreal 5.8 tools wrapped in-process (UE 5.8+; see the epic category).\n\nEvery tool takes an \"action\" parameter that selects the operation. Call project(action=\"get_status\") first.\n\n═══ QUICK START ═══\n1. project(action=\"get_status\") - check if the editor is connected\n2. If not connected: editor(action=\"start_editor\") to launch UE\n3. level(action=\"get_outliner\") - see what's in the current level\n4. asset(action=\"list\") - browse project assets\n5. reflection(action=\"reflect_class\", className=\"StaticMeshActor\") - understand any UE class\n6. demo(action=\"step\", stepIndex=1) through 19 - run the Neon Shrine demo to see the bridge in action\n7. demo(action=\"cleanup\") - clean up after the demo\n\n═══ TOOLS ═══\n\nEvery category tool lists its own actions (and each action's parameters) in\nits description - read the description of the category you need. Categories:\nproject, asset, blueprint, level, material, animation, landscape, pcg,\nfoliage, niagara, audio, widget, editor, reflection, gameplay, gas,\nnetworking, demo, feedback, statetree, chooser, plugins, epic (830 wrapped Unreal 5.8 tools; UE 5.8+), fab.\n\n═══ TIPS ═══\n• Start with level(action=\"get_outliner\") or asset(action=\"list\") to discover what's in the project.\n• Use reflection(action=\"reflect_class\") to understand any UE class's properties.\n• asset(action=\"search\", query=\"/Game/Characters/*\") accepts wildcards.\n• For BP scripting: blueprint(action=\"search_node_types\") → blueprint(action=\"add_node\") → blueprint(action=\"connect_pins\").\n• editor(action=\"execute_python\") is the escape hatch for any Unreal Python API call.\n• Animation tools need a skeleton path - use animation(action=\"list_skeletal_meshes\") to find it.\n• Editor lifecycle: editor(action=\"stop_editor\") / editor(action=\"start_editor\") / editor(action=\"restart_editor\") manage the UE process. editor(action=\"build_project\") builds the project C++ code (stop the editor first).\n• editor(action=\"hot_reload\") triggers Live Coding compilation without restarting the editor.\n• editor(action=\"focus_on_actor\", actorLabel=\"MyActor\") snaps the viewport to any actor.\n• Log output: editor(action=\"get_log\", category=\"LogMCPBridge\") to see bridge-specific logs.\n\n═══ FLOWS - READ BEFORE ACTING ═══\n\nBefore you run bash/npm commands or chain 3+ category tool calls to\nsatisfy a user request, look at the `flows` field returned by\nproject(action=\"get_status\").\n\nThat field lists named, pre-built sequences for this project. Each\nentry has a name and description. If ANY flow's description matches\nwhat the user asked for, you MUST run it instead of building the\nsequence yourself.\n\nExamples:\n  User asks                          | Look for a flow like\n  ---------------------------------- | ------------------------------\n  \"rebuild and relaunch the editor\"  | rebuild\n  \"run the smoke tests\"              | smoke\n  \"redeploy the plugin\"              | deploy, redeploy\n  \"package the project\"              | package\n\nRun a matched flow with: flow(action=\"run\", flowName=\"<name>\")\n\nDO NOT:\n- Skip the get_status flows check before running bash/npm yourself.\n- Author a new flow on your own. Only the user authors flows.\n- Suggest a flow for a one-off task the user is unlikely to repeat.\n\nDO suggest a new flow IF AND ONLY IF all three are true:\n  1. You just finished a sequence with 3+ steps.\n  2. The sequence had the same shape every run, with only 1-2 values\n     changing.\n  3. The user is likely to ask for the same shape again.\nIn that case say: \"This sequence (X -> Y -> Z) might be worth registering\nas a flow in ue-mcp.yml. Want me to draft one?\" Then STOP. Wait.\n\n═══ FEEDBACK ═══\nIf you had to use editor(action=\"execute_python\") as a workaround because a native tool\ncouldn't handle the task, keep a mental note of what you did and why. When your task is\ncomplete, tell the user:\n  \"I had to use custom Python scripts to [describe what]. Would you like to submit\n   feedback to help improve ue-mcp?\"\nIf the user agrees, call feedback(action=\"submit\") with:\n  • title - short, generic description of the gap (no project-specific details)\n  • summary - what was attempted and why the native tool fell short\n  • pythonWorkaround - the Python code that was used\n  • idealTool - what tool/action should handle this natively\nThis creates a GitHub issue so the maintainers can add proper support.\n\nNot every gap belongs to ue-mcp core. Plugins (PIE Studio, Perforce, Meshy, ...)\nown their own surfaces and their own trackers. submit checks the plugin registry\nand aims the issue at the owning repo on its own, and the approval prompt lets\nthe user change it - do NOT set the repo parameter yourself unless the user\nnames a repo. feedback(action=\"route\") answers \"where would this land?\" without\nposting anything.\n",
+  "scenario": "editor-down",
+  "schemaVersion": 1,
+  "server": {
+    "name": "ue-mcp",
+    "version": "0.6.4"
+  },
+  "toolCount": 27,
+  "tools": [
+    {
+      "description": "Animation assets, skeletons, montages, blendspaces, anim blueprints, physics assets.\n\nActions:\n- read_anim_blueprint: Read AnimBP structure. Params: assetPath\n- read_montage: Read montage. Params: assetPath\n- read_sequence: Read anim sequence. Params: assetPath\n- scan_animation_tracks: Scan AnimSequence bone-track counts. Params: directory?, recursive?, assetPaths?, skeletonPath?, targetTrackCount?, includeTrackNames?\n- read_blendspace: Read blendspace. Params: assetPath\n- add_blend_sample: Append a sample to a BlendSpace. Params: assetPath, animation (AnimSequence path), position {x,y} (or flat x,y) (#248)\n- set_blend_sample: Move an existing BlendSpace sample or swap its animation. Params: assetPath, sampleIndex, position? {x,y} (or flat x,y), animation? (#272)\n- list: List anim assets. Params: directory?, recursive?\n- create_montage: Create montage. Params: animSequencePath, name?, packagePath?\n- author_montages_batch: Batch-author montages in one call: idempotent create, slot name, blend/rate/length properties, sections and notifies, then save. Every item reports success plus the failing stage (validate|create|slot|properties|sections|notifies|save) and error, so one bad item does not hide the rest. Newly created montages come back as a delete_asset_batch rollback. Each montage still holds the single segment create_montage builds. Params: items[] (each: name, animSequencePath, packagePath?, onConflict?, slotName?, trackIndex?, rateScale?, blendIn?, blendOut?, sequenceLength?, sections? [{sectionName, startTime?, linkedSection?}], notifies? [{notifyName, triggerTime, notifyClass?, properties?}])\n- create_anim_blueprint: Create AnimBP. Params: skeletonPath, name?, packagePath?, parentClass?\n- create_blendspace: Create blendspace (2D). Params: skeletonPath, name?, packagePath?, axisHorizontal?, axisVertical?\n- create_blendspace_1d: Create BlendSpace1D. Params: skeletonPath, name?, packagePath?, axisName? (default Speed), axisMin?, axisMax?, gridNum? (#459)\n- populate_blendspace: One-call axis params + samples authoring for BlendSpace 1D/2D. Params: assetPath, axis? ({name?, min?, max?, gridNum?}) for axis 0, blendspaceAxes? (per-axis array), axisHorizontal?/axisVertical? + horizontalMin/horizontalMax/verticalMin/verticalMax/gridNumHorizontal/gridNumVertical (back-compat), samples ([{animationPath, x, y?}]), clearExisting? (default true) (#459)\n- add_notify: Add notify. For PlayMontageNotify the notifyName is also written onto the spawned notify object so OnPlayMontageNotifyBegin broadcasts it (not 'None'), and montage branching-point markers refresh (#528). notifyProperties writes EditAnywhere fields onto the spawned notify object and therefore requires a notifyClass that resolves. Params: assetPath, notifyName, triggerTime, notifyClass?, notifyProperties?\n- remove_notify: Remove notify(s) by name and/or class. Pass at least one of notifyName/notifyClass; both filters AND. Idempotent: alreadyDeleted=true if no match. Params: assetPath, notifyName?, notifyClass? (#471)\n- get_skeleton_info: Read skeleton. Params: assetPath\n- list_sockets: List sockets. Params: assetPath\n- list_skeletal_meshes: List skeletal meshes. Params: directory?, recursive?\n- get_physics_asset: Read physics asset. Params: assetPath\n- create_sequence: Create blank AnimSequence. Params: name, skeletonPath, packagePath?, numFrames?, frameRate?\n- set_bone_keyframes: Set bone transform keyframes. Params: assetPath, boneName, keyframes\n- bake_keyframes_batch: Bake per-bone keyframe arrays for many bones into an AnimSequence in one call. Auto-creates each bone track first (set_bone_keyframes silently leaves a T-pose if the track is missing), wraps the batch in one transaction, and raises if any bone fails instead of reporting hollow success (#540). Params: assetPath, tracks ([{bone, keyframes:[{location,rotation{x,y,z,w},scale?}]}]), save? (default true)\n- get_bone_transforms: Read reference pose transforms for one, many, or ALL bones. Omit boneNames to return every bone with index/parentIndex/location/rotation/scale. With boneNames, returns only the named bones. Params: skeletonPath, boneNames? (omit = all bones), space? ('local' default, or 'component' for composed parent-chain transforms - retarget-chain / anatomical-scale work) (#245)\n- inspect_anim_nodes: Deep-dump the FAnimNode_* struct of anim graph nodes (PoseDriver PoseTargets/PoseAsset/RBF params/source bones, etc.) that read_anim_graph omits because it skips the 'Node' property. Params: assetPath, graphName? (default AnimGraph), nodeClass? (substring filter, e.g. 'PoseDriver') (#657)\n- compare_curves_to_morph_targets: Compare an AnimSequence/PoseAsset's curve names against a SkeletalMesh's morph target names. Returns curves[], morphTargets[], matched[], curvesWithoutMorph[], morphsWithoutCurve[] - verify authored curves drive morphs without Python. Params: animPath (AnimSequence or PoseAsset), skeletalMeshPath (#656)\n- set_montage_sequence: Replace the animation sequence in a montage slot. With segmentIndex, replaces only that one segment; without it, replaces every segment in the slot. Params: assetPath, animSequencePath, slotIndex? (default 0), segmentIndex? (#626)\n- set_montage_properties: Set montage properties. Params: assetPath, sequenceLength?, rateScale?, blendIn?, blendOut?\n- create_state_machine: Create state machine in AnimBP. Params: assetPath, name?, graphName?\n- add_state: Add state to a state machine. Params: assetPath, stateMachineName, stateName\n- add_transition: Add directed transition between states. Params: assetPath, stateMachineName, fromState, toState\n- set_state_animation: Assign anim asset to state. Params: assetPath, stateMachineName, stateName, animAssetPath\n- set_transition_blend: Set blend type/duration on transition. Params: assetPath, stateMachineName, fromState, toState, blendDuration?, blendLogic?\n- set_transition_condition: Set a transition's 'can enter transition' condition from a bool variable, keyed by transition (not graph name - every rule graph is named 'Transition' so blueprint graph tools can only reach the first). Wires VariableGet(bool) -> bCanEnterTransition, replacing any prior condition. Identify the transition by transitionGuid (from add_transition/read_state_machine) OR fromState+toState. Params: assetPath, stateMachineName, variableName (existing bool var), transitionGuid? OR fromState?+toState?, negate? (default false) (#707)\n- read_state_machine: Read state machine topology. Params: assetPath, stateMachineName\n- read_anim_graph: Read AnimBP AnimGraph nodes with properties & pins. Params: assetPath, graphName?\n- add_curve: Add float curve to AnimSequence. Params: assetPath, curveName, curveType?\n- set_anim_curve_keys: Set float-curve key VALUES on an AnimSequence (add_curve only creates an empty named curve - it cannot set keyframe values). Adds the curve if missing, then replaces its keys. Use for authoring Distance/Speed/any float curve directly. Params: assetPath, curveName, keys ([{time, value, interp?('linear'|'constant'|'cubic')}]), interpolation? (default 'linear', applied to keys without their own interp) (#712)\n- apply_animation_modifier: Instantiate a UAnimationModifier subclass and run it on an AnimSequence. Headline use: modifierClass='DistanceCurveModifier' bakes a Distance curve from the clip's root motion for distance matching (needs root motion baked first - see bake_root_motion_from_bone). Registers the modifier on the sequence so it re-applies on reimport. props sets the modifier's EditAnywhere fields (e.g. DistanceCurveModifier: {CurveName, Axis:'XY'|'X'|..., bStopAtEnd, StopSpeedThreshold, SampleRate}). Note: DistanceCurveModifier ships in the 'Animation Locomotion Library' plugin (off by default) - enable it first. Params: assetPath, modifierClass (short name or /Script path), props? (#712)\n- set_montage_slot: Set slot name on a montage track. Params: assetPath, slotName, trackIndex?\n- add_montage_section: Add composite section to montage. Pass segmentIndex (with slotName or slotIndex) to anchor the section to a specific segment: its startTime is taken from that segment and it stays linked, so inserting a segment ahead of it moves the marker with its animation. Without segmentIndex the section is a bare absolute-time marker. Params: assetPath, sectionName, startTime?, linkedSection?, segmentIndex?, slotName?, slotIndex? (#826)\n- add_montage_segment: Append (or insert) an animation segment into a montage slot's anim track. This is the only way to get more than one animation into a montage: create_montage builds exactly one segment, set_montage_sequence replaces rather than appends, and add_montage_section only writes a time marker with no animation behind it. Creates the named slot when it does not exist. Validates that the source shares the montage's skeleton and matches the track's additive type, then relays out the segments, refreshes linked sections and notifies, and rewrites the montage length. Params: assetPath, animSequencePath, slotName? (created if absent), slotIndex? (default 0, used when slotName is omitted), startPos? (trim into the source, default 0), endPos? (default source play length), playRate? (default 1, negative reverses), loopCount? (default 1), insertIndex? (default appends) (#826)\n- remove_montage_segment: Remove a segment from a montage slot by index, then relay out the remaining segments and rewrite the montage length. Idempotent: alreadyDeleted=true when the slot already holds no segments. Params: assetPath, segmentIndex, slotName?, slotIndex? (default 0) (#826)\n- list_montage_segments: List every slot's segments on a montage so a caller can address them by index: animation path, startPos/endPos trim, playRate, loopCount, track position and length per segment, plus the sections with the slot and segment each one links to. Params: assetPath, slotName? (filter to one slot) (#826)\n- create_ik_rig: Create IKRigDefinition asset, optionally with retargetRoot + chains[]. Params: name, skeletalMeshPath, packagePath?, retargetRoot?, chains?: [{name, startBone, endBone, goal?}]\n- read_ik_rig: Read IK Rig chains, solvers, skeleton. Params: assetPath\n- list_control_rig_variables: List ControlRig variables and hierarchy. Params: assetPath\n- read_control_rig_graph: Read a Control Rig's RigVM models: every graph with its nodes (name, node path, class), each node's pins (name, pin path, cppType, direction, execute flag, default value, nested sub-pins) and the links between them, plus full member-variable metadata (type, subtype, array-ness, default, public/read-only). list_control_rig_variables only ever reported a node COUNT, which is not enough to verify solver wiring (#774). Params: assetPath, graphName? (substring filter), includePins? (default true), includeDefaults? (default true), includeLinks? (default true), limit? (nodes per graph, default 200)\n- read_control_rig_hierarchy: Read a Control Rig's per-element hierarchy metadata: each element's name, type (Bone|Control|Null|Curve...), index, and parent. Params: assetPath (#619)\n- set_root_motion: Set root motion settings on AnimSequence. Params: assetPath, enableRootMotion?, forceRootLock?, useNormalizedRootMotionScale?, rootMotionRootLock?\n- add_virtual_bone: Add virtual bone. Params: skeletonPath, sourceBone, targetBone\n- remove_virtual_bone: Remove virtual bone. Params: skeletonPath, virtualBoneName\n- create_composite: Create AnimComposite. Params: name, skeletonPath, packagePath?\n- list_modifiers: List applied animation modifiers. Params: assetPath\n- create_ik_retargeter: Create IKRetargeter asset and (default) initialize the UE 5.7 ops stack: assigns sourceRig+targetRig to all ops, runs AutoMapChains. Returns chainsMapped count. Params: name, packagePath?, sourceRig?, targetRig?, autoMapChains? (default true) (#246)\n- read_ik_retargeter: Read IKRetargeter: source/target rigs and chain mappings. Params: assetPath (#246)\n- set_ik_rig_mesh: Set the preview/source skeletal mesh on an EXISTING IK Rig. Params: rigPath, meshPath (#701)\n- set_ik_retargeter_rig: Set the source or target IK Rig on an EXISTING IK Retargeter. Params: retargeterPath, rigPath, side? (source|target, default target) (#703)\n- auto_align_retarget_pose: Auto-align all bones of the source/target retarget pose (chain-to-chain) - fixes a retargeter that outputs a static reference pose. Params: retargeterPath, side? (source|target, default target) (#701)\n- reset_retarget_pose: Reset the current retarget pose (all bones) to the reference pose. Params: retargeterPath, side? (source|target, default target) (#701)\n- batch_retarget_animations: Bake a set of source AnimSequences onto the target skeleton through an IK Retargeter (RunBatchRetarget). Params: retargeterPath, sourceMesh, targetMesh, animPaths[], outputPath? (default: alongside source), prefix?, suffix? (default _Retargeted), overwrite? (#701)\n- set_anim_blueprint_skeleton: Set target skeleton on AnimBP. Params: assetPath, skeletonPath\n- read_bone_track: Read bone transform samples from AnimSequence. Params: assetPath, boneName, frames?: [int]\n- create_pose_search_database: Create a PoseSearchDatabase asset (motion matching). Params: name, packagePath?, schemaPath?\n- set_pose_search_schema: Set the Schema on an existing PoseSearchDatabase. Params: assetPath, schemaPath\n- add_pose_search_sequence: Append an AnimSequence/AnimComposite/AnimMontage/BlendSpace to a PoseSearchDatabase, with optional per-clip flags. Params: assetPath, sequencePath, mirror? ('original'|'mirrored'|'both'), disableReselection?, sampleStart?, sampleEnd?, enabled? (#684)\n- set_pose_search_clips: Author the whole clip list of a PoseSearchDatabase in one call (the 'duplicate a stock PSD, swap its clips' pipeline step). Replaces the list by default. Each clip carries per-entry flags. Params: assetPath, clips ([{sequencePath, mirror? ('original'|'mirrored'|'both'), disableReselection?, sampleStart?, sampleEnd?, enabled?}] - a bare string path also works), clearExisting? (default true). Follow with build_pose_search_index (#684)\n- build_pose_search_index: Build (or rebuild) the search index. Params: assetPath, wait? (default true)\n- read_pose_search_database: Inspect a PoseSearchDatabase: schema, animation entries, cost biases, tags. Params: assetPath\n- set_pose_search_database_settings: Tune a PoseSearchDatabase: cost biases, KD-tree neighbours, search mode, PCA components, normalization set. Params: assetPath, continuingPoseCostBias?, baseCostBias?, loopingCostBias?, kdTreeQueryNumNeighbors?, numberOfPrincipalComponents?, poseSearchMode? ('bruteforce'|'pcakdtree'|'vptree'|'eventonly'), normalizationSetPath? (motion matching)\n- create_pose_search_schema: Create a PoseSearchSchema (the feature definition a database indexes against). Binds a skeleton (and optional mirror table) and, by default, adds Trajectory+Pose default channels so the schema is immediately buildable. Refine with add_pose_search_schema_*_channel. Params: name, skeletonPath, packagePath?, mirrorDataTablePath?, sampleRate?, addDefaultChannels? (default true) (motion matching)\n- add_pose_search_schema_pose_channel: Add a Pose feature channel to a schema (samples named bones for velocity/position/rotation/phase). Params: schemaPath, bones ([{bone, flags?:['velocity','position','rotation','phase'], weight?}] - a bare bone-name string defaults to position), weight? (motion matching)\n- add_pose_search_schema_trajectory_channel: Add a Trajectory feature channel to a schema (past/future motion samples). Params: schemaPath, samples ([{offset (seconds; negative=history, positive=prediction), flags?:['position','velocity','facingDirection','velocityDirection', ...XY variants], weight?}]), weight? (motion matching)\n- read_pose_search_schema: Inspect a PoseSearchSchema: skeleton(s), mirror table, sample rate, feature channels. Params: schemaPath (motion matching)\n- create_mirror_data_table: Create a MirrorDataTable for a skeleton (needed for mirrored poses in motion matching / mirror nodes). Auto-derives bone-pair rows from find/replace expressions (defaults to UE mannequin _l/_r suffix swap). Params: name, skeletonPath, packagePath?, expressions? ([{find, replace, method?:'suffix'|'prefix'|'regex'}]), mirrorAxis? (X|Y|Z, default X), mirrorRootMotion? (default true)\n- read_mirror_data_table: Inspect a MirrorDataTable: skeleton and bone-pair rows (name -> mirroredName). Params: assetPath (motion matching)\n- create_pose_search_normalization_set: Create a PoseSearchNormalizationSet grouping databases so they normalize their cost space together (consistent blending across a locomotion set). Assign it via set_pose_search_database_settings(normalizationSetPath). Params: name, packagePath?, databases? ([PoseSearchDatabase paths]) (motion matching)\n- add_motion_matching_node: Add a Motion Matching node to an AnimBP AnimGraph and point it at a PoseSearchDatabase (the runtime node that searches the database each frame). Connects its output to the Output Pose by default. For chooser-driven database selection, bind an anim-node function that calls SetDatabasesToSearch. Params: assetPath (AnimBP), databasePath, graphName? (default AnimGraph), connectToOutput? (default true), blendTime? (motion matching)\n- add_pose_history_node: Add a Pose History (PoseSearchHistoryCollector) node to an AnimBP AnimGraph - the Motion Matching node needs it in the graph to query pose/trajectory history. Defaults to self-generated trajectory (no external trajectory pin needed) and inserts itself into the pose chain feeding the Output Pose. Params: assetPath (AnimBP), graphName? (default AnimGraph), poseCount?, samplingInterval?, generateTrajectory? (default true), trajectoryHistoryCount?, trajectoryPredictionCount?, insertBeforeOutput? (default true) (motion matching)\n- set_motion_matching_chooser: Drive the Motion Matching node's Database from a ChooserTable so the database is selected at runtime by character state. Wires a thread-safe EvaluateChooser (result typed to PoseSearchDatabase) into the MM node's Database pin. contextSource selects what the chooser reads its columns from: 'self' (default, the anim instance - choosers branching on AnimBP variables) or 'pawn' (the owning pawn via TryGetPawnOwner - choosers branching on character/pawn state). Params: assetPath (AnimBP), chooserPath (ChooserTable), graphName? (default AnimGraph), contextSource? ('self'|'pawn') (motion matching)\n- add_sequence_evaluator: Add a Sequence Evaluator node (explicit-time player) to an AnimBP graph - the node distance matching drives by setting its ExplicitTime each frame. graphName can be the top-level AnimGraph or a state's inner graph (pass the state name). Defaults bTeleportToExplicitTime=false so time advances and root motion extracts. Connects to the Output Pose by default. Returns nodeGuid for bind_anim_node_function. Params: assetPath (AnimBP), sequencePath? (AnimSequence to evaluate), graphName? (default AnimGraph), explicitTime?, shouldLoop?, teleportToExplicitTime? (default false), connectToOutput? (default true) (#713)\n- bind_anim_node_function: Bind a thread-safe anim-node function to an anim graph node's update slot - the mechanism distance matching uses to advance a Sequence Evaluator's explicit time each frame (function calls AnimDistanceMatchingLibrary::DistanceMatchToTarget / AdvanceTimeByDistanceMatching). The function must already exist on the AnimBP (create it as a BlueprintThreadSafe function first). Identify the node by nodeGuid (from add_sequence_evaluator / add_*_node). Params: assetPath (AnimBP), nodeGuid, functionName, graphName? (default AnimGraph), binding? ('update' (default)|'becomeRelevant'|'initialUpdate') (#713)\n- set_sequence_properties: Batch-set properties on AnimSequence assets. If a path is a Montage and resolveFromMontages is true (default), resolves to its first AnimSequence. Params: assetPaths[], properties{enableRootMotion?, forceRootLock?, useNormalizedRootMotionScale?, rootMotionRootLock?}, resolveFromMontages?\n- bake_root_motion_from_bone: Bake delta translation from a source bone (e.g. pelvis) onto the root bone across the whole sequence; compensates the source bone so world-space position is unchanged. Params: assetPath, sourceBone, rootBone? (default 'root'), axes? (default ['x','y']), interpolation? ('linear'|'per_frame', default 'linear')\n- get_bone_transform: Read a bone or socket transform on a live actor's SkeletalMeshComponent. Wraps GetBoneTransform / GetSocketTransform. Params: actorLabel, boneName (or socket name), componentName? (default: CharacterMesh0 / Mesh / first SK component), world? (auto|pie|game|editor, default auto), space? (world|component|local, default world). Returns location, rotation, scale (#420)\n- list_bones: List bones in a live actor's SkeletalMeshComponent ref skeleton (name, index, parent). Params: actorLabel, componentName?, world? (auto|pie|game|editor, default auto) (#420)\n- rebind_leader_pose: Re-bind every secondary SkeletalMeshComponent on an actor to a body component (default CharacterMesh0 / Mesh). One-call fix for the 'character explodes after rotating the actor' failure mode. Params: actorLabel, bodyComponent? (#419)\n- preview_animation: Toggle bUpdateAnimationInEditor + VisibilityBasedAnimTickOption=AlwaysTickPoseAndRefreshBones on every SkeletalMeshComponent of an actor. Bypasses the 'cannot be edited on templates' guard for level instances. Params: actorLabel, enabled (#419/#420)\n\nEpic 5.8 toolset actions (341): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "read_anim_blueprint",
+              "read_montage",
+              "read_sequence",
+              "scan_animation_tracks",
+              "read_blendspace",
+              "add_blend_sample",
+              "set_blend_sample",
+              "list",
+              "create_montage",
+              "author_montages_batch",
+              "create_anim_blueprint",
+              "create_blendspace",
+              "create_blendspace_1d",
+              "populate_blendspace",
+              "add_notify",
+              "remove_notify",
+              "get_skeleton_info",
+              "list_sockets",
+              "list_skeletal_meshes",
+              "get_physics_asset",
+              "create_sequence",
+              "set_bone_keyframes",
+              "bake_keyframes_batch",
+              "get_bone_transforms",
+              "inspect_anim_nodes",
+              "compare_curves_to_morph_targets",
+              "set_montage_sequence",
+              "set_montage_properties",
+              "create_state_machine",
+              "add_state",
+              "add_transition",
+              "set_state_animation",
+              "set_transition_blend",
+              "set_transition_condition",
+              "read_state_machine",
+              "read_anim_graph",
+              "add_curve",
+              "set_anim_curve_keys",
+              "apply_animation_modifier",
+              "set_montage_slot",
+              "add_montage_section",
+              "add_montage_segment",
+              "remove_montage_segment",
+              "list_montage_segments",
+              "create_ik_rig",
+              "read_ik_rig",
+              "list_control_rig_variables",
+              "read_control_rig_graph",
+              "read_control_rig_hierarchy",
+              "set_root_motion",
+              "add_virtual_bone",
+              "remove_virtual_bone",
+              "create_composite",
+              "list_modifiers",
+              "create_ik_retargeter",
+              "read_ik_retargeter",
+              "set_ik_rig_mesh",
+              "set_ik_retargeter_rig",
+              "auto_align_retarget_pose",
+              "reset_retarget_pose",
+              "batch_retarget_animations",
+              "set_anim_blueprint_skeleton",
+              "read_bone_track",
+              "create_pose_search_database",
+              "set_pose_search_schema",
+              "add_pose_search_sequence",
+              "set_pose_search_clips",
+              "build_pose_search_index",
+              "read_pose_search_database",
+              "set_pose_search_database_settings",
+              "create_pose_search_schema",
+              "add_pose_search_schema_pose_channel",
+              "add_pose_search_schema_trajectory_channel",
+              "read_pose_search_schema",
+              "create_mirror_data_table",
+              "read_mirror_data_table",
+              "create_pose_search_normalization_set",
+              "add_motion_matching_node",
+              "add_pose_history_node",
+              "set_motion_matching_chooser",
+              "add_sequence_evaluator",
+              "bind_anim_node_function",
+              "set_sequence_properties",
+              "bake_root_motion_from_bone",
+              "get_bone_transform",
+              "list_bones",
+              "rebind_leader_pose",
+              "preview_animation",
+              "epic_rename_socket",
+              "epic_remove_socket",
+              "epic_set_socket_transform",
+              "epic_get_socket_transform",
+              "epic_get_socket_bone",
+              "epic_get_socket_names",
+              "epic_add_socket",
+              "epic_get_morph_target_names",
+              "epic_assign_physics_asset",
+              "epic_get_physics_asset",
+              "epic_set_material",
+              "epic_get_material",
+              "epic_get_material_slots",
+              "epic_get_bone_children",
+              "epic_get_bone_parent",
+              "epic_get_bone_names",
+              "epic_get_skeleton",
+              "epic_get_bounds",
+              "epic_get_section_count",
+              "epic_get_vertex_count",
+              "epic_get_lod_count",
+              "epic_import_file",
+              "epic_remove_variable",
+              "epic_change_variable_type",
+              "epic_get_variable",
+              "epic_list_variables",
+              "epic_add_variable",
+              "epic_get_connected_pins",
+              "epic_disconnect_pins",
+              "epic_connect_pins",
+              "epic_set_pin_value",
+              "epic_get_pin_value",
+              "epic_list_pins",
+              "epic_add_variable_node",
+              "epic_add_event_node",
+              "epic_set_node_position",
+              "epic_get_node_position",
+              "epic_delete_node",
+              "epic_list_nodes",
+              "epic_create_node",
+              "epic_add_interaction_graph",
+              "epic_add_backward_solve_graph",
+              "epic_add_event_graph",
+              "epic_get_interaction_graph",
+              "epic_get_backward_solve_graph",
+              "epic_get_event_graph",
+              "epic_get_forward_solve_graph",
+              "epic_add_graph",
+              "epic_list_graphs",
+              "epic_get_graph",
+              "epic_get_children",
+              "epic_get_parent",
+              "epic_set_local_transform",
+              "epic_get_local_transform",
+              "epic_set_global_transform",
+              "epic_get_global_transform",
+              "epic_add_control",
+              "epic_add_null",
+              "epic_add_bone",
+              "epic_add_element",
+              "epic_get_all_controls",
+              "epic_get_all_nulls",
+              "epic_get_all_bones",
+              "epic_get_elements",
+              "epic_import_bones_from_asset",
+              "epic_create",
+              "epic_paste_folders",
+              "epic_copy_folders",
+              "epic_paste_sections",
+              "epic_copy_sections",
+              "epic_paste_tracks",
+              "epic_copy_tracks",
+              "epic_paste_bindings",
+              "epic_copy_bindings",
+              "epic_remove_binding_tag",
+              "epic_untag_binding",
+              "epic_tag_binding",
+              "epic_get_binding_tags",
+              "epic_get_all_binding_tags",
+              "epic_find_bindings_by_tag",
+              "epic_find_binding_by_tag",
+              "epic_get_section_post_roll_frames",
+              "epic_set_section_post_roll_frames",
+              "epic_get_section_pre_roll_frames",
+              "epic_set_section_pre_roll_frames",
+              "epic_set_section_animation",
+              "epic_set_byte_track_enum",
+              "epic_set_property_name_and_path",
+              "epic_get_section_to_key",
+              "epic_get_binding_id",
+              "epic_get_child_possessables",
+              "epic_bake_transform",
+              "epic_set_sequence_locked",
+              "epic_is_sequence_locked",
+              "epic_set_track_filter_active",
+              "epic_is_track_filter_active",
+              "epic_get_track_filter_names",
+              "epic_fix_actor_references",
+              "epic_rebind_component",
+              "epic_remove_invalid_bindings",
+              "epic_remove_all_bindings",
+              "epic_remove_actors_from_binding",
+              "epic_replace_binding_with_actors",
+              "epic_add_actors_to_binding",
+              "epic_add_event_repeater_section",
+              "epic_add_event_trigger_section",
+              "epic_get_sequence_lock_state",
+              "epic_get_sub_sequence_hierarchy",
+              "epic_focus_parent_sequence",
+              "epic_focus_sub_sequence",
+              "epic_get_folder_contents",
+              "epic_add_binding_to_folder",
+              "epic_add_track_to_folder",
+              "epic_remove_root_folder",
+              "epic_get_root_folders",
+              "epic_add_root_folder",
+              "epic_add_actors_by_name",
+              "epic_set_selection_range",
+              "epic_get_selection_range",
+              "epic_play_to",
+              "epic_is_camera_cut_locked",
+              "epic_select_folders",
+              "epic_set_camera_lock",
+              "epic_force_evaluate",
+              "epic_empty_selection",
+              "epic_select_bindings",
+              "epic_select_sections",
+              "epic_select_tracks",
+              "epic_get_selected_folders",
+              "epic_get_selected_bindings",
+              "epic_get_selected_sections",
+              "epic_get_selected_tracks",
+              "epic_get_section_properties",
+              "epic_get_section_completion_mode",
+              "epic_set_section_completion_mode",
+              "epic_get_section_blend_type",
+              "epic_set_section_blend_type",
+              "epic_get_section_ease_out",
+              "epic_get_section_ease_in",
+              "epic_set_section_ease_out",
+              "epic_set_section_ease_in",
+              "epic_set_camera_cut_binding",
+              "epic_set_section_end_bounded",
+              "epic_set_section_start_bounded",
+              "epic_has_section_end_frame",
+              "epic_has_section_start_frame",
+              "epic_get_section_range",
+              "epic_set_section_range",
+              "epic_remove_section",
+              "epic_get_sections",
+              "epic_add_section",
+              "epic_set_track_display_name",
+              "epic_get_track_display_name",
+              "epic_remove_track_from_sequence",
+              "epic_remove_track",
+              "epic_find_tracks_by_type",
+              "epic_get_tracks_on_sequence",
+              "epic_get_tracks_on_binding",
+              "epic_add_track_to_sequence",
+              "epic_add_track_to_binding",
+              "epic_get_bound_objects",
+              "epic_remove_binding",
+              "epic_set_binding_name",
+              "epic_get_binding_name",
+              "epic_find_binding_by_name",
+              "epic_get_bindings",
+              "epic_create_camera",
+              "epic_add_spawnable_from_class",
+              "epic_add_spawnable_from_instance",
+              "epic_add_actors",
+              "epic_set_playback_range_locked",
+              "epic_is_playback_range_locked",
+              "epic_set_clock_source",
+              "epic_get_clock_source",
+              "epic_set_evaluation_type",
+              "epic_get_evaluation_type",
+              "epic_set_tick_resolution",
+              "epic_get_tick_resolution",
+              "epic_find_marked_frame_by_label",
+              "epic_delete_all_marked_frames",
+              "epic_delete_marked_frame",
+              "epic_get_marked_frames",
+              "epic_add_marked_frame",
+              "epic_get_work_range",
+              "epic_set_work_range",
+              "epic_get_view_range",
+              "epic_set_view_range",
+              "epic_set_playback_range",
+              "epic_get_playback_range",
+              "epic_set_display_rate",
+              "epic_get_display_rate",
+              "epic_get_loop_mode",
+              "epic_set_loop_mode",
+              "epic_get_playback_speed",
+              "epic_set_playback_speed",
+              "epic_get_playhead_frame",
+              "epic_set_playhead_frame",
+              "epic_is_playing",
+              "epic_pause",
+              "epic_play",
+              "epic_refresh_sequence",
+              "epic_close_sequence",
+              "epic_open_sequence",
+              "epic_get_focused_sequence",
+              "epic_get_current_sequence",
+              "epic_create_level_sequence",
+              "epic_get_keys_by_index",
+              "epic_bake_channel_keys",
+              "epic_is_curve_shown",
+              "epic_show_curve",
+              "epic_curve_editor_empty_selection",
+              "epic_curve_editor_select_keys",
+              "epic_get_curve_editor_selected_keys",
+              "epic_get_selected_key_channels",
+              "epic_is_curve_editor_open",
+              "epic_close_curve_editor",
+              "epic_open_curve_editor",
+              "epic_select_channels",
+              "epic_get_selected_channels",
+              "epic_get_default_value",
+              "epic_set_default_value",
+              "epic_remove_key_at_frame",
+              "epic_get_keys",
+              "epic_add_key_string",
+              "epic_add_key_integer",
+              "epic_add_key_bool",
+              "epic_add_key_float",
+              "epic_get_channel_names",
+              "epic_set_anim_mode_local_spaces",
+              "epic_get_anim_mode_local_spaces",
+              "epic_set_anim_mode_only_rig_sel",
+              "epic_get_anim_mode_only_rig_sel",
+              "epic_set_anim_mode_hide_manips",
+              "epic_get_anim_mode_hide_manips",
+              "epic_set_anim_mode_nulls",
+              "epic_get_anim_mode_nulls",
+              "epic_set_anim_mode_hierarchy",
+              "epic_get_anim_mode_hierarchy",
+              "epic_set_anim_mode_gizmo_scale",
+              "epic_get_anim_mode_gizmo_scale",
+              "epic_get_transform",
+              "epic_set_transform",
+              "epic_get_controls_info",
+              "epic_get_control_rigs",
+              "epic_find_or_create_track",
+              "epic_import_fbx_to_rig",
+              "epic_export_fbx_from_rig",
+              "epic_frame_selection",
+              "epic_clear_selection",
+              "epic_select_control",
+              "epic_get_selected_controls",
+              "epic_zero_transforms",
+              "epic_mirror_selected_controls",
+              "epic_select_mirrored_controls",
+              "epic_merge_anim_layers",
+              "epic_reorder_anim_layers",
+              "epic_duplicate_anim_layer",
+              "epic_delete_anim_layer",
+              "epic_add_layer_from_selection",
+              "epic_get_anim_layers",
+              "epic_snap_control_rig",
+              "epic_blend_values_on_selected",
+              "epic_tween_control_rig",
+              "epic_bake_space",
+              "epic_delete_space",
+              "epic_move_space",
+              "epic_set_space",
+              "epic_is_fk_control_rig",
+              "epic_set_priority_order",
+              "epic_get_priority_order",
+              "epic_set_layered_mode",
+              "epic_is_layered_control_rig",
+              "epic_hide_all_controls",
+              "epic_show_all_controls",
+              "epic_set_controls_mask",
+              "epic_get_controls_mask",
+              "epic_collapse_anim_layers",
+              "epic_load_anim_into_rig",
+              "epic_bake_to_control_rig",
+              "epic_key_controls_at_frames",
+              "epic_key_controls",
+              "epic_get_actor_transform_at_frame",
+              "epic_set_world_transform",
+              "epic_get_world_transform",
+              "epic_set_euler_transform",
+              "epic_get_euler_transform",
+              "epic_set_scale",
+              "epic_get_scale",
+              "epic_set_rotator",
+              "epic_get_rotator",
+              "epic_set_position",
+              "epic_get_position",
+              "epic_set_vector2d",
+              "epic_get_vector2d",
+              "epic_set_int",
+              "epic_get_int",
+              "epic_set_bool",
+              "epic_get_bool",
+              "epic_set_float",
+              "epic_get_float",
+              "epic_get_sections_for_nodes",
+              "epic_get_pinned_nodes",
+              "epic_set_node_pinned",
+              "epic_get_locked_nodes",
+              "epic_set_node_locked",
+              "epic_get_deactivated_nodes",
+              "epic_set_node_deactivated",
+              "epic_get_soloed_nodes",
+              "epic_get_muted_nodes",
+              "epic_set_node_solo",
+              "epic_set_node_muted",
+              "epic_is_node_expanded",
+              "epic_set_node_expanded",
+              "epic_get_node_label",
+              "epic_set_outliner_selection",
+              "epic_get_outliner_selection",
+              "epic_get_outliner_children",
+              "epic_get_outliner_tree",
+              "epic_clear_track_row_condition",
+              "epic_set_track_row_condition",
+              "epic_get_track_row_condition",
+              "epic_clear_track_condition",
+              "epic_set_track_condition",
+              "epic_get_track_condition",
+              "epic_clear_section_condition",
+              "epic_set_section_condition",
+              "epic_get_section_condition",
+              "epic_save_default_spawnable_state",
+              "epic_change_actor_template_class",
+              "epic_get_custom_bindings_of_type",
+              "epic_get_custom_binding_objects",
+              "epic_get_custom_binding_type",
+              "epic_convert_to_custom_binding",
+              "epic_convert_to_possessable",
+              "epic_convert_to_spawnable",
+              "epic_get_linked_level_sequence",
+              "epic_get_linked_anim_sequences",
+              "epic_link_anim_sequence",
+              "epic_export_anim_sequence",
+              "epic_import_fbx",
+              "epic_export_fbx"
+            ],
+            "type": "string"
+          },
+          "actorLabel": {
+            "description": "Actor label for live skeletal queries",
+            "type": "string"
+          },
+          "addDefaultChannels": {
+            "description": "create_pose_search_schema: add Trajectory+Pose default channels (default true)",
+            "type": "boolean"
+          },
+          "animAssetPath": {
+            "description": "Path to animation sequence or blendspace",
+            "type": "string"
+          },
+          "animPath": {
+            "description": "compare_curves_to_morph_targets: AnimSequence or PoseAsset path (#656)",
+            "type": "string"
+          },
+          "animPaths": {
+            "description": "batch_retarget_animations: AnimSequence paths to bake (#701)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "animSequencePath": {
+            "type": "string"
+          },
+          "animation": {
+            "description": "AnimSequence path for add_blend_sample / set_blend_sample",
+            "type": "string"
+          },
+          "assetPath": {
+            "type": "string"
+          },
+          "assetPaths": {
+            "description": "Asset paths (batch) for set_sequence_properties",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "autoMapChains": {
+            "description": "create_ik_retargeter: assign rigs to ops + AutoMapChains after creation (default true)",
+            "type": "boolean"
+          },
+          "axes": {
+            "description": "Axes to bake ('x','y','z') for bake_root_motion_from_bone",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "axis": {
+            "additionalProperties": {},
+            "description": "populate_blendspace: axis params for axis 0 (#459)",
+            "type": "object"
+          },
+          "axisHorizontal": {
+            "type": "string"
+          },
+          "axisIndex": {
+            "description": "populate_blendspace: axis index when using 'axis' on a 2D blendspace (#459)",
+            "type": "number"
+          },
+          "axisMax": {
+            "type": "number"
+          },
+          "axisMin": {
+            "type": "number"
+          },
+          "axisName": {
+            "description": "create_blendspace_1d axis display name (#459)",
+            "type": "string"
+          },
+          "axisVertical": {
+            "type": "string"
+          },
+          "baseCostBias": {
+            "description": "set_pose_search_database_settings: flat cost added to every pose",
+            "type": "number"
+          },
+          "binding": {
+            "description": "bind_anim_node_function: 'update' (default), 'becomeRelevant', or 'initialUpdate'",
+            "type": "string"
+          },
+          "blendDuration": {
+            "type": "number"
+          },
+          "blendIn": {
+            "type": "number"
+          },
+          "blendLogic": {
+            "description": "Standard or Inertialization",
+            "type": "string"
+          },
+          "blendOut": {
+            "type": "number"
+          },
+          "blendTime": {
+            "description": "add_motion_matching_node: inertial blend time",
+            "type": "number"
+          },
+          "blendspaceAxes": {
+            "description": "populate_blendspace: per-axis params array (alias for backwards-compat) (#459)",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "bodyComponent": {
+            "description": "rebind_leader_pose: explicit body component name",
+            "type": "string"
+          },
+          "boneName": {
+            "type": "string"
+          },
+          "boneNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "bones": {
+            "description": "add_pose_search_schema_pose_channel: [{bone, flags?, weight?}] or bone-name strings; also add_pose_search_schema_trajectory_channel reuses 'samples'",
+            "type": "array"
+          },
+          "chains": {
+            "description": "IK retarget chains for create_ik_rig",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "endBone": {
+                  "type": "string"
+                },
+                "goal": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "startBone": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "startBone",
+                "endBone"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "chooserPath": {
+            "description": "set_motion_matching_chooser: ChooserTable that selects the database",
+            "type": "string"
+          },
+          "clearExisting": {
+            "description": "populate_blendspace: clear existing samples before adding new ones (default true) (#459)",
+            "type": "boolean"
+          },
+          "clips": {
+            "description": "set_pose_search_clips: array of clip entries ({sequencePath, mirror?, disableReselection?, sampleStart?, sampleEnd?, enabled?}) or bare path strings",
+            "type": "array"
+          },
+          "componentName": {
+            "description": "SkeletalMeshComponent name (default: CharacterMesh0 / Mesh)",
+            "type": "string"
+          },
+          "connectToOutput": {
+            "description": "add_motion_matching_node: wire the node to the Output Pose (default true)",
+            "type": "boolean"
+          },
+          "contextSource": {
+            "description": "set_motion_matching_chooser: chooser context object - 'self' (anim instance, default) or 'pawn' (owning pawn)",
+            "type": "string"
+          },
+          "continuingPoseCostBias": {
+            "description": "set_pose_search_database_settings: bias to keep playing the current clip",
+            "type": "number"
+          },
+          "curveName": {
+            "description": "Curve name for add_curve",
+            "type": "string"
+          },
+          "curveType": {
+            "description": "Curve type (default: float)",
+            "type": "string"
+          },
+          "databasePath": {
+            "description": "add_motion_matching_node: PoseSearchDatabase the node searches",
+            "type": "string"
+          },
+          "databases": {
+            "description": "create_pose_search_normalization_set: PoseSearchDatabase paths to normalize together",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "directory": {
+            "type": "string"
+          },
+          "disableReselection": {
+            "description": "PoseSearch clip: disallow reselecting poses from the same asset",
+            "type": "boolean"
+          },
+          "enableRootMotion": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "description": "preview_animation: toggle on/off",
+            "type": "boolean"
+          },
+          "endPos": {
+            "description": "add_montage_segment: trim end inside the source animation (default: source play length)",
+            "type": "number"
+          },
+          "explicitTime": {
+            "description": "add_sequence_evaluator: initial ExplicitTime",
+            "type": "number"
+          },
+          "expressions": {
+            "description": "create_mirror_data_table: [{find, replace, method?}] find/replace bone-name rules",
+            "type": "array"
+          },
+          "forceRootLock": {
+            "type": "boolean"
+          },
+          "frameRate": {
+            "type": "number"
+          },
+          "frames": {
+            "description": "Specific frames to sample for read_bone_track",
+            "items": {
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "fromState": {
+            "type": "string"
+          },
+          "functionName": {
+            "description": "bind_anim_node_function: thread-safe anim-node function name to bind",
+            "type": "string"
+          },
+          "generateTrajectory": {
+            "description": "add_pose_history_node: self-generate trajectory (default true)",
+            "type": "boolean"
+          },
+          "graphName": {
+            "description": "Target graph name (default: AnimGraph). read_control_rig_graph: substring filter over model names (#774)",
+            "type": "string"
+          },
+          "gridNum": {
+            "type": "number"
+          },
+          "gridNumHorizontal": {
+            "type": "number"
+          },
+          "gridNumVertical": {
+            "type": "number"
+          },
+          "horizontalMax": {
+            "type": "number"
+          },
+          "horizontalMin": {
+            "type": "number"
+          },
+          "includeDefaults": {
+            "description": "read_control_rig_graph: include pin default values (default true) (#774)",
+            "type": "boolean"
+          },
+          "includeLinks": {
+            "description": "read_control_rig_graph: include pin-to-pin links (default true) (#774)",
+            "type": "boolean"
+          },
+          "includePins": {
+            "description": "read_control_rig_graph: include each node's pins (default true) (#774)",
+            "type": "boolean"
+          },
+          "includeTrackNames": {
+            "description": "Include full bone track name arrays in scan_animation_tracks results",
+            "type": "boolean"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "insertBeforeOutput": {
+            "description": "add_pose_history_node: splice into the pose chain feeding Output Pose (default true)",
+            "type": "boolean"
+          },
+          "insertIndex": {
+            "description": "add_montage_segment: position within the slot's segment list (default: append)",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "interpolation": {
+            "description": "bake_root_motion_from_bone: 'linear' (default) or 'per_frame'",
+            "type": "string"
+          },
+          "items": {
+            "description": "author_montages_batch: montage authoring specifications",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "animSequencePath": {
+                  "type": "string"
+                },
+                "blendIn": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "blendOut": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "notifies": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "notifyClass": {
+                        "type": "string"
+                      },
+                      "notifyName": {
+                        "type": "string"
+                      },
+                      "properties": {
+                        "additionalProperties": {},
+                        "type": "object"
+                      },
+                      "triggerTime": {
+                        "minimum": 0,
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "notifyName",
+                      "triggerTime"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "onConflict": {
+                  "enum": [
+                    "skip",
+                    "error"
+                  ],
+                  "type": "string"
+                },
+                "packagePath": {
+                  "type": "string"
+                },
+                "rateScale": {
+                  "type": "number"
+                },
+                "sections": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "linkedSection": {
+                        "type": "string"
+                      },
+                      "sectionName": {
+                        "type": "string"
+                      },
+                      "startTime": {
+                        "minimum": 0,
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "sectionName"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "sequenceLength": {
+                  "exclusiveMinimum": 0,
+                  "type": "number"
+                },
+                "slotName": {
+                  "type": "string"
+                },
+                "trackIndex": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name",
+                "animSequencePath"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "kdTreeQueryNumNeighbors": {
+            "description": "set_pose_search_database_settings: KD-tree neighbours to consider",
+            "type": "number"
+          },
+          "keyframes": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "frame": {
+                  "type": "number"
+                },
+                "location": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "x": {
+                      "type": "number"
+                    },
+                    "y": {
+                      "type": "number"
+                    },
+                    "z": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "x",
+                    "y",
+                    "z"
+                  ],
+                  "type": "object"
+                },
+                "rotation": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "w": {
+                      "type": "number"
+                    },
+                    "x": {
+                      "type": "number"
+                    },
+                    "y": {
+                      "type": "number"
+                    },
+                    "z": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "x",
+                    "y",
+                    "z",
+                    "w"
+                  ],
+                  "type": "object"
+                },
+                "scale": {
+                  "$ref": "#/properties/keyframes/items/properties/location"
+                }
+              },
+              "required": [
+                "frame"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "keys": {
+            "description": "set_anim_curve_keys: [{time, value, interp?}] keyframes",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "interp": {
+                  "type": "string"
+                },
+                "time": {
+                  "type": "number"
+                },
+                "value": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "time",
+                "value"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "limit": {
+            "description": "read_control_rig_graph: max nodes reported per graph (default 200) (#774)",
+            "type": "number"
+          },
+          "linkedSection": {
+            "description": "Next section name to link to",
+            "type": "string"
+          },
+          "loopCount": {
+            "description": "add_montage_segment: how many times the segment repeats (default 1)",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "loopingCostBias": {
+            "description": "set_pose_search_database_settings: bias for looping clips",
+            "type": "number"
+          },
+          "meshPath": {
+            "description": "Skeletal mesh path for set_ik_rig_mesh (#701)",
+            "type": "string"
+          },
+          "mirror": {
+            "description": "PoseSearch clip mirror option: 'original' | 'mirrored' | 'both'",
+            "type": "string"
+          },
+          "mirrorAxis": {
+            "description": "create_mirror_data_table: X, Y or Z (default X)",
+            "type": "string"
+          },
+          "mirrorDataTablePath": {
+            "description": "create_pose_search_schema: optional MirrorDataTable to bind",
+            "type": "string"
+          },
+          "mirrorRootMotion": {
+            "description": "create_mirror_data_table: mirror root motion (default true)",
+            "type": "boolean"
+          },
+          "modifierClass": {
+            "description": "apply_animation_modifier: UAnimationModifier subclass (short name e.g. 'DistanceCurveModifier' or /Script path)",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "negate": {
+            "description": "Negate the bool condition in set_transition_condition (#707)",
+            "type": "boolean"
+          },
+          "nodeClass": {
+            "description": "inspect_anim_nodes: node class substring filter, e.g. PoseDriver (#657)",
+            "type": "string"
+          },
+          "nodeGuid": {
+            "description": "bind_anim_node_function: target anim graph node GUID (from add_sequence_evaluator / add_*_node)",
+            "type": "string"
+          },
+          "normalizationSetPath": {
+            "description": "set_pose_search_database_settings: PoseSearchNormalizationSet to assign",
+            "type": "string"
+          },
+          "notifyClass": {
+            "type": "string"
+          },
+          "notifyName": {
+            "type": "string"
+          },
+          "notifyProperties": {
+            "additionalProperties": {},
+            "description": "add_notify: EditAnywhere fields to set on the spawned notify object (requires notifyClass)",
+            "type": "object"
+          },
+          "numFrames": {
+            "type": "number"
+          },
+          "numberOfPrincipalComponents": {
+            "description": "set_pose_search_database_settings: PCA components for PCAKDTree mode",
+            "type": "number"
+          },
+          "onConflict": {
+            "description": "Asset-creation conflict policy: skip (default) | error | overwrite",
+            "type": "string"
+          },
+          "outputPath": {
+            "description": "batch_retarget_animations: destination folder for baked assets (#701)",
+            "type": "string"
+          },
+          "overwrite": {
+            "description": "batch_retarget_animations: overwrite existing outputs (#701)",
+            "type": "boolean"
+          },
+          "packagePath": {
+            "type": "string"
+          },
+          "parentClass": {
+            "description": "Parent AnimInstance class name for create_anim_blueprint",
+            "type": "string"
+          },
+          "playRate": {
+            "description": "add_montage_segment: segment play rate, negative plays in reverse (default 1)",
+            "type": "number"
+          },
+          "poseCount": {
+            "description": "add_pose_history_node: number of history poses to retain",
+            "type": "number"
+          },
+          "poseSearchMode": {
+            "description": "set_pose_search_database_settings: bruteforce | pcakdtree | vptree | eventonly",
+            "type": "string"
+          },
+          "position": {
+            "additionalProperties": false,
+            "description": "BlendSpace sample position {x,y}",
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "prefix": {
+            "description": "batch_retarget_animations: output name prefix (#701)",
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {},
+            "description": "Property dict for set_sequence_properties",
+            "type": "object"
+          },
+          "props": {
+            "additionalProperties": {},
+            "description": "apply_animation_modifier: modifier EditAnywhere property values",
+            "type": "object"
+          },
+          "rateScale": {
+            "type": "number"
+          },
+          "recursive": {
+            "type": "boolean"
+          },
+          "resolveFromMontages": {
+            "description": "Resolve AnimMontage inputs to first anim reference (default true)",
+            "type": "boolean"
+          },
+          "retargetRoot": {
+            "description": "Retarget root bone name for IK Rig",
+            "type": "string"
+          },
+          "retargeterPath": {
+            "description": "IK Retargeter path (#701/#703)",
+            "type": "string"
+          },
+          "rigPath": {
+            "description": "IK Rig path for set_ik_rig_mesh / set_ik_retargeter_rig (#701/#703)",
+            "type": "string"
+          },
+          "rootBone": {
+            "description": "Root bone name for bake_root_motion_from_bone (default 'root')",
+            "type": "string"
+          },
+          "rootMotionRootLock": {
+            "description": "RefPose|AnimFirstFrame|Zero",
+            "type": "string"
+          },
+          "sampleEnd": {
+            "description": "PoseSearch clip sampling range end (seconds); [0,0] = whole clip",
+            "type": "number"
+          },
+          "sampleIndex": {
+            "description": "BlendSpace sample index for set_blend_sample",
+            "type": "number"
+          },
+          "sampleRate": {
+            "description": "create_pose_search_schema: schema sample rate (default 30)",
+            "type": "number"
+          },
+          "sampleStart": {
+            "description": "PoseSearch clip sampling range start (seconds); [0,0] = whole clip",
+            "type": "number"
+          },
+          "samples": {
+            "description": "populate_blendspace: [{animationPath, x, y?}] (#459)",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "samplingInterval": {
+            "description": "add_pose_history_node: seconds between history samples",
+            "type": "number"
+          },
+          "save": {
+            "description": "bake_keyframes_batch: save the asset after baking (default true)",
+            "type": "boolean"
+          },
+          "schemaPath": {
+            "description": "Path to a UPoseSearchSchema asset",
+            "type": "string"
+          },
+          "sectionName": {
+            "description": "Section name for add_montage_section",
+            "type": "string"
+          },
+          "segmentIndex": {
+            "description": "set_montage_sequence: replace only this segment index within the slot (#626). remove_montage_segment: segment to remove. add_montage_section: segment to anchor the section to (#826)",
+            "type": "number"
+          },
+          "sequenceLength": {
+            "type": "number"
+          },
+          "sequencePath": {
+            "description": "Animation asset path to add to a PoseSearchDatabase",
+            "type": "string"
+          },
+          "shouldLoop": {
+            "description": "add_sequence_evaluator: bShouldLoop",
+            "type": "boolean"
+          },
+          "side": {
+            "description": "source|target for retargeter rig/pose actions (#701/#703)",
+            "type": "string"
+          },
+          "skeletalMeshPath": {
+            "description": "Path to skeletal mesh for create_ik_rig / compare_curves_to_morph_targets (#656)",
+            "type": "string"
+          },
+          "skeletonPath": {
+            "type": "string"
+          },
+          "slotIndex": {
+            "type": "number"
+          },
+          "slotName": {
+            "description": "Slot name for set_montage_slot. add_montage_segment: target slot, created when absent. remove_montage_segment / list_montage_segments / add_montage_section: target slot (#826)",
+            "type": "string"
+          },
+          "sourceBone": {
+            "type": "string"
+          },
+          "sourceMesh": {
+            "description": "batch_retarget_animations: source skeletal mesh (#701)",
+            "type": "string"
+          },
+          "sourceRig": {
+            "description": "Source IKRig path for create_ik_retargeter",
+            "type": "string"
+          },
+          "space": {
+            "description": "Bone-space frame. get_bone_transforms (ref skeleton): 'local' (default) | 'component'. get_bone_transform (live actor): 'world' (default) | 'component' | 'local'",
+            "type": "string"
+          },
+          "startPos": {
+            "description": "add_montage_segment: trim start inside the source animation (default 0)",
+            "type": "number"
+          },
+          "startTime": {
+            "description": "Start time for montage section",
+            "type": "number"
+          },
+          "stateMachineName": {
+            "type": "string"
+          },
+          "stateName": {
+            "type": "string"
+          },
+          "suffix": {
+            "description": "batch_retarget_animations: output name suffix (#701)",
+            "type": "string"
+          },
+          "targetBone": {
+            "type": "string"
+          },
+          "targetMesh": {
+            "description": "batch_retarget_animations: target skeletal mesh (#701)",
+            "type": "string"
+          },
+          "targetRig": {
+            "description": "Target IKRig path for create_ik_retargeter",
+            "type": "string"
+          },
+          "targetTrackCount": {
+            "description": "Flag sequences with more than this many bone tracks",
+            "type": "number"
+          },
+          "teleportToExplicitTime": {
+            "description": "add_sequence_evaluator: bTeleportToExplicitTime (default false so time advances / root motion extracts)",
+            "type": "boolean"
+          },
+          "toState": {
+            "type": "string"
+          },
+          "trackIndex": {
+            "description": "Slot track index (default: 0)",
+            "type": "number"
+          },
+          "tracks": {
+            "description": "Per-bone keyframe arrays for bake_keyframes_batch (#540)",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "bone": {
+                  "type": "string"
+                },
+                "keyframes": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "frame": {
+                        "type": "number"
+                      },
+                      "location": {
+                        "$ref": "#/properties/keyframes/items/properties/location"
+                      },
+                      "rotation": {
+                        "$ref": "#/properties/keyframes/items/properties/rotation"
+                      },
+                      "scale": {
+                        "$ref": "#/properties/keyframes/items/properties/location"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "bone",
+                "keyframes"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "trajectoryHistoryCount": {
+            "description": "add_pose_history_node: generated trajectory history samples",
+            "type": "number"
+          },
+          "trajectoryPredictionCount": {
+            "description": "add_pose_history_node: generated trajectory prediction samples",
+            "type": "number"
+          },
+          "transitionGuid": {
+            "description": "Transition GUID selector for set_transition_condition (#707)",
+            "type": "string"
+          },
+          "triggerTime": {
+            "type": "number"
+          },
+          "useNormalizedRootMotionScale": {
+            "type": "boolean"
+          },
+          "variableName": {
+            "description": "Bool variable name for set_transition_condition (#707)",
+            "type": "string"
+          },
+          "verticalMax": {
+            "type": "number"
+          },
+          "verticalMin": {
+            "type": "number"
+          },
+          "virtualBoneName": {
+            "type": "string"
+          },
+          "wait": {
+            "description": "build_pose_search_index: block until the async build resolves (default true)",
+            "type": "boolean"
+          },
+          "weight": {
+            "description": "Channel weight for pose/trajectory channels",
+            "type": "number"
+          },
+          "world": {
+            "description": "World scope for live actor skeletal queries: auto (default, prefer PIE), pie/game, or editor",
+            "type": "string"
+          },
+          "x": {
+            "type": "number"
+          },
+          "y": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "animation"
+    },
+    {
+      "description": "Asset management: list, search, read, CRUD, import meshes/textures, datatables, stringtables.\n\nActions:\n- list: List assets via the AssetRegistry (sees /Game and every mounted plugin root). Paginated: returns totalMatched, offset, hasMore and nextOffset so a large folder can be walked deterministically instead of dropping the bridge on one oversized response (#790). Params: directory? (default /Game), classFilter?, recursive? (default true), maxResults? (default 500, max 5000), offset? (default 0)\n- search: Search by name/class/path. Params: query, directory?, maxResults?, searchAll?\n- read: Read asset via reflection. Params: assetPath\n- read_properties: Read asset properties with values. Blueprint paths resolve to the generated-class CDO (#568). propertyName accepts dotted/indexed paths into nested structs, array elements, and instanced subobjects (e.g. `Config.Traits[1].Params.Field`); landing on an array of subobjects also lists each element's index+class (#527). expandDepth inlines the properties of subobjects OWNED by this asset, so a data asset's nested payload comes back in ONE call instead of a reference you have to chase (#755); references to OTHER assets are marked expandable rather than followed, unless expandExternal=true. Capped by maxExpandedObjects with expansionTruncated reported. Params: assetPath, propertyName?, includeValues?, valueFormat?, expandDepth? (0-5, default 0), expandExternal?, maxExpandedObjects? (default 64)\n- list_properties: List reflected properties on any asset. Params: assetPath, includeValues?, valueFormat? ('text'|'json')\n- get_properties: Read property values on any asset. propertyName accepts dotted/indexed paths into nested structs, array elements, and instanced subobjects. valueFormat='json' returns structured values. Params: assetPath, propertyName?, includeValues?, valueFormat?\n- duplicate: Duplicate asset. Params: sourcePath, destinationPath\n- rename: Rename asset. Params: assetPath, newName (or sourcePath, destinationPath), force?. World Partition levels are detected and their __ExternalActors__/__ExternalObjects__ packages migrate atomically alongside the .umap, source-side redirectors get fixed up, and the active editor world is swapped to blank if it matches the source (#409). Refuses if any package is dirty - save first. If a prior rename left externals orphaned at the old path, re-running reconciles them. Rollback descriptor is emitted even on partial failure so the inverse rename can recover. `force=true` lets the call merge into a destination with pre-existing externals (used by rollback). For batches of 3+ scene-referenced non-world assets use bulk_rename instead.\n- bulk_rename: Batched rename using IAssetTools::RenameAssets - single transaction with one redirector-fixup pass (matches Content Browser drag). Use this over looped rename for scene-referenced assets. World assets are rejected (status=rejected_world); use rename_asset which handles WP externals atomically (#409). Params: renames[] where each entry is {sourcePath, destinationPath} OR {assetPath, newName}.\n- move: Move asset. Params: sourcePath, destinationPath\n- delete: Delete asset. On failure returns reason (open_in_editor / has_referencers / in_memory_referenced / package_read_only / package_dirty / unknown) plus referencers, inMemoryReferencers, packageReadOnly, packageDirty diagnostics (#601). Pass force=true to auto-close any open asset editors before deleting (#278). Params: assetPath, force?\n- delete_batch: Batch-delete assets. Per-path status (deleted/absent/failed) plus reason+referencers on failed entries (#278). Params: assetPaths[], force?\n- create_data_asset: Create UDataAsset instance of custom class. className accepts the C++ spelling with or without the A/U/F/E prefix (UMyConfig and MyConfig both resolve), a /Script/Module.ClassName path, or a loaded class name; a failed lookup lists the spellings tried and the closest matches (#823). Params: name, className, packagePath?, properties? (key/value map)\n- create_asset_by_class: Create an asset of ANY concrete UObject class (not just UDataAsset) - physical-material subclasses, curves, settings objects. className accepts the C++ spelling with or without the A/U/F/E prefix, a /Script/Module.ClassName path, or a loaded class name (#823). Params: name, className, packagePath?, properties? (key/value map), onConflict? (skip|replace|rename). Actors/components and specialized assets (Blueprint/Material) have dedicated actions (#726)\n- bulk_upsert_data_assets: Create or update up to 500 UDataAsset instances in ONE call. Every descriptor is first applied to a transient copy, so a bad class, property path, or value rejects the whole batch before a package is touched; nothing is half-written by a typo. Per-item status is created | updated | unchanged | skipped | failed (dryRun reports wouldCreate | wouldUpdate | wouldRemainUnchanged | wouldSkip), each with its own error when it failed. Replaying the same request returns unchanged, and only changed packages are saved. Emits a rollback descriptor that restores prior values and deletes what it created. Params: items[]: [{name, packagePath, className, properties?}], onConflict? (update (default) | skip | error), dryRun? (default false), save? (default true)\n- save: Save one asset, or every dirty asset under /Game when assetPath is omitted. force=true saves regardless of the dirty flag - several edits (OFPA level actors, some subsystem property writes) never mark their package dirty, so a dirty-only save skipped them and still reported success. Returns the package name plus on-disk file path, size and mtime so the write can be verified rather than trusted (#768). Params: assetPath?, force?\n- save_all_dirty: Flush every dirty package to disk in one call. Reports the packages it attempted, which ones reached disk (with file path, size and mtime) and which are still dirty afterwards, because a bare savedAll boolean has come back true while packages were never written (#768). Params: saveMapPackages? (default true), saveContentPackages? (default true)\n- set_mesh_material: Assign material to static mesh slot. Params: assetPath, materialPath, slotIndex?\n- set_mesh_materials_batch: Assign materials across many meshes and slots in one call, so an N mesh x M slot kit costs one round trip instead of N*M. StaticMesh and SkeletalMesh both work. Address a slot by slotName (survives a reimport reordering slot indices) or by slotIndex (default 0); passing both is rejected when they disagree. Every submitted assignment returns its own index/ok/status/error, status being ok|updated|unchanged|invalid|protected|duplicate|not_found|slot_not_found|failed|skipped. Default is all-or-nothing: any preflight rejection aborts before a mesh is touched. Pass continueOnError to apply the assignments that did pass and keep the rejects reported alongside them. Each mesh is written and saved once no matter how many of its slots the batch names, and the rollback payload restores only the writes that landed. Params: assignments ([{assetPath, materialPath, slotName? | slotIndex?}], max 500), save? (default true), dryRun? (default false), continueOnError? (default false) (#822)\n- recenter_pivot: Move static mesh pivot to geometry center. Params: assetPath OR assetPaths\n- import_static_mesh: Import from FBX, OBJ, or GLB/glTF (glTF routes through Interchange) (#549). importUniformScale=100 fixes metre-authored FBX (#687). Params: filePath, name?, packagePath?, combineMeshes?, importMaterials?, importTextures?, generateLightmapUVs?, importUniformScale?\n- import_skeletal_mesh: Import skeletal mesh from FBX. importUniformScale=100 fixes metre-authored FBX (Blender FBX_SCALE_ALL) that lands 100x too small on a cm skeleton (#687). Returns post-import readback: boxExtent, morphTargets[], numLODs, skeleton (#678). Params: filePath, name?, packagePath?, skeletonPath?, importMaterials?, importTextures?, importUniformScale? (default 1.0), importMorphTargets? (default true), createPhysicsAsset? (default false), replaceExisting? (default true)\n- import_animation: Import anim from FBX. Params: filePath, name?, packagePath?, skeletonPath\n- import_texture: Import image. sRGB/compressionSettings/lodGroup/neverStream are applied at import time (folded in, no second call needed) (#661). Params: filePath, name?, packagePath?, sRGB?, compressionSettings? (Default|Normalmap|Grayscale|HDR|BC7|...), lodGroup?, neverStream?\n- create_render_target_2d: Create and persist a TextureRenderTarget2D asset. Render format is applied before resource initialization. Params: name, packagePath? (default /Game), width? (1-8192, default 512), height? (1-8192, default 512), format? (R8|RG8|RGBA8|RGBA8_SRGB|R16F|RG16F|RGBA16F|R32F|RG32F|RGBA32F|RGB10A2, default RGBA8_SRGB), clearColor? ({r,g,b,a}, default transparent), generateMips? (default false), targetGamma? (default 0), onConflict? (skip|error)\n- read_cloth_data: Read Chaos cloth data on a skeletal mesh: per clothing asset, its configs (reflected properties), LOD count, and per-LOD point-weight-map summary (name, target, vertex count, min/max - including the MaxDistances mask). Params: skeletalMeshPath (#595)\n- set_cloth_config: Set properties on a clothing asset's Chaos cloth config via reflection. Params: skeletalMeshPath, properties (object), clothingAsset? (name filter), configType? (config class/key filter) (#595)\n- export_texture: Export a Texture2D to a PNG on disk (for inspection or external diffing). Params: assetPath, outputPath (.png) (#697)\n- compare_textures: Compare two Texture2D assets by dimensions, pixel format, and source-content identity (FTextureSource id) - tells you whether an authored texture actually changed without offline pixel-diffing. Params: assetPathA, assetPathB (#697)\n- import_texture_batch: Import many textures in one call - the loop stays inside the editor (no per-file bridge round-trip), so this finishes far faster than N import_texture calls. Per-item result records mirror import_texture. Params: items[]: [{filePath, packagePath?, name?, replaceExisting?}], packagePath? (default for items that don't set it), save? (default true), automated? (default true). Returns requested/imported/failed counts + items[] (#430)\n- reimport: Reimport asset from source file. Params: assetPath, filePath?\n- read_datatable: Read DataTable rows. Params: assetPath, rowFilter?\n- create_datatable: Create DataTable. Params: name, packagePath?, rowStruct\n- reimport_datatable: Reimport DataTable from JSON. Params: assetPath, jsonPath?, jsonString?\n- set_datatable_row: Append or overwrite a single DataTable row. Params: assetPath, rowName, row (object with row-struct fields - partial updates merge with the existing row). Idempotent; rollback restores the prior row (#437)\n- add_datatable_row: Alias for set_datatable_row (#437)\n- update_datatable_row: Alias for set_datatable_row; partial update merges with existing row (#437)\n- remove_datatable_row: Remove a single DataTable row. Idempotent (alreadyDeleted=true if missing). Params: assetPath, rowName (#437)\n- get_datatable_row: Read one DataTable row's fields without dumping the whole table. Params: assetPath, rowName (#535)\n- set_datatable_cell: Write a single field on a single existing row (merges, leaves other cells untouched). Errors if the row doesn't exist. Params: assetPath, rowName, fieldName, value (#535)\n- rename_datatable_row: Rename a row key, preserving its values. Params: assetPath, oldName, newName (#535)\n- fill_datatable_from_json: Bulk-upsert rows from a {rowName: {field: value}} object without touching unrelated rows (non-destructive, unlike reimport_datatable). Params: assetPath, rows (object) or jsonString (#535)\n- create_curvetable: Create CurveTable asset. Params: name, packagePath?, onConflict?\n- read_curvetable: Read CurveTable rows and keys. Params: assetPath, rowFilter?\n- list_curvetable_rows: Alias for read_curvetable. Params: assetPath, rowFilter?\n- import_curvetable: Import CurveTable from JSON/CSV string or file. Params: assetPath, jsonString?, csvString?, filePath?, format?, interpMode?\n- add_curvetable_row: Add CurveTable row. Params: assetPath, rowName, curveType? ('simple'|'rich'), interpMode?\n- remove_curvetable_row: Remove CurveTable row. Idempotent if missing. Params: assetPath, rowName\n- rename_curvetable_row: Rename CurveTable row. Params: assetPath, oldName, newName\n- get_curvetable_keys: Read keys from one CurveTable row. Params: assetPath, rowName\n- set_curvetable_keys: Replace keys on one CurveTable row. Params: assetPath, rowName, keys:[{time,value,interpMode?,arriveTangent?,leaveTangent?}]\n- add_curvetable_key: Add or update one key on a CurveTable row. Params: assetPath, rowName, time, value, interpMode?, keyTimeTolerance?\n- list_textures: List textures. Params: directory?, recursive?\n- get_texture_info: Get texture details. Params: assetPath\n- set_texture_settings: Set texture settings. Params: assetPath, settings (object with compressionSettings?, lodGroup?, sRGB?, neverStream?). Keys may also be passed at the top level.\n- create_stringtable: Create a StringTable asset. Params: name, packagePath?, namespace?, onConflict?\n- read_stringtable: Read StringTable entries and keys. Params: assetPath, keyFilter?\n- list_stringtable_keys: List StringTable keys. Params: assetPath, keyFilter?\n- get_stringtable_entry: Read one StringTable entry. Params: assetPath, key\n- set_stringtable_entry: Create or update one StringTable entry. Params: assetPath, key, sourceString (or value)\n- remove_stringtable_entry: Remove one StringTable entry. Idempotent (alreadyDeleted=true if missing). Params: assetPath, key\n- import_stringtable: Import StringTable entries from CSV. Params: assetPath, filePath (or csvPath)\n- add_input_mapping: Append an Enhanced Input key mapping to an InputMappingContext (InputAction + key by name string e.g. 'Mouse2D','LeftMouseButton'). Idempotent on (action,key). For modifiers/triggers use gameplay(set_mapping_modifiers). Same as gameplay(add_imc_mapping) (#525). Params: mappingContext (IMC path), inputAction (IA path), key\n- remove_input_mapping: Remove an IMC key mapping. Same as gameplay(remove_imc_mapping) (#525). Params: mappingContext (IMC path), mappingIndex? | (inputAction? + key?)\n- list_input_mappings: List an IMC's key->action bindings with triggers/modifiers. Same as gameplay(read_imc) (#525). Params: mappingContext (IMC path)\n- add_socket: Add socket to StaticMesh or SkeletalMesh. SkeletalMesh writes mesh-local sockets by default; pass a Skeleton asset path to edit skeleton-level sockets. Idempotent on socket name; pass onConflict='update' to overwrite an existing socket's transform with the supplied relativeLocation/relativeRotation/relativeScale (#412). Params: assetPath, socketName, boneName? (SkeletalMesh only, default 'root'), relativeLocation?, relativeRotation?, relativeScale?, onConflict? (skip\\|update\\|error, default skip)\n- remove_socket: Remove socket by name. Params: assetPath, socketName\n- list_sockets: List sockets on a mesh (StaticMesh or SkeletalMesh). SkeletalMesh results include mesh-local sockets plus assigned Skeleton sockets, each with source='mesh' or source='skeleton'. Params: assetPath\n- set_socket_transform: Update an existing socket's relative transform on StaticMesh or SkeletalMesh. Pass any subset of relativeLocation/relativeRotation/relativeScale; omitted fields stay at their current values. Errors if the socket does not exist (use add_socket to create). Common after FBX import when SOCKET_* empties land with scale=(100,100,100) (#412). Params: assetPath, socketName, relativeLocation?, relativeRotation?, relativeScale?\n- set_property: Set a UPROPERTY on any loaded asset (Material, DataAsset, DataTable, SubsurfaceProfile, etc.) using a dotted path. Blueprint paths resolve to the generated-class CDO so you can author its defaults + Instanced sub-object arrays (#568). Walks nested structs, array elements by index, and instanced subobjects internally - no more read-modify-write copies (e.g. `settings.mean_free_path_distance` on a UMaterial, or `Config.Traits[1].Params.Field` on a config asset #527). Value goes through MCPJsonProperty::SetJsonOnProperty so JSON null clears object refs, structs accept {x,y,z}, arrays/maps round-trip. TMap values take { \"Key\": value } or, for struct keys, [{ key: {...}, value: ... }]; a write that cannot store every entry fails and leaves the old value untouched (#820). Params: assetPath, propertyName (dotted path), value (#420)\n- append_array_elements: Append one or more JSON values to a reflected TArray without replacing existing entries. Supports dotted property paths plus native and user-defined USTRUCT elements. All elements are validated before mutation; returns appended indices and rollback data, and leaves the package dirty without saving. Params: assetPath, propertyName, elements\n- bulk_set_properties: Set dotted UPROPERTY paths on as many as 500 assets in one preflighted batch. Every asset, path, and value is validated before anything is mutated, and every submitted item comes back with its own ok/status/error, so a bad path in item 300 never hides the other 499 verdicts. Default is all-or-nothing: any preflight rejection aborts before a single UObject is touched. Pass continueOnError to apply the items that did pass and keep the rejects reported alongside them. Returns per-property readback, aggregate counts, targeted save results, and a replayable rollback payload covering only the writes that landed. Params: items ([{assetPath, properties}]), save? (default true), dryRun? (default false), continueOnError? (default false)\n- set_texture_settings_by_type: Apply the canonical (compressionSettings, sRGB, LOD group) combo to every texture in each group: normal -> Normalmap, grayscale -> Grayscale, baseColor -> Default sRGB, hdr -> HDR. Params: groups (object: {normal?:[paths], grayscale?:[paths], baseColor?:[paths], hdr?:[paths]}) (#421)\n- create_interchange_pipeline: One-call factory for a UInterchangeGenericAssetsPipeline asset with the 15-property mesh-import boilerplate already applied (RecomputeNormals=false, MikkTSpace=true, HighPrecisionTangents=true, BuildNanite=false, CreatePhysicsAsset=false, etc.). Params: assetPath OR (name + packagePath?), meshType? (skeletal default | static), options? (dotted-path overrides on the resulting pipeline e.g. {'MeshPipeline.bBuildNanite': true}), onConflict? (#421)\n- reload_package: Force reload an asset package from disk. Params: assetPath\n- health_check: Diagnose stuck-unloadable asset. Returns onDisk/inRegistry/isLoaded/canLoad/isStuck flags so an agent can detect the half-shutdown state where load returns null but the file exists (#279). Params: assetPath\n- force_reload: Aggressive reload from disk: closes open editors, reloads the package (rebuilding a Blueprint's class and CDO so container properties come back fresh, not just scalars), and reports objectReplaced. Refuses a dirty package unless discardUnsaved=true, and fails loudly when the editor would not release the old object rather than serving stale values (#279/#820). Params: assetPath, discardUnsaved? (default false)\n- export: Export asset to disk file (Texture2D → PNG, StaticMesh → FBX, etc.). Params: assetPath, outputPath\n- search_fts: Ranked asset search (token-scored over name/class/path). Params: query, maxResults?, classFilter?\n- reindex_fts: Rebuild the SQLite FTS5 asset index. Params: directory?\n- get_referencers: Reverse dependency lookup (what references this). Params: packages[] OR packagePath (#150). Returns {referencersByPackage, totalReferencers}.\n- get_dependencies: Forward dependency lookup (what packages this asset references). Params: packages[] OR packagePath, hard? (default true), soft? (default true) (#588). Returns {dependenciesByPackage, totalDependencies}.\n- list_skeleton_bones: List bones (names + rest-pose local and component-space transforms) from a SkeletalMesh or Skeleton asset, no live actor needed. Params: assetPath, includeTransforms? (default true) (#593). Returns {bones, boneCount, sourceKind}.\n- get_primary_asset_ids: Enumerate AssetManager-registered FPrimaryAssetIds (verify a primary-asset registration). Params: type? (FPrimaryAssetType; omit for all types), maxResults? (default 1000) (#579). Returns {primaryAssetIds:[{primaryAssetId, type, name, assetPath}], count, total}.\n- set_sk_material_slots: Set materials on a USkeletalMesh by slot name or slotIndex (bypasses the blueprint override-materials path that UE's ICH silently reverts). Params: assetPath, slots[{slotName?|slotIndex?, materialPath}]\n- diagnose_registry: Scan a content path and compare disk vs AssetRegistry (including in-memory pending-kill entries). Returns onDiskCount, inMemoryIncludedCount, ghostCount and paths. Params: path, recursive? (default true), reconcile? (forceRescan=true)\n- get_mesh_bounds: Get StaticMesh OR SkeletalMesh bounding box. Params: assetPath. Returns min, max, boxExtent, boxCenter, meshKind (#193/#351)\n- get_mesh_info: One-call mesh QA: bounds + material slots + skeleton + LOD/vertex counts. Works for both UStaticMesh and USkeletalMesh. Params: assetPath. Returns meshKind, boundsOrigin, boundsExtent, heightM, lodCount, vertexCount, skeletonPath (skeletal only), materialSlots:[{index, slotName, materialPath, isDefaultFallback}], materialCount (#431)\n- read_import_sources: Read AssetImportData source filenames on an imported asset (StaticMesh, SkeletalMesh, Texture, Animation, etc.). Returns sources[] of {relativeFilename, absolutePath, timestamp, fileHash, displayLabelName}. Params: assetPath (#270)\n- get_mesh_collision: Inspect StaticMesh collision setup. Params: assetPath. Returns collisionTraceFlag, hasSimple/ComplexCollision, element counts (#177)\n- migrate: Copy assets and their dependencies into ANOTHER project's Content directory - the scripted form of the content browser's Migrate (#760). destinationContentDir is the TARGET project's Content folder. While this server drives more than one editor, a 'toEditor' parameter is offered as well: name the destination editor and its Content folder is resolved for you and its asset registry rescanned afterwards, so the assets are visible there without a manual rescan (#817). The call runs in the editor holding the SOURCE assets, so it pushes assets out of the project it is attached to. Unsaved or never-saved assets are refused, because migrate copies files and would otherwise silently omit your edits. Every asset is resolved before anything is copied, and the destination is checked for the packages afterwards rather than reporting success on the call returning. Params: assetPaths (string[]) or assetPath, toEditor OR destinationContentDir, includeDependencies? (default true), onConflict? (skip|overwrite, default skip), allowDirty?, dryRun?\n- move_folder: Move/rename entire content folder with redirector fixup in one transaction. Params: sourcePath, destinationPath (#192)\n- create_folder: Create empty content browser folder(s). Params: path OR paths[] (e.g. /Game/Foo, /Game/Bar/Baz). Returns per-path created/existed/failed (#212)\n- delete_folder: Delete content browser folder(s) - counterpart to delete_asset, which leaves the parent directory entry behind as an orphan. Empty folders only by default; pass force=true to also delete any assets still inside (Content Browser 'Delete folder' equivalent). Per-path status (deleted/absent/failed) with reason (invalid_path/protected_path/not_empty/delete_failed) and a sample of contained assets on not_empty entries. Params: path OR paths[], force?\n- set_mesh_nav: Set StaticMesh nav contribution. Params: assetPath, bHasNavigationData?, clearNavCollision? (#167)\n- create_user_defined_enum: Create a UserDefinedEnum content asset, optionally pre-populated with values. Params: name, packagePath? (default /Game), values? ([display-name strings]), onConflict? (#686)\n- list_enum_values: List a UEnum's enumerators (index, authored short name, display name, value). Works on native and UserDefinedEnum assets. Params: assetPath (#686)\n- edit_user_defined_enum: Author a UserDefinedEnum content asset. op=add_value appends an enumerator (authored name is auto-assigned; pass displayName - or name - to set the editable display text). op=rename_value sets a new displayName on the enumerator resolved by index or name (matches short or display name). op=remove_value deletes it. Recompiles dependents automatically. Native UEnums are not editable. Params: assetPath, op (add_value|rename_value|remove_value), displayName?, name?, index? (#686)\n- create_user_defined_struct: Create a UserDefinedStruct content asset, optionally pre-populated with fields. Each field is {name, type} where type is a MakePinType string (bool|int|int64|float|string|name|text|byte, a struct like Vector, an enum, or an object ref like Actor). Params: name, packagePath? (default /Game), structFields? ([{name, type}]), onConflict? (#735)\n- list_struct_fields: List a UserDefinedStruct's members (index, internal name, friendly/display name, GUID, type label). Use this to find the GUID for a stable rename/retype. Native structs are not editable. Params: assetPath (#735)\n- edit_user_defined_struct: Author a UserDefinedStruct content asset. op=add_field appends a member (type via MakePinType string; pass fieldName for its display name). op=rename_field sets a new newDisplayName on the member resolved by fieldGuid or fieldName - the member GUID is preserved so existing Blueprint pins and DataTable rows survive. op=set_field_type changes a member's type. op=remove_field deletes it. Recompiles dependents automatically. Native structs are not editable. Params: assetPath, op (add_field|rename_field|set_field_type|remove_field), fieldName?, fieldGuid?, newDisplayName?, type? (#735)\n- rename_struct_field: Rename a UserDefinedStruct field's display name while preserving its member GUID, so Blueprint pins and DataTable rows keyed off it survive. Convenience wrapper over edit_user_defined_struct(op=rename_field). Resolve the field by fieldGuid or fieldName (matches friendly or internal name). Params: assetPath, fieldName | fieldGuid, newDisplayName (#735)\n- lock: Acquire an exclusive lock on an asset for this editor. Returns acquired=true, or acquired=false with holder{sessionId,ttlSecondsRemaining} when another session holds it. Params: assetPath, ttlSeconds? (default 300), sessionId?\n- unlock: Release an asset lock held by this editor (or force=true to break any holder's lock). Params: assetPath, force?, sessionId?\n- list_locks: List all currently-held asset locks with holder session id, acquiredAt, and ttlSecondsRemaining.\n- unlock_all: Release every lock held by one session in a single call, returning the number released. Defaults to the addressed editor's own session; pass sessionId to clear a different one (for example after a crashed session left assets wedged). Params: sessionId?\n- diff: Semantic structural diff between two assets of any type, dispatching on the asset's class. Blueprints are diffed structurally (parent class, variables, functions, components, per-graph node and connection deltas); other asset types report that diffing is not supported yet rather than failing opaquely. Params: assetPath, otherPath\n\nEpic 5.8 toolset actions (76): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "list",
+              "search",
+              "read",
+              "read_properties",
+              "list_properties",
+              "get_properties",
+              "duplicate",
+              "rename",
+              "bulk_rename",
+              "move",
+              "delete",
+              "delete_batch",
+              "create_data_asset",
+              "create_asset_by_class",
+              "bulk_upsert_data_assets",
+              "save",
+              "save_all_dirty",
+              "set_mesh_material",
+              "set_mesh_materials_batch",
+              "recenter_pivot",
+              "import_static_mesh",
+              "import_skeletal_mesh",
+              "import_animation",
+              "import_texture",
+              "create_render_target_2d",
+              "read_cloth_data",
+              "set_cloth_config",
+              "export_texture",
+              "compare_textures",
+              "import_texture_batch",
+              "reimport",
+              "read_datatable",
+              "create_datatable",
+              "reimport_datatable",
+              "set_datatable_row",
+              "add_datatable_row",
+              "update_datatable_row",
+              "remove_datatable_row",
+              "get_datatable_row",
+              "set_datatable_cell",
+              "rename_datatable_row",
+              "fill_datatable_from_json",
+              "create_curvetable",
+              "read_curvetable",
+              "list_curvetable_rows",
+              "import_curvetable",
+              "add_curvetable_row",
+              "remove_curvetable_row",
+              "rename_curvetable_row",
+              "get_curvetable_keys",
+              "set_curvetable_keys",
+              "add_curvetable_key",
+              "list_textures",
+              "get_texture_info",
+              "set_texture_settings",
+              "create_stringtable",
+              "read_stringtable",
+              "list_stringtable_keys",
+              "get_stringtable_entry",
+              "set_stringtable_entry",
+              "remove_stringtable_entry",
+              "import_stringtable",
+              "add_input_mapping",
+              "remove_input_mapping",
+              "list_input_mappings",
+              "add_socket",
+              "remove_socket",
+              "list_sockets",
+              "set_socket_transform",
+              "set_property",
+              "append_array_elements",
+              "bulk_set_properties",
+              "set_texture_settings_by_type",
+              "create_interchange_pipeline",
+              "reload_package",
+              "health_check",
+              "force_reload",
+              "export",
+              "search_fts",
+              "reindex_fts",
+              "get_referencers",
+              "get_dependencies",
+              "list_skeleton_bones",
+              "get_primary_asset_ids",
+              "set_sk_material_slots",
+              "diagnose_registry",
+              "get_mesh_bounds",
+              "get_mesh_info",
+              "read_import_sources",
+              "get_mesh_collision",
+              "migrate",
+              "move_folder",
+              "create_folder",
+              "delete_folder",
+              "set_mesh_nav",
+              "create_user_defined_enum",
+              "list_enum_values",
+              "edit_user_defined_enum",
+              "create_user_defined_struct",
+              "list_struct_fields",
+              "edit_user_defined_struct",
+              "rename_struct_field",
+              "lock",
+              "unlock",
+              "list_locks",
+              "unlock_all",
+              "diff",
+              "epic_list_runtime_sources",
+              "epic_list_registries",
+              "epic_list_items",
+              "epic_list_data_sources",
+              "epic_get_schema",
+              "epic_get_registry_info",
+              "epic_get_items",
+              "epic_search",
+              "epic_find_similar",
+              "epic_write_file",
+              "epic_read_file",
+              "epic_get_plugin_content_paths",
+              "epic_get_dependencies",
+              "epic_get_referencers",
+              "epic_is_checked_out",
+              "epic_can_edit_asset",
+              "epic_is_dirty",
+              "epic_save_assets",
+              "epic_load_asset",
+              "epic_update_metadata_tags",
+              "epic_get_metadata_tags",
+              "epic_get_asset_class",
+              "epic_get_asset_tags",
+              "epic_find_assets",
+              "epic_delete",
+              "epic_move",
+              "epic_duplicate",
+              "epic_exists",
+              "epic_list_folders",
+              "epic_create_folder",
+              "epic_get_keys",
+              "epic_set_keys",
+              "epic_add_key",
+              "epic_rename_row",
+              "epic_remove_row",
+              "epic_add_row",
+              "epic_list_rows",
+              "epic_create",
+              "epic_import_file",
+              "epic_create__data_asset_tools",
+              "epic_set_rows",
+              "epic_get_rows",
+              "epic_rename_rows",
+              "epic_remove_rows",
+              "epic_add_rows",
+              "epic_list_rows__data_table_tools",
+              "epic_get_schema__data_table_tools",
+              "epic_create__data_table_tools",
+              "epic_import_file__data_table_tools",
+              "epic_search_row_structs",
+              "epic_set_nanite_enabled",
+              "epic_is_nanite_enabled",
+              "epic_remove_collisions",
+              "epic_generate_convex_collisions",
+              "epic_remove_lods",
+              "epic_generate_lods",
+              "epic_set_lod_thresholds",
+              "epic_get_lod_thresholds",
+              "epic_set_material",
+              "epic_get_material",
+              "epic_get_material_slots",
+              "epic_get_bounds",
+              "epic_get_vertex_count",
+              "epic_get_triangle_count",
+              "epic_get_lod_count",
+              "epic_import_file__static_mesh_tools",
+              "epic_remove_entry",
+              "epic_set_entry",
+              "epic_get_entry",
+              "epic_list_keys",
+              "epic_get_namespace",
+              "epic_get_table_id",
+              "epic_create__string_table_tools",
+              "epic_import_file__string_table_tools",
+              "epic_get_size",
+              "epic_import_file__texture_tools"
+            ],
+            "type": "string"
+          },
+          "allowDirty": {
+            "description": "migrate: migrate the on-disk version of an asset with unsaved edits (#760)",
+            "type": "boolean"
+          },
+          "assetPath": {
+            "description": "Asset path",
+            "type": "string"
+          },
+          "assetPathA": {
+            "description": "compare_textures: first texture (#697)",
+            "type": "string"
+          },
+          "assetPathB": {
+            "description": "compare_textures: second texture (#697)",
+            "type": "string"
+          },
+          "assetPaths": {
+            "description": "Array of asset paths (recenter_pivot batch - first mesh sets reference pivot; also migrate)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "assignments": {
+            "description": "set_mesh_materials_batch entries: [{assetPath, materialPath, slotName? | slotIndex?}] (max 500). slotName is preferred for imported kits because slot indices are not stable across reimports",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "assetPath": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "materialPath": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "slotIndex": {
+                  "type": "integer"
+                },
+                "slotName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "assetPath",
+                "materialPath"
+              ],
+              "type": "object"
+            },
+            "maxItems": 500,
+            "minItems": 1,
+            "type": "array"
+          },
+          "automated": {
+            "description": "import_texture_batch: bypass interactive dialogs (default true)",
+            "type": "boolean"
+          },
+          "bHasNavigationData": {
+            "description": "Toggle nav data generation for set_mesh_nav",
+            "type": "boolean"
+          },
+          "boneName": {
+            "description": "Bone name (for skeletal mesh sockets)",
+            "type": "string"
+          },
+          "classFilter": {
+            "description": "Restrict search_fts to assets whose class name contains this substring",
+            "type": "string"
+          },
+          "className": {
+            "description": "Class for create_data_asset/create_asset_by_class: loaded class name with or without the C++ A/U/F/E prefix, or a /Script/Module.ClassName path",
+            "type": "string"
+          },
+          "clearColor": {
+            "additionalProperties": false,
+            "description": "create_render_target_2d: linear clear color (default transparent)",
+            "properties": {
+              "a": {
+                "type": "number"
+              },
+              "b": {
+                "type": "number"
+              },
+              "g": {
+                "type": "number"
+              },
+              "r": {
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "clearNavCollision": {
+            "description": "Remove NavCollision from mesh for set_mesh_nav",
+            "type": "boolean"
+          },
+          "clothingAsset": {
+            "description": "set_cloth_config: clothing asset name filter (#595)",
+            "type": "string"
+          },
+          "combineMeshes": {
+            "description": "Combine all meshes in FBX into one (default false - imports as separate assets)",
+            "type": "boolean"
+          },
+          "compressionSettings": {
+            "description": "Texture compression: Default, Normalmap, Grayscale, Displacementmap, VectorDisplacementmap, HDR, EditorIcon, Alpha, DistanceFieldFont, HDR_Compressed, BC7",
+            "type": "string"
+          },
+          "configType": {
+            "description": "set_cloth_config: config class/key filter (#595)",
+            "type": "string"
+          },
+          "continueOnError": {
+            "description": "bulk_set_properties / set_mesh_materials_batch: apply the items that passed preflight instead of aborting the whole batch (default false). Rejected items are still reported in items[]",
+            "type": "boolean"
+          },
+          "createPhysicsAsset": {
+            "description": "import_skeletal_mesh: auto-create a PhysicsAsset (default false) (#678)",
+            "type": "boolean"
+          },
+          "csvPath": {
+            "description": "StringTable CSV import path",
+            "type": "string"
+          },
+          "csvString": {
+            "description": "CurveTable CSV payload for import_curvetable",
+            "type": "string"
+          },
+          "curveType": {
+            "description": "CurveTable row type",
+            "enum": [
+              "simple",
+              "rich"
+            ],
+            "type": "string"
+          },
+          "data": {
+            "additionalProperties": {},
+            "description": "Alias for row in set_datatable_row",
+            "type": "object"
+          },
+          "destinationContentDir": {
+            "description": "migrate: the TARGET project's Content folder (#760)",
+            "type": "string"
+          },
+          "destinationPath": {
+            "type": "string"
+          },
+          "directory": {
+            "type": "string"
+          },
+          "discardUnsaved": {
+            "description": "force_reload: reload even though the package has unsaved changes, discarding them (default false) (#820)",
+            "type": "boolean"
+          },
+          "displayName": {
+            "description": "edit_user_defined_enum: display text for the enumerator",
+            "type": "string"
+          },
+          "dryRun": {
+            "description": "migrate: resolve and report without copying (#760). bulk_upsert_data_assets: run the full preflight and report planned statuses without writing",
+            "type": "boolean"
+          },
+          "elements": {
+            "description": "append_array_elements: one or more values to append after full prevalidation",
+            "items": {},
+            "minItems": 1,
+            "type": "array"
+          },
+          "expandDepth": {
+            "description": "read_properties: inline owned subobjects to this depth (default 0) (#755)",
+            "maximum": 5,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "expandExternal": {
+            "description": "read_properties: also follow references to other assets (default false) (#755)",
+            "type": "boolean"
+          },
+          "exportName": {
+            "type": "string"
+          },
+          "fieldGuid": {
+            "description": "edit_user_defined_struct/rename_struct_field: resolve a field by its member GUID (stable across renames)",
+            "type": "string"
+          },
+          "fieldName": {
+            "description": "DataTable field/column name for set_datatable_cell (#535); also resolves a UserDefinedStruct member by friendly/internal name for edit_user_defined_struct/rename_struct_field, or names the new member for add_field (#735)",
+            "type": "string"
+          },
+          "fields": {
+            "additionalProperties": {},
+            "description": "Alias for row in set_datatable_row",
+            "type": "object"
+          },
+          "filePath": {
+            "description": "Absolute file path for imports",
+            "type": "string"
+          },
+          "force": {
+            "description": "delete / delete_batch: auto-close any open asset editors before deleting (#278). delete_folder: also delete assets contained in the folder. save: write even if the package is not marked dirty (#768).",
+            "type": "boolean"
+          },
+          "format": {
+            "description": "CurveTable import format or create_render_target_2d pixel format",
+            "enum": [
+              "json",
+              "csv",
+              "R8",
+              "RG8",
+              "RGBA8",
+              "RGBA8_SRGB",
+              "R16F",
+              "RG16F",
+              "RGBA16F",
+              "R32F",
+              "RG32F",
+              "RGBA32F",
+              "RGB10A2"
+            ],
+            "type": "string"
+          },
+          "generateLightmapUVs": {
+            "type": "boolean"
+          },
+          "generateMips": {
+            "description": "create_render_target_2d: automatically generate mipmaps (default false)",
+            "type": "boolean"
+          },
+          "groups": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "description": "set_texture_settings_by_type: { normal?: [...], grayscale?: [...], baseColor?: [...], hdr?: [...] }",
+            "type": "object"
+          },
+          "hard": {
+            "description": "get_dependencies: include hard dependencies (default true)",
+            "type": "boolean"
+          },
+          "height": {
+            "description": "create_render_target_2d: pixel height, 1-8192 (default 512)",
+            "maximum": 8192,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "imcPath": {
+            "type": "string"
+          },
+          "importMaterials": {
+            "type": "boolean"
+          },
+          "importMorphTargets": {
+            "description": "import_skeletal_mesh: import morph targets (default true) (#678)",
+            "type": "boolean"
+          },
+          "importTextures": {
+            "type": "boolean"
+          },
+          "importUniformScale": {
+            "description": "import_skeletal_mesh: FBX uniform scale; pass 100 for metre-authored FBX (#687)",
+            "type": "number"
+          },
+          "includeDependencies": {
+            "description": "migrate: also copy referenced assets (default true) (#760)",
+            "type": "boolean"
+          },
+          "includeTransforms": {
+            "description": "list_skeleton_bones: include rest-pose transforms (default true)",
+            "type": "boolean"
+          },
+          "includeValues": {
+            "description": "Include property values in read_properties/list_properties/get_properties",
+            "type": "boolean"
+          },
+          "index": {
+            "description": "edit_user_defined_enum: enumerator index for rename/remove",
+            "type": "number"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputAction": {
+            "description": "InputAction asset path for add_input_mapping (#525)",
+            "type": "string"
+          },
+          "inputActionPath": {
+            "type": "string"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "interpMode": {
+            "description": "CurveTable interpolation mode",
+            "enum": [
+              "linear",
+              "constant",
+              "cubic",
+              "none"
+            ],
+            "type": "string"
+          },
+          "items": {
+            "description": "Batch entries: import_texture_batch takes {filePath, packagePath?, name?, replaceExisting?}; bulk_set_properties takes {assetPath, properties}; bulk_upsert_data_assets takes {name, packagePath, className, properties?} (max 500)",
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "filePath": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "packagePath": {
+                      "type": "string"
+                    },
+                    "replaceExisting": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "filePath"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "assetPath": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "properties": {
+                      "additionalProperties": {},
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "assetPath",
+                    "properties"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "className": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "packagePath": {
+                      "type": "string"
+                    },
+                    "properties": {
+                      "additionalProperties": {},
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "packagePath",
+                    "className"
+                  ],
+                  "type": "object"
+                }
+              ]
+            },
+            "maxItems": 500,
+            "minItems": 1,
+            "type": "array"
+          },
+          "jsonPath": {
+            "type": "string"
+          },
+          "jsonString": {
+            "type": "string"
+          },
+          "key": {
+            "description": "Key name for add_input_mapping or StringTable entry key (e.g. 'Mouse2D', 'LeftMouseButton') (#525)",
+            "type": "string"
+          },
+          "keyFilter": {
+            "description": "Filter StringTable keys by substring",
+            "type": "string"
+          },
+          "keyTimeTolerance": {
+            "description": "CurveTable key update tolerance",
+            "type": "number"
+          },
+          "keys": {
+            "description": "CurveTable key array",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "arriveTangent": {
+                  "type": "number"
+                },
+                "interpMode": {
+                  "enum": [
+                    "linear",
+                    "constant",
+                    "cubic",
+                    "none"
+                  ],
+                  "type": "string"
+                },
+                "leaveTangent": {
+                  "type": "number"
+                },
+                "time": {
+                  "type": "number"
+                },
+                "value": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "time",
+                "value"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "lodGroup": {
+            "description": "Texture LOD group: World, WorldNormalMap, Character, UI, Lightmap, Effects, etc.",
+            "type": "string"
+          },
+          "mappingContext": {
+            "description": "InputMappingContext asset path for add_input_mapping (#525)",
+            "type": "string"
+          },
+          "mappingIndex": {
+            "description": "Index of an IMC mapping for remove_input_mapping (#525)",
+            "type": "number"
+          },
+          "materialPath": {
+            "description": "Material asset path for set_mesh_material",
+            "type": "string"
+          },
+          "maxExpandedObjects": {
+            "description": "read_properties: cap on expanded objects (default 64) (#755)",
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "maxResults": {
+            "type": "number"
+          },
+          "meshType": {
+            "description": "create_interchange_pipeline: 'skeletal' (default) or 'static'",
+            "type": "string"
+          },
+          "mode": {
+            "description": "Alias for curveType",
+            "enum": [
+              "simple",
+              "rich"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "description": "Asset name (defaults to filename)",
+            "type": "string"
+          },
+          "namespace": {
+            "description": "StringTable namespace for create_stringtable",
+            "type": "string"
+          },
+          "neverStream": {
+            "type": "boolean"
+          },
+          "newDisplayName": {
+            "description": "edit_user_defined_struct/rename_struct_field: new display name for rename_field",
+            "type": "string"
+          },
+          "newName": {
+            "type": "string"
+          },
+          "offset": {
+            "description": "list: index of the first match to return, for paging large folders (#790)",
+            "type": "number"
+          },
+          "oldName": {
+            "description": "Existing row key for rename_datatable_row (#535)",
+            "type": "string"
+          },
+          "onConflict": {
+            "description": "Asset-creation conflict policy: skip (default) | error | overwrite. bulk_upsert_data_assets uses update (default) | skip | error",
+            "type": "string"
+          },
+          "op": {
+            "description": "edit_user_defined_enum op: add_value | rename_value | remove_value. edit_user_defined_struct op: add_field | rename_field | set_field_type | remove_field",
+            "type": "string"
+          },
+          "options": {
+            "additionalProperties": {},
+            "description": "create_interchange_pipeline: dotted-path overrides",
+            "type": "object"
+          },
+          "otherPath": {
+            "description": "diff: the asset to compare assetPath against",
+            "type": "string"
+          },
+          "outputPath": {
+            "description": "Absolute file path for export (e.g. C:/output/texture.png)",
+            "type": "string"
+          },
+          "packagePath": {
+            "description": "Destination package path (e.g. /Game/Meshes)",
+            "type": "string"
+          },
+          "packages": {
+            "description": "Package paths for get_referencers / get_dependencies",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "path": {
+            "description": "Content path (e.g. /Game/Foo) - used by diagnose_registry, create_folder",
+            "type": "string"
+          },
+          "paths": {
+            "description": "Multiple content paths for create_folder",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "properties": {
+            "additionalProperties": {},
+            "description": "Key/value property overrides for create_data_asset",
+            "type": "object"
+          },
+          "propertyName": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "reconcile": {
+            "description": "diagnose_registry: force synchronous rescan (evicts pending-kill ghosts)",
+            "type": "boolean"
+          },
+          "recursive": {
+            "type": "boolean"
+          },
+          "relativeLocation": {
+            "additionalProperties": false,
+            "description": "Socket relative location",
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "z": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "z"
+            ],
+            "type": "object"
+          },
+          "relativeRotation": {
+            "additionalProperties": false,
+            "description": "Socket relative rotation",
+            "properties": {
+              "pitch": {
+                "type": "number"
+              },
+              "roll": {
+                "type": "number"
+              },
+              "yaw": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "pitch",
+              "yaw",
+              "roll"
+            ],
+            "type": "object"
+          },
+          "relativeScale": {
+            "$ref": "#/properties/relativeLocation",
+            "description": "Socket relative scale"
+          },
+          "renames": {
+            "description": "Array of rename descriptors for bulk_rename - each {sourcePath, destinationPath} or {assetPath, newName}",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "replaceExisting": {
+            "description": "import_skeletal_mesh: replace an existing asset at the destination (default true) (#678)",
+            "type": "boolean"
+          },
+          "row": {
+            "additionalProperties": {},
+            "description": "DataTable row fields object for set_datatable_row",
+            "type": "object"
+          },
+          "rowFilter": {
+            "type": "string"
+          },
+          "rowName": {
+            "description": "DataTable row key for set_datatable_row / remove_datatable_row",
+            "type": "string"
+          },
+          "rowStruct": {
+            "type": "string"
+          },
+          "rows": {
+            "additionalProperties": {},
+            "description": "DataTable bulk rows { rowName: {field: value} } for fill_datatable_from_json (#535)",
+            "type": "object"
+          },
+          "sRGB": {
+            "type": "boolean"
+          },
+          "saveContentPackages": {
+            "description": "save_all_dirty: include content packages (default true)",
+            "type": "boolean"
+          },
+          "saveMapPackages": {
+            "description": "save_all_dirty: include map packages (default true)",
+            "type": "boolean"
+          },
+          "searchAll": {
+            "description": "Search all content roots (plugins, engine content) not just /Game/",
+            "type": "boolean"
+          },
+          "sessionId": {
+            "description": "lock / unlock / unlock_all: owning session id (defaults to this server process)",
+            "type": "string"
+          },
+          "settings": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "skeletalMeshPath": {
+            "description": "read_cloth_data/set_cloth_config: skeletal mesh path (#595)",
+            "type": "string"
+          },
+          "skeletonPath": {
+            "type": "string"
+          },
+          "slotIndex": {
+            "description": "Material slot index (default 0)",
+            "type": "number"
+          },
+          "slots": {
+            "description": "Per-slot material assignments for set_sk_material_slots",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "materialPath": {
+                  "type": "string"
+                },
+                "slotIndex": {
+                  "type": "number"
+                },
+                "slotName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "materialPath"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "socketName": {
+            "description": "Socket name",
+            "type": "string"
+          },
+          "soft": {
+            "description": "get_dependencies: include soft dependencies (default true)",
+            "type": "boolean"
+          },
+          "sourcePath": {
+            "type": "string"
+          },
+          "sourceString": {
+            "description": "StringTable entry source string",
+            "type": "string"
+          },
+          "structFields": {
+            "description": "create_user_defined_struct: initial members as [{name, type}] (type is a MakePinType string, default bool)",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "targetGamma": {
+            "description": "create_render_target_2d: target gamma (default 0 uses engine behavior)",
+            "minimum": 0,
+            "type": "number"
+          },
+          "time": {
+            "description": "CurveTable key time",
+            "type": "number"
+          },
+          "ttlSeconds": {
+            "description": "lock: seconds before the lock auto-expires (default 300)",
+            "type": "number"
+          },
+          "type": {
+            "description": "get_primary_asset_ids: FPrimaryAssetType filter (omit for all types) (#579); also the member type (MakePinType string) for edit_user_defined_struct add_field/set_field_type (#735)",
+            "type": "string"
+          },
+          "typeFilter": {
+            "type": "string"
+          },
+          "value": {
+            "description": "Property value for set_property - scalar, object/array, or asset-path string. Goes through MCPJsonProperty (#420/#531)"
+          },
+          "valueFormat": {
+            "description": "Property value format for read_properties/list_properties/get_properties. Default text preserves the existing Unreal ExportText output; json returns structured JSON where supported.",
+            "enum": [
+              "text",
+              "json"
+            ],
+            "type": "string"
+          },
+          "values": {
+            "description": "create_user_defined_enum: initial value display names",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "width": {
+            "description": "create_render_target_2d: pixel width, 1-8192 (default 512)",
+            "maximum": 8192,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "asset"
+    },
+    {
+      "description": "Audio: sound assets, playback, MetaSound + SoundCue graph authoring, submixes/effects, sound classes/mixes, attenuation, concurrency, spatialization.\n\nActions:\n- list: List sound assets (SoundWave, SoundCue, MetaSoundSource) under a directory, paginated. Params: directory? (default /Game), recursive? (default true), maxResults? (default 1000), offset? (default 0). Returns assets, count, total, offset, hasMore, nextOffset (#730).\n- extract_pcm: Decode a USoundWave's imported audio to in-memory PCM (no intermediate file, no reliance on the original source path) for semantic sound search / analysis. Returns sampleRate, numChannels, numFrames, durationSeconds, and 16-bit PCM samples base64-encoded (interleaved). Params: soundPath (required), maxSeconds? (cap the decoded window; default full asset), downmixMono? (default false) (#729).\n- import_audio: Import a WAV/OGG/FLAC file as a USoundWave. Returns durationSeconds, numChannels, looping. Params: filePath, name?, packagePath? (default /Game/Audio), looping?, replaceExisting? (default true)\n- play_at_location: Play a sound in the editor world. Params: soundPath, location, volumeMultiplier?, pitchMultiplier?\n- spawn_ambient: Place an AmbientSound actor. Params: soundPath, location, label?\n- metasound_author: PREFERRED: stamp a whole MetaSound graph in ONE call from a declarative spec (avoids dozens of add_node/connect round-trips). Params: name, packagePath?, format? ('mono'|'stereo'), oneShot?, onConflict?, inputs? [{name,dataType,default?}], outputs? [{name,dataType}], nodes? [{id,class,namespace?,variant?,majorVersion?,inputs?:{vertex:value}}], connections? [{from,to}]. Endpoints are 'nodeId:vertex', or special heads 'input:<name>', 'output:<name>', 'audioOut:<channel>'. Each element reports its own ok/error; builds + saves at the end.\n- create_metasound: Create an empty MetaSoundSource and open a builder session for INCREMENTAL authoring (add_node/connect/...). For a whole graph at once prefer metasound_author. Params: name, packagePath? (default /Game/Audio/MetaSounds), format? ('mono'|'stereo'), oneShot?. Returns assetPath.\n- metasound_list_node_classes: List common MetaSound node classes to add (name, namespace, variant, notes). Params: filter? (substring).\n- metasound_get_graph: Report a MetaSound's builder-session state (active builder, audio outputs, oneShot). Params: assetPath.\n- metasound_add_node: Add a node to a MetaSound graph by registered class name. Returns nodeId (+ input/output counts). Params: assetPath, nodeClassName (e.g. 'Sine'), nodeNamespace? (default 'UE'), nodeVariant? (e.g. 'Audio'), majorVersion? (default 1).\n- metasound_add_input: Add a graph input to a MetaSound. Params: assetPath, name, dataType ('Float'|'Int32'|'Bool'|'String'|'Trigger'|'Audio'|'Time'|...), defaultValue?.\n- metasound_add_output: Add a graph output to a MetaSound. Params: assetPath, name, dataType.\n- metasound_connect: Connect one node's output vertex to another node's input vertex. Params: assetPath, fromNodeId, fromOutput (vertex name), toNodeId, toInput (vertex name).\n- metasound_connect_input: Connect a graph input to a node input vertex. Params: assetPath, graphInput (name), toNodeId, toInput (vertex name).\n- metasound_connect_output: Connect a node output vertex to a graph output. Params: assetPath, fromNodeId, fromOutput (vertex name), graphOutput (name).\n- metasound_connect_audio_out: Connect a node output vertex to the source's audio output. Params: assetPath, fromNodeId, fromOutput (vertex name, must be Audio type), channel? (0=left/mono, 1=right; default 0).\n- metasound_set_default: Set a default value on a node input vertex, or on a graph input. Params: assetPath, value (required), dataType? (Float|Int32|Bool|String hint), then EITHER (nodeId + inputName) OR graphInput.\n- metasound_build: Write the builder document to the MetaSound asset and save. Call after authoring. Params: assetPath.\n- cue_author: PREFERRED: create a SoundCue and stamp its whole node tree in ONE call. Params: name, packagePath?, onConflict?, nodes [{id,type,soundWavePath?,properties?}], connections [{parent,child,index?}] (omit parent => root), root? (nodeId). Each element reports ok/error; links + saves at the end.\n- create_cue: Create a SoundCue, optionally seeded from a wave. For a whole graph prefer cue_author. Params: name, packagePath?, soundWavePath?.\n- cue_add_node: Add a node to a SoundCue graph. Returns nodeId. Params: cuePath, nodeType ('wave_player'|'mixer'|'random'|'modulator'|'attenuation'|'looping'|'concatenator'|'delay'|'switch'), soundWavePath? (wave_player), properties? (node-specific fields).\n- cue_connect: Connect a SoundCue node as a child of another (or as the cue root). Params: cuePath, parentNodeId (omit for root), childNodeId, childIndex? (default append).\n- cue_get_graph: Read a SoundCue node graph: nodes (id, type, children) and root. Params: cuePath.\n- create_submix: Create a USoundSubmix, optionally parented. Params: name, packagePath? (default /Game/Audio/Submixes), parentPath?, outputVolume?, wetLevel?, dryLevel?.\n- set_submix_parent: Reparent a submix (sets ParentSubmix, updating both ends). Params: submixPath, parentPath (empty detaches to root).\n- add_submix_effect: Append a submix effect preset to a submix's effect chain (creates the preset asset). Params: submixPath, effectType ('reverb'|'eq'|'dynamics'|'filter'|'delay'), name?, packagePath?, settings? (effect Settings struct as JSON).\n- create_sound_class: Create a USoundClass, optionally parented, with properties. Params: name, packagePath? (default /Game/Audio/SoundClasses), parentPath?, properties? (FSoundClassProperties JSON: Volume, Pitch, bIsUISound, ...).\n- create_sound_mix: Create a USoundMix with sound-class adjusters. Params: name, packagePath? (default /Game/Audio/SoundMixes), adjusters? ([{soundClassPath, volumeAdjuster?, pitchAdjuster?, applyToChildren?}]), fadeInTime?, fadeOutTime?.\n- create_concurrency: Create a USoundConcurrency asset. Params: name, packagePath? (default /Game/Audio/Concurrency), maxCount?, limitToOwner?, resolutionRule? (e.g. 'StopFarthestThenOldest'), volumeScale?.\n- create_attenuation: Create a USoundAttenuation asset. Params: name, packagePath? (default /Game/Audio/Attenuation), settings? (FSoundAttenuationSettings JSON), plus shortcuts: falloffDistance?, spatialize?, enableOcclusion?.\n- set_sound_submix: Set a sound's base submix (routing target). Params: soundPath, submixPath (empty detaches).\n- add_sound_submix_send: Add a submix send to a sound. Params: soundPath, submixPath, sendLevel? (default 1.0).\n- set_sound_class: Assign a sound class to a sound. Params: soundPath, soundClassPath.\n- set_sound_attenuation: Attach an attenuation asset to a sound. Params: soundPath, attenuationPath (empty clears).\n- set_sound_concurrency: Attach a concurrency asset to a sound. Params: soundPath, concurrencyPath (empty clears).\n- set_property: Set any UPROPERTY on an audio asset by (dotted) name, value as JSON. Handles nested structs, arrays, object refs. Params: assetPath, propertyName, value.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "list",
+              "extract_pcm",
+              "import_audio",
+              "play_at_location",
+              "spawn_ambient",
+              "metasound_author",
+              "create_metasound",
+              "metasound_list_node_classes",
+              "metasound_get_graph",
+              "metasound_add_node",
+              "metasound_add_input",
+              "metasound_add_output",
+              "metasound_connect",
+              "metasound_connect_input",
+              "metasound_connect_output",
+              "metasound_connect_audio_out",
+              "metasound_set_default",
+              "metasound_build",
+              "cue_author",
+              "create_cue",
+              "cue_add_node",
+              "cue_connect",
+              "cue_get_graph",
+              "create_submix",
+              "set_submix_parent",
+              "add_submix_effect",
+              "create_sound_class",
+              "create_sound_mix",
+              "create_concurrency",
+              "create_attenuation",
+              "set_sound_submix",
+              "add_sound_submix_send",
+              "set_sound_class",
+              "set_sound_attenuation",
+              "set_sound_concurrency",
+              "set_property"
+            ],
+            "type": "string"
+          },
+          "adjusters": {
+            "type": "array"
+          },
+          "assetPath": {
+            "type": "string"
+          },
+          "attenuationPath": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "number"
+          },
+          "childIndex": {
+            "type": "number"
+          },
+          "childNodeId": {
+            "type": "string"
+          },
+          "concurrencyPath": {
+            "type": "string"
+          },
+          "connections": {
+            "description": "author: connection specs",
+            "type": "array"
+          },
+          "cuePath": {
+            "type": "string"
+          },
+          "dataType": {
+            "description": "MetaSound data type: Float, Int32, Bool, String, Trigger, Audio, Time, ...",
+            "type": "string"
+          },
+          "defaultValue": {},
+          "directory": {
+            "type": "string"
+          },
+          "downmixMono": {
+            "description": "extract_pcm: average channels to mono (#729)",
+            "type": "boolean"
+          },
+          "dryLevel": {
+            "type": "number"
+          },
+          "effectType": {
+            "type": "string"
+          },
+          "enableOcclusion": {
+            "type": "boolean"
+          },
+          "fadeInTime": {
+            "type": "number"
+          },
+          "fadeOutTime": {
+            "type": "number"
+          },
+          "falloffDistance": {
+            "type": "number"
+          },
+          "filePath": {
+            "description": "import_audio: path to a WAV/OGG/FLAC file",
+            "type": "string"
+          },
+          "filter": {
+            "type": "string"
+          },
+          "format": {
+            "description": "create_metasound: 'mono' | 'stereo'",
+            "type": "string"
+          },
+          "fromNodeId": {
+            "type": "string"
+          },
+          "fromOutput": {
+            "type": "string"
+          },
+          "graphInput": {
+            "type": "string"
+          },
+          "graphOutput": {
+            "type": "string"
+          },
+          "inputName": {
+            "type": "string"
+          },
+          "inputs": {
+            "description": "metasound_author: [{name,dataType,default?}]",
+            "type": "array"
+          },
+          "label": {
+            "type": "string"
+          },
+          "limitToOwner": {
+            "type": "boolean"
+          },
+          "location": {
+            "additionalProperties": false,
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "z": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "z"
+            ],
+            "type": "object"
+          },
+          "looping": {
+            "description": "import_audio: set SoundWave bLooping",
+            "type": "boolean"
+          },
+          "majorVersion": {
+            "type": "number"
+          },
+          "maxCount": {
+            "type": "number"
+          },
+          "maxResults": {
+            "description": "list: page size (default 1000) (#730)",
+            "type": "number"
+          },
+          "maxSeconds": {
+            "description": "extract_pcm: cap decoded window in seconds (#729)",
+            "type": "number"
+          },
+          "metasoundPath": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nodeClassName": {
+            "type": "string"
+          },
+          "nodeId": {
+            "type": "string"
+          },
+          "nodeNamespace": {
+            "type": "string"
+          },
+          "nodeType": {
+            "type": "string"
+          },
+          "nodeVariant": {
+            "type": "string"
+          },
+          "nodes": {
+            "description": "author: node specs",
+            "type": "array"
+          },
+          "offset": {
+            "description": "list: pagination offset (default 0) (#730)",
+            "type": "number"
+          },
+          "onConflict": {
+            "description": "skip|replace|rename when the asset name exists",
+            "type": "string"
+          },
+          "oneShot": {
+            "type": "boolean"
+          },
+          "outputVolume": {
+            "type": "number"
+          },
+          "outputs": {
+            "description": "metasound_author: [{name,dataType}]",
+            "type": "array"
+          },
+          "packagePath": {
+            "type": "string"
+          },
+          "parentNodeId": {
+            "type": "string"
+          },
+          "parentPath": {
+            "type": "string"
+          },
+          "pitchMultiplier": {
+            "type": "number"
+          },
+          "properties": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "propertyName": {
+            "type": "string"
+          },
+          "recursive": {
+            "type": "boolean"
+          },
+          "replaceExisting": {
+            "description": "import_audio: replace an existing asset (default true)",
+            "type": "boolean"
+          },
+          "resolutionRule": {
+            "type": "string"
+          },
+          "root": {
+            "description": "cue_author: explicit root nodeId",
+            "type": "string"
+          },
+          "sendLevel": {
+            "type": "number"
+          },
+          "settings": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "soundClassPath": {
+            "type": "string"
+          },
+          "soundPath": {
+            "type": "string"
+          },
+          "soundWavePath": {
+            "type": "string"
+          },
+          "spatialize": {
+            "type": "boolean"
+          },
+          "submixPath": {
+            "type": "string"
+          },
+          "toInput": {
+            "type": "string"
+          },
+          "toNodeId": {
+            "type": "string"
+          },
+          "value": {
+            "description": "JSON value for set_default / set_property"
+          },
+          "volumeMultiplier": {
+            "type": "number"
+          },
+          "volumeScale": {
+            "type": "number"
+          },
+          "wetLevel": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "audio"
+    },
+    {
+      "description": "Blueprint reading, authoring, and compilation, including AnimGraph/EventGraph node scripting: add_node, connect_pins, search_node_types, plus variables, functions, graphs, components, interfaces, and event dispatchers.\n\nActions:\n- read: Read BP structure incl. SCS components AND inherited native components from the CDO (CharacterMesh0, CharMoveComp, etc.). Params: assetPath, includeComponentProperties? (dump UPROPERTY name/type/value per component template; off by default) (#353/#370)\n- list_variables: List variables with name, type, guid, category, tooltip, exposeOnSpawn, blueprintReadOnly, private, and editFlag ('EditAnywhere'|'EditDefaultsOnly'|'EditInstanceOnly'|'none'). instanceEditable is true only for EditAnywhere and EditInstanceOnly - EditDefaultsOnly is class-defaults-only and reports false (#744). private is reported separately because it is a Blueprint-graph access flag, not a details-panel one. Params: assetPath\n- list_functions: List the whole graph surface of a Blueprint, matching what list_graphs reports. Every entry carries kind ('function' own declaration | 'override' of a parent function | 'interface' implementation | 'event_graph' | 'event' entry point on an event graph | 'macro' | 'delegate_signature' | 'subgraph' collapsed graph | 'inherited'), source ('own'|'parent'|'interface'), graphName, and declaringClass/declaringClassPath where one applies. name and nodeCount are unchanged; nodeCount is 0 for entries that are not graphs. Params: assetPath, includeInherited? (append overridable parent/interface functions this Blueprint has not implemented, default false) (#809)\n- read_graph: Read graph nodes. Supports pagination, file dumps, and title/class node filters. With includeDefaults, literal FText pin values are returned inline (defaultValue falls back to the pin's text literal, plus an explicit defaultTextValue) and object-ref pins report defaultObject (#743). Params: assetPath, graphName, offset?, limit?, includePins?, includeDefaults?, includeComments?, dumpToFile?, outputPath?, titleFilter?, classFilter? (#560)\n- read_graph_summary: Lightweight graph summary (nodes+edges only, ~10KB). Filterable node list. Params: assetPath, graphName?, titleFilter?, classFilter? (#560)\n- get_execution_flow: Trace exec pins from an entry point. Params: assetPath, graphName?, entryPoint?\n- get_dependencies: Forward (classes/functions/assets) or reverse (referencers) deps. Params: assetPath, reverse?\n- diff: Semantic structural diff between two Blueprints (binary uassets are unreviewable in git). Compares parent class, variables (type/default), functions/macros, components, and per-graph node + connection deltas keyed on stable node GUIDs so edits are matched rather than shown as remove+add. Returns a structured delta plus a human summary and changeCount. Params: assetPath (base/A), otherPath (compare/B). Revision-based diffing (fromRevision/toRevision via source control) is a staged follow-up.\n- create: Create Blueprint. assetPath is the full destination, e.g. /Game/Blueprints/BP_Example; a name plus packagePath pair is accepted as the same thing. A .uasset suffix, an object suffix, and backslashes are normalized away rather than reaching the editor as an invalid asset name. Params: assetPath, name?, packagePath?, parentClass?\n- add_variable: Add variable. varType accepts bool/int/float/string/name/text/byte/vector/rotator/transform/gameplaytag, object:/Script/Module.Class, struct:/Game/Path/To/Struct, or a full class/struct path. Unrecognized types are rejected rather than silently defaulting. Params: assetPath, name, varType (alias: type), onConflict? (skip|error, default skip) (#745)\n- set_variable_properties: Edit variable properties. Note: replication is set with networking(set_property_replicated), and blueprintReadOnly is not writable here - list_variables reports it. Params: assetPath, name, editFlag? (EditAnywhere|EditDefaultsOnly|EditInstanceOnly|none - the exact value list_variables reports, and the only form that round-trips every state), instanceEditable? (two-state shorthand; mutually exclusive with editFlag), private?, category?, tooltip?, exposeOnSpawn?\n- create_function: Create function. Params: assetPath, functionName\n- delete_function: Delete function. Params: assetPath, functionName\n- rename_function: Rename function. Params: assetPath, oldName, newName\n- add_node: Add graph node. For a CallFunction node bound to a custom C++ UFUNCTION, pass nodeParams {functionName, className (or targetClass) = /Script/Module.Class}; the function also resolves against the BP's own component classes and an unambiguous loaded BlueprintCallable function, producing a bound node with pins instead of a stub (#546). nodeClass='CallParent' places a 'Parent: <Function>' call bound to the parent implementation (functionName resolves against ParentClass) so an override graph can chain to the base (#688). Params: assetPath, graphName?, nodeClass, nodeParams?\n- delete_node: Delete node. Params: assetPath, graphName, nodeName\n- set_node_property: Set node pin default or struct property. Params: assetPath, graphName, nodeName, propertyName, value\n- connect_pins: Wire nodes. Params: sourceNode, sourcePin, targetNode, targetPin, assetPath, graphName?, breakExistingSource?, breakExistingTarget?\n- add_component: Add BP component. componentClass accepts short names (e.g. 'ChildActorComponent') or full paths. For a ChildActorComponent, pass childActorClass to set its ChildActorClass in the same call (a Blueprint path with or without _C, or a C++ class) (#526). Params: assetPath, componentClass, componentName?, parentComponent? (SCS parent for hierarchy - #115), childActorClass?\n- remove_component: Remove SCS component. Params: assetPath, componentName\n- set_component_property: Set property on SCS or inherited component. Inherited components go through the child BP's InheritableComponentHandler override template so the parent stays untouched. Pass value=null to clear a TObjectPtr/SoftObject/WeakObject/UClass/Interface reference (e.g. clear AnimClass on CharacterMesh0) (#420). Params: assetPath, componentName, propertyName, value\n- set_component_override_materials: Write OverrideMaterials on a mesh-component template (StaticMeshComponent / SkeletalMeshComponent / any UMeshComponent). Pass materialPaths as a string[] of material asset paths (empty array clears). Avoids any TArray<UObject*> coercion on the generic set_component_property path (#442). Params: assetPath, componentName, materialPaths\n- add_timeline_track: Add a track to a Blueprint timeline. Creates the UTimelineTemplate if missing, builds the matching curve asset (float/vector/color/event), applies keyframes, bumps TimelineLength to cover the last key, then recompiles so K2Node_Timeline regenerates its output pins. Params: assetPath, timelineName, trackName, trackType ('float'|'vector'|'color'|'event'), keyframes ([{time, value}]). value is a number for float/event, {x,y,z} for vector, {r,g,b,a} for color (#457)\n- set_capsule_size: Call UCapsuleComponent::SetCapsuleSize on a CapsuleComponent template (CharacterMovement-friendly path; raw property writes leave the visualizer stale). Pass either or both of halfHeight/radius. Returns the new + previous values. Params: assetPath, componentName, halfHeight?, radius? (#419)\n- get_component_property: Read a single property value from an SCS or inherited component template. Returns the ICH override value for child BPs if one exists. Params: assetPath, componentName, propertyName\n- set_class_default: Set UPROPERTY on Blueprint CDO. Pass value=null to clear an object/class/interface reference (#420). Params: assetPath, propertyName, value\n- delete_variable: Delete a member variable. Params: assetPath, name\n- add_function_parameter: Add input or output parameter to a function. Params: assetPath, functionName, parameterName, parameterType?, isOutput?\n- set_variable_default: Set default value on a BP variable. Params: assetPath, name, value\n- compile: Compile Blueprint. Params: assetPath\n- list_node_types: List node types. Params: category?, includeFunctions?\n- search_node_types: Search placeable nodes across every loaded Blueprint function library (KismetMathLibrary, GameplayStatics, custom libraries) plus UEdGraphNode classes. Matches the C++ name, the palette label from DisplayName metadata, and Keywords metadata, ignoring case/spaces/underscores, so 'is point in box' finds IsPointInBox and 'vector length' finds VSize. Results are ranked and each carries an addNode block (nodeClass + nodeParams incl. targetClass) that add_node accepts verbatim. Params: query, limit? (default 50), className? (narrow to one owning class), includeGraphNodes? (#808)\n- create_interface: Create BP Interface. Params: assetPath\n- add_interface: Implement interface. Params: blueprintPath, interfacePath\n- override_function: Override an inherited interface implementation (inherited via the parent class) or an overridable parent virtual function, with the matching signature so it actually binds as the override (create_function makes a blank, non-binding graph). Returns kind ('function' with a graphName, or 'event' with a nodeId in EventGraph). Event-shaped functions become override events unless preferFunction=true. Pass interfacePath to also implement the interface first if it is not present. Then wire the body with add_node (use nodeClass='CallParent' to chain to the base implementation). Params: assetPath, functionName, source? ('auto'|'interface'|'parent', advisory), preferFunction?, interfacePath? (#688)\n- list_overridable_functions: List functions this Blueprint can override: inherited interface implementations and overridable parent virtuals. Each entry has name, source ('interface'|'parent'), declaringClass, canBeEvent. Params: assetPath (#688)\n- list_graphs: List all graphs in a blueprint. Returns selector/objectPath plus duplicateIndex/duplicateCount; pass selector back as graphName for unambiguous nested graph edits. Params: assetPath\n- resolve_graph: Resolve a Blueprint graph name to selectors accepted by read_graph/add_node/connect_pins and other graph actions. Duplicate nested AnimBP names such as Locomotion return every match with selectors like Locomotion[3], object paths, and ambiguity metadata. Params: assetPath, graphName\n- add_event_dispatcher: Add event dispatcher (multicast delegate variable + signature graph + UFunction). Without parameters, broadcasters fire void(). With parameters, the signature graph gets typed user pins so K2Node_CallDelegate compiles cleanly (#276). Params: blueprintPath, name, parameters?: [{name, type}] where type is bool/int/float/string/name/text/vector/rotator/transform/object:/Script/Module.Class/struct:/Script/Module.Struct\n- duplicate: Duplicate blueprint asset. Params: sourcePath, destinationPath\n- add_local_variable: Add function-scope local variable. Params: assetPath, functionName, name, varType? (alias: type, default bool)\n- list_local_variables: List local variables in a function. Params: assetPath, functionName\n- validate: Validate blueprint without saving (compile + collect diagnostics). Params: assetPath\n- read_component_properties: Dump ALL UPROPERTYs on a BP component template incl. array contents (#105). Params: assetPath, componentName\n- read_node_property: Read a node pin default OR a reflected node property for verification (#102). Params: assetPath, graphName?, nodeName, propertyName\n- reparent_component: Reparent an SCS component under a new parent (#115). Params: assetPath, componentName, newParent\n- reparent: Change a Blueprint's ParentClass and recompile (#138). Params: assetPath, parentClass (short name or full path).\n- flush_ich: Flush orphaned InheritableComponentHandler override records (invalid component-override entries invisible to read/remove_component). Recompiles + saves. Params: assetPath. Returns recordsBefore/After/Removed (#580)\n- set_actor_tick_settings: Set actor CDO tick settings (#116). Params: assetPath, bCanEverTick?, bStartWithTickEnabled?, TickInterval?\n- export_nodes_t3d: Export graph nodes as T3D text (Ctrl+C equivalent) for bulk round-trip (#130). Params: assetPath, graphName?, nodeIds? (omit = whole graph)\n- import_nodes_t3d: Paste a T3D node blob into a graph (Ctrl+V equivalent) for bulk authoring (#130). Params: assetPath, graphName?, t3d, posX?, posY?\n- set_cdo_property: Set UPROPERTY on any C++ class CDO (not just Blueprints). Params: className, propertyName, value (#182/#183)\n- get_cdo_properties: Read UPROPERTY values from any C++ class CDO. Params: className, propertyNames? (#183)\n- run_construction_script: Spawn temp actor, run construction script, return generated components and transforms. Params: assetPath, location? (#195)\n- compile_all: Batch compile + save Blueprints. Params: assetPaths[], save? (default true). Returns per-path status (compiled/failed/not_found) (#284)\n- author: Author a whole Blueprint in one call: optionally create it (parentClass), then add components, variables and function stubs, then compile - one agent-facing action instead of a dozen add_* round-trips. Params: assetPath, parentClass? (create/ensure the BP if given), components? [{componentClass, componentName?, parentComponent?, childActorClass?}], variables? [{name, varType}], functions? [{functionName}], compile? (default true). Returns per-step results + created flag. (#607)\n- cleanup_graph: Remove orphan/corrupted nodes (no class, blank title+no pins, missing target UFunction). Params: assetPath, graphName? (default: every graph) (#285)\n- connect_pins_batch: Apply many pin connections in one call (single compile + save). Params: assetPath, graphName?, connections[]: [{sourceNode, sourcePin, targetNode, targetPin}] (#267)\n- set_node_position: Move a graph node to (posX, posY). Params: assetPath, graphName?, nodeId, posX, posY (#277)\n- auto_layout: Topological layered layout for a graph. Eliminates the (0,0) stack from programmatic add_node. Params: assetPath, graphName?, columnGap? (default 360), rowGap? (default 200) (#277)\n\nEpic 5.8 toolset actions (53): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "TickInterval": {
+            "type": "number"
+          },
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "read",
+              "list_variables",
+              "list_functions",
+              "read_graph",
+              "read_graph_summary",
+              "get_execution_flow",
+              "get_dependencies",
+              "diff",
+              "create",
+              "add_variable",
+              "set_variable_properties",
+              "create_function",
+              "delete_function",
+              "rename_function",
+              "add_node",
+              "delete_node",
+              "set_node_property",
+              "connect_pins",
+              "add_component",
+              "remove_component",
+              "set_component_property",
+              "set_component_override_materials",
+              "add_timeline_track",
+              "set_capsule_size",
+              "get_component_property",
+              "set_class_default",
+              "delete_variable",
+              "add_function_parameter",
+              "set_variable_default",
+              "compile",
+              "list_node_types",
+              "search_node_types",
+              "create_interface",
+              "add_interface",
+              "override_function",
+              "list_overridable_functions",
+              "list_graphs",
+              "resolve_graph",
+              "add_event_dispatcher",
+              "duplicate",
+              "add_local_variable",
+              "list_local_variables",
+              "validate",
+              "read_component_properties",
+              "read_node_property",
+              "reparent_component",
+              "reparent",
+              "flush_ich",
+              "set_actor_tick_settings",
+              "export_nodes_t3d",
+              "import_nodes_t3d",
+              "set_cdo_property",
+              "get_cdo_properties",
+              "run_construction_script",
+              "compile_all",
+              "author",
+              "cleanup_graph",
+              "connect_pins_batch",
+              "set_node_position",
+              "auto_layout",
+              "epic_read_graph_dsl",
+              "epic_write_graph_dsl",
+              "epic_get_graph_dsl_docs",
+              "epic_list_event_dispatchers",
+              "epic_add_event_dispatcher",
+              "epic_remove_variable",
+              "epic_set_variable_category",
+              "epic_get_variable_category",
+              "epic_set_variable_replication",
+              "epic_get_variable_replication",
+              "epic_set_variable_instance_editable",
+              "epic_list_variables",
+              "epic_add_object_variable",
+              "epic_add_struct_variable",
+              "epic_add_variable",
+              "epic_set_parent",
+              "epic_get_parent",
+              "epic_get_pin_value",
+              "epic_set_pin_value",
+              "epic_break_pins",
+              "epic_connect_pins",
+              "epic_arrange_nodes",
+              "epic_set_node_position",
+              "epic_retarget_node_class",
+              "epic_remove_node_pin",
+              "epic_add_node_pin",
+              "epic_delete_node",
+              "epic_create_node",
+              "epic_add_component_bound_event",
+              "epic_list_component_events",
+              "epic_find_node_categories",
+              "epic_get_node_type_pins",
+              "epic_find_node_types",
+              "epic_get_connected_subgraph",
+              "epic_find_nodes",
+              "epic_list_compatible_event_functions",
+              "epic_set_create_event_function",
+              "epic_get_create_event_function",
+              "epic_get_node_infos",
+              "epic_add_object_function_param",
+              "epic_add_struct_function_param",
+              "epic_remove_function_param",
+              "epic_add_function_param",
+              "epic_remove_function_graph",
+              "epic_add_event",
+              "epic_add_function_graph",
+              "epic_list_events",
+              "epic_list_functions",
+              "epic_get_graph",
+              "epic_list_graphs",
+              "epic_get_default_object",
+              "epic_compile_blueprint",
+              "epic_create"
+            ],
+            "type": "string"
+          },
+          "assetPath": {
+            "description": "Blueprint asset path",
+            "type": "string"
+          },
+          "assetPaths": {
+            "description": "Asset paths for compile_all",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "bCanEverTick": {
+            "type": "boolean"
+          },
+          "bStartWithTickEnabled": {
+            "type": "boolean"
+          },
+          "blueprintPath": {
+            "type": "string"
+          },
+          "breakExistingSource": {
+            "description": "connect_pins: break all existing links on the source pin before connecting",
+            "type": "boolean"
+          },
+          "breakExistingTarget": {
+            "description": "connect_pins: break all existing links on the target pin before connecting",
+            "type": "boolean"
+          },
+          "category": {
+            "type": "string"
+          },
+          "childActorClass": {
+            "description": "ChildActorClass for an added ChildActorComponent - Blueprint path (with/without _C) or C++ class (#526)",
+            "type": "string"
+          },
+          "classFilter": {
+            "description": "read_graph/read_graph_summary: case-insensitive substring match on node class name (#560)",
+            "type": "string"
+          },
+          "className": {
+            "description": "C++ class name or path for set_cdo_property / get_cdo_properties",
+            "type": "string"
+          },
+          "columnGap": {
+            "description": "auto_layout: horizontal spacing between columns (default 360)",
+            "type": "number"
+          },
+          "compile": {
+            "description": "author: compile after authoring (default true) (#607)",
+            "type": "boolean"
+          },
+          "componentClass": {
+            "type": "string"
+          },
+          "componentName": {
+            "type": "string"
+          },
+          "components": {
+            "description": "author: [{componentClass, componentName?, parentComponent?, childActorClass?}] (#607)",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "connections": {
+            "description": "connect_pins_batch: per-connection records",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "sourceNode": {
+                  "type": "string"
+                },
+                "sourcePin": {
+                  "type": "string"
+                },
+                "targetNode": {
+                  "type": "string"
+                },
+                "targetPin": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "sourceNode",
+                "sourcePin",
+                "targetNode",
+                "targetPin"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "destinationPath": {
+            "type": "string"
+          },
+          "dumpToFile": {
+            "description": "Write read_graph JSON to a file instead of returning nodes inline; without offset/limit this dumps the full graph, otherwise it dumps the requested slice",
+            "type": "boolean"
+          },
+          "editFlag": {
+            "description": "set_variable_properties: EditAnywhere|EditDefaultsOnly|EditInstanceOnly|none - the exact value list_variables reports (#744)",
+            "type": "string"
+          },
+          "entryPoint": {
+            "description": "Event/function name to start exec-flow trace",
+            "type": "string"
+          },
+          "exposeOnSpawn": {
+            "description": "Toggle ExposeOnSpawn flag on a variable",
+            "type": "boolean"
+          },
+          "fromRevision": {
+            "description": "diff: reserved for revision diffing (not implemented; passing it is an explicit error)",
+            "type": "string"
+          },
+          "functionName": {
+            "type": "string"
+          },
+          "functions": {
+            "description": "author: [{functionName}] (#607)",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "graphName": {
+            "type": "string"
+          },
+          "halfHeight": {
+            "description": "set_capsule_size: capsule half height (unscaled)",
+            "type": "number"
+          },
+          "includeComments": {
+            "description": "Include node comments in read_graph results (default true)",
+            "type": "boolean"
+          },
+          "includeComponentProperties": {
+            "description": "read: dump UPROPERTY name/type/value per component template (#353/#370)",
+            "type": "boolean"
+          },
+          "includeDefaults": {
+            "description": "Include pin default values in read_graph results (default true)",
+            "type": "boolean"
+          },
+          "includeFunctions": {
+            "type": "boolean"
+          },
+          "includeInherited": {
+            "description": "list_functions: also list overridable parent/interface functions this Blueprint has not implemented (#809)",
+            "type": "boolean"
+          },
+          "includePins": {
+            "description": "Include pins in read_graph results (default true)",
+            "type": "boolean"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "instanceEditable": {
+            "description": "set_variable_properties: true = EditAnywhere (per-instance), false = not instance-editable",
+            "type": "boolean"
+          },
+          "interfacePath": {
+            "type": "string"
+          },
+          "isOutput": {
+            "type": "boolean"
+          },
+          "keyframes": {
+            "description": "add_timeline_track: [{time, value}] - value is number for float/event, {x,y,z} for vector, {r,g,b,a} for color (#457)",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "limit": {
+            "description": "Pagination limit for read_graph",
+            "exclusiveMinimum": 0,
+            "type": "integer"
+          },
+          "location": {
+            "additionalProperties": {},
+            "description": "run_construction_script: {x,y,z} spawn location for the temp actor",
+            "type": "object"
+          },
+          "materialPaths": {
+            "description": "Material asset paths for set_component_override_materials (#442)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "newName": {
+            "type": "string"
+          },
+          "newParent": {
+            "description": "New parent component name for reparent_component",
+            "type": "string"
+          },
+          "nodeClass": {
+            "type": "string"
+          },
+          "nodeId": {
+            "description": "Node guid or name (set_node_position)",
+            "type": "string"
+          },
+          "nodeIds": {
+            "description": "Node guids/names to export (omit = whole graph)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "nodeName": {
+            "type": "string"
+          },
+          "nodeParams": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "offset": {
+            "description": "Pagination offset for read_graph",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "oldName": {
+            "type": "string"
+          },
+          "onConflict": {
+            "description": "add_variable: skip (default) or error when the variable already exists",
+            "type": "string"
+          },
+          "otherPath": {
+            "description": "diff: the compare-against Blueprint (B)",
+            "type": "string"
+          },
+          "outputPath": {
+            "description": "Absolute or Saved-relative JSON path for read_graph dumps; default path includes the asset, graph, and a path hash",
+            "type": "string"
+          },
+          "packagePath": {
+            "description": "create: destination folder, used with name. assetPath is the canonical alternative (#798)",
+            "type": "string"
+          },
+          "parameterName": {
+            "type": "string"
+          },
+          "parameterType": {
+            "type": "string"
+          },
+          "parameters": {
+            "description": "add_event_dispatcher: typed signature parameters [{name, type}]. type is bool/int/float/string/name/text/vector/rotator/transform/object:/Script/Module.Class/struct:/Script/Module.Struct",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "parentClass": {
+            "type": "string"
+          },
+          "parentComponent": {
+            "description": "Parent SCS component for add_component hierarchy (#115)",
+            "type": "string"
+          },
+          "path": {
+            "description": "Legacy alias for assetPath. Use assetPath (#798)",
+            "type": "string"
+          },
+          "posX": {
+            "description": "Re-center pasted nodes around this X (with posY)",
+            "type": "number"
+          },
+          "posY": {
+            "description": "Re-center pasted nodes around this Y (with posX)",
+            "type": "number"
+          },
+          "preferFunction": {
+            "description": "override_function: force the function-graph form even when the function could be placed as an override event (#688)",
+            "type": "boolean"
+          },
+          "private": {
+            "description": "set_variable_properties: the Blueprint editor's Private checkbox, independent of editFlag",
+            "type": "boolean"
+          },
+          "propertyName": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "description": "Property names to read for get_cdo_properties (omit = all)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "query": {
+            "type": "string"
+          },
+          "radius": {
+            "description": "set_capsule_size: capsule radius (unscaled)",
+            "type": "number"
+          },
+          "reverse": {
+            "description": "get_dependencies: true → referencers of this asset",
+            "type": "boolean"
+          },
+          "rowGap": {
+            "description": "auto_layout: vertical spacing between rows (default 200)",
+            "type": "number"
+          },
+          "save": {
+            "description": "compile_all: persist on success (default true)",
+            "type": "boolean"
+          },
+          "source": {
+            "description": "override_function: advisory hint for where the overridable function comes from (#688)",
+            "enum": [
+              "auto",
+              "interface",
+              "parent"
+            ],
+            "type": "string"
+          },
+          "sourceNode": {
+            "type": "string"
+          },
+          "sourcePath": {
+            "type": "string"
+          },
+          "sourcePin": {
+            "type": "string"
+          },
+          "t3d": {
+            "description": "T3D blob from export_nodes_t3d (or copied from the BP graph editor)",
+            "type": "string"
+          },
+          "targetNode": {
+            "type": "string"
+          },
+          "targetPin": {
+            "type": "string"
+          },
+          "timelineName": {
+            "description": "Timeline name for add_timeline_track (#457)",
+            "type": "string"
+          },
+          "titleFilter": {
+            "description": "read_graph/read_graph_summary: case-insensitive substring match on node title (#560)",
+            "type": "string"
+          },
+          "toRevision": {
+            "description": "diff: reserved for revision diffing (not implemented; passing it is an explicit error)",
+            "type": "string"
+          },
+          "tooltip": {
+            "type": "string"
+          },
+          "trackName": {
+            "description": "Track name within the timeline (#457)",
+            "type": "string"
+          },
+          "trackType": {
+            "description": "add_timeline_track type (#457)",
+            "enum": [
+              "float",
+              "vector",
+              "color",
+              "event"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "description": "add_variable: alias for varType",
+            "type": "string"
+          },
+          "value": {},
+          "varType": {
+            "description": "Variable type for add_variable/add_local_variable",
+            "type": "string"
+          },
+          "variables": {
+            "description": "author: [{name, varType}] (#607)",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "blueprint"
+    },
+    {
+      "description": "Author ChooserTable assets (the data-driven selection layer behind Motion Matching): introspect columns, list/add/edit/delete rows mapping input-column conditions to an output object.\n\nActions:\n- create: Create an empty ChooserTable asset. Add input columns with add_column, then rows with add_row. Params: name, packagePath? (default /Game), onConflict? (#685)\n- describe: Introspect a ChooserTable: row count, each input column (index, name, columnType, cellType) and the fallback result. Read this first to learn the cell text format each column expects. Params: table (#685)\n- add_column: Add an input column to a ChooserTable (so rows have a condition to fill). columnType is a Chooser column struct short name, e.g. EnumColumn, BoolColumn, FloatRangeColumn, GameplayTagColumn, ObjectColumn, or an Output* column. Optionally bind its input: inputStruct (parameter struct e.g. EnumContextProperty/BoolContextProperty), boundProperty (context property name to read), enumPath (for enum columns). Sizes the new column's cells to the current rows. Params: table, columnType, inputStruct?, boundProperty?, enumPath? (#685)\n- list_rows: List every row: index, disabled flag, output object (resultType + referenced asset path), and each column's cell value as round-trippable text. Params: table (#685)\n- add_row: Append a row. Set the output via `output` (asset path) + outputType ('asset' hard ref default | 'soft_asset' | 'evaluate' for a nested ChooserTable). Set input-column conditions via `cells` (array aligned to column order) and/or `inputs` (object keyed by column index or name). Cell values are struct text like '(Value=2)' - partial fields are allowed and unspecified ones keep defaults; a bare number/bool works for scalar columns. Params: table, output?, outputType?, cells?, inputs? (#685)\n- set_row: Edit an existing row by index: optionally replace the output (output + outputType), toggle disabled, and/or update column cells (cells / inputs, same format as add_row). Params: table, index, output?, outputType?, disabled?, cells?, inputs? (#685)\n- delete_row: Delete a row by index (removes its output plus the per-row cell from every column). Params: table, index (#685)\n- list_object_references: List every leaf object reference reachable from a chooser, descending through nested chooser tables. list_rows renders those as an opaque resultType:NestedChooser with an empty output, so the actual PoseSearchDatabase/asset paths were invisible. Each entry reports the owning table, the exact location (e.g. ResultsStructs[3].Asset), the struct type and the current object path. Params: assetPath, classFilter? (match the referenced object's class), pathFilter? (substring on the path) (#754)\n- remap_object_references: Repoint object references throughout a chooser's nested structure. Either an exact swap (from + to) or a folder rewrite (fromPrefix + toPrefix), which is the 'adopt vendor choosers into our namespace' case. DRY RUN BY DEFAULT - pass dryRun=false to apply. Object-typed targets are class-checked before assignment; the chooser is recompiled and left dirty rather than saved. Params: assetPath, from?+to? | fromPrefix?+toPrefix?, dryRun? (default true) (#754)",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "create",
+              "describe",
+              "add_column",
+              "list_rows",
+              "add_row",
+              "set_row",
+              "delete_row",
+              "list_object_references",
+              "remap_object_references"
+            ],
+            "type": "string"
+          },
+          "allowMissing": {
+            "description": "remap_object_references: write a soft reference even when the target does not exist yet (default false) (#754)",
+            "type": "boolean"
+          },
+          "assetPath": {
+            "description": "list_object_references / remap_object_references: ChooserTable asset path (#754)",
+            "type": "string"
+          },
+          "boundProperty": {
+            "description": "add_column: context property name the column reads at evaluation time",
+            "type": "string"
+          },
+          "cells": {
+            "description": "Per-column cell values aligned to column order; each is struct text like '(Value=2)', or a scalar. null/omitted leaves a column at its default.",
+            "type": "array"
+          },
+          "classFilter": {
+            "description": "list_object_references: only references whose target class matches (#754)",
+            "type": "string"
+          },
+          "columnType": {
+            "description": "add_column: Chooser column struct short name (EnumColumn, BoolColumn, FloatRangeColumn, GameplayTagColumn, ObjectColumn, Output*Column, ...)",
+            "type": "string"
+          },
+          "disabled": {
+            "description": "set_row: enable/disable the row without deleting it",
+            "type": "boolean"
+          },
+          "dryRun": {
+            "description": "remap_object_references: preview without writing (default true) (#754)",
+            "type": "boolean"
+          },
+          "enumPath": {
+            "description": "add_column: enum asset path for an EnumColumn",
+            "type": "string"
+          },
+          "from": {
+            "description": "remap_object_references: exact object path to replace (#754)",
+            "type": "string"
+          },
+          "fromPrefix": {
+            "description": "remap_object_references: path prefix to rewrite, e.g. /Game/Vendor/ (#754)",
+            "type": "string"
+          },
+          "index": {
+            "description": "Row index for set_row / delete_row",
+            "type": "number"
+          },
+          "inputStruct": {
+            "description": "add_column: parameter struct to bind the column input (e.g. EnumContextProperty, BoolContextProperty)",
+            "type": "string"
+          },
+          "inputs": {
+            "additionalProperties": {},
+            "description": "Cell values keyed by column index (as string) or column name; same value format as cells",
+            "type": "object"
+          },
+          "name": {
+            "description": "create: new ChooserTable asset name",
+            "type": "string"
+          },
+          "onConflict": {
+            "description": "create: conflict policy skip (default) | error | overwrite",
+            "type": "string"
+          },
+          "output": {
+            "description": "Output asset path for the row (a PoseSearchDatabase, a nested ChooserTable, etc.)",
+            "type": "string"
+          },
+          "outputType": {
+            "description": "Output wrapper: 'asset' (hard ref, default) | 'soft_asset' | 'evaluate' (nested ChooserTable reference)",
+            "type": "string"
+          },
+          "packagePath": {
+            "description": "create: destination package path (default /Game)",
+            "type": "string"
+          },
+          "pathFilter": {
+            "description": "list_object_references: substring filter on the referenced object path (#754)",
+            "type": "string"
+          },
+          "table": {
+            "description": "ChooserTable asset path, e.g. /Game/Path/CT_Locomotion",
+            "type": "string"
+          },
+          "to": {
+            "description": "remap_object_references: replacement object path (#754)",
+            "type": "string"
+          },
+          "toPrefix": {
+            "description": "remap_object_references: replacement prefix, e.g. /Game/MyProject/ (#754)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "chooser"
+    },
+    {
+      "description": "Conversation graphs (UConversationDatabase): dialogue nodes, node connections, sub-nodes, speakers, and entry points.\n\nActions:\n- __epic_seed__\n\nEpic 5.8 toolset actions (7): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "epic_get_sub_nodes",
+              "epic_get_node_connections",
+              "epic_get_node_by_guid",
+              "epic_get_node_guids",
+              "epic_get_all_nodes",
+              "epic_list_speakers",
+              "epic_list_entry_points"
+            ],
+            "type": "string"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "conversation"
+    },
+    {
+      "description": "Dataflow graphs: node and pin authoring, variables, comment boxes, templates, and creation of Dataflow-compatible assets (Chaos geometry and simulation graphs).\n\nActions:\n- __epic_seed__\n\nEpic 5.8 toolset actions (22): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "epic_update_node",
+              "epic_set_variable",
+              "epic_reposition_node",
+              "epic_remove_variable",
+              "epic_remove_node",
+              "epic_remove_comment_box",
+              "epic_list_variables",
+              "epic_list_node_types",
+              "epic_list_dataflow_templates_for_asset_class",
+              "epic_list_dataflow_compatible_asset_types",
+              "epic_get_node_type_schema",
+              "epic_get_node_info",
+              "epic_get_graph_structure",
+              "epic_disconnect_node_pins",
+              "epic_create_graph",
+              "epic_create_dataflow_compatible_asset_from_template",
+              "epic_create_dataflow_compatible_asset",
+              "epic_connect_node_pins",
+              "epic_assign_dataflow_template",
+              "epic_add_variable",
+              "epic_add_node",
+              "epic_add_comment_box"
+            ],
+            "type": "string"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "dataflow"
+    },
+    {
+      "description": "Neon Shrine demo scene builder and cleanup.\n\nActions:\n- step: Execute demo step. Params: stepIndex?\n- get_steps: List every demo step up front: index, id and description, plus a count. Use this to see what the 19 steps build before running any of them. Params: none\n- cleanup: Remove demo assets and actors. Switches editor to /Game/MCP_Home before deleting so the editor is never left on an Untitled map.\n- go_home: Switch the editor to /Game/MCP_Home (creating it on first use). Use this before any operation that would leave the editor on an Untitled map.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "step",
+              "get_steps",
+              "cleanup",
+              "go_home"
+            ],
+            "type": "string"
+          },
+          "stepIndex": {
+            "description": "Step index to execute. Omit for step list.",
+            "type": "number"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "demo"
+    },
+    {
+      "description": "Editor commands, Python execution, PIE, undo/redo, hot reload, viewport, performance, sequencer, build pipeline, logs, editor control.\n\nActions:\n- start_editor: Launch Unreal Editor and BLOCK until it is fully ready (not merely until the socket answers), rendering a startup progress bar in the terminal. Returns the phase timeline it waited through. Do NOT poll get_engine_state or get_status afterwards: this call already waited, and a ready editor is the only way it returns success. Params: timeout? (seconds, default 300)\n- get_engine_state: What the engine is REALLY doing, read from outside the game thread: startup phase from the editor's own log, process table (PID, command line, responding), the plugin's status snapshot (slow-task name and percent, active modal dialog, game-thread stall), and native dialog windows. Call this ONCE when something is already wrong (handlers timing out, an editor that will not come up). Never call it in a wait loop: start_editor blocks until ready on its own, and polling this during startup burns tokens re-reading state that is already tracked. Params: probeWindows? (default true; scans native windows, costs ~2s)\n- stop_editor: Close Unreal Editor gracefully (asks the editor to quit itself via the bridge; never an OS kill). Acts only on the editor for the loaded project, resolved from the port lockfile that editor published at <project>/Saved/UE_MCP_Bridge/port.json. With no lockfile there is no port to aim at and the call refuses, naming the file it checked, rather than probing a default port that another project's editor could answer on (#819).\n- restart_editor: Stop then start the editor for the loaded project. Editors for other projects are left alone: the stop is aimed by this project's port lockfile, and the decision to start is made from the process holding this project's .uproject open, never from whether some editor is running (#819).\n- build_project: Build the project's C++ code using Unreal Build Tool. Editor should be stopped first.\n- execute_command: Run console command. Params: command\n- execute_python: GATED LAST RESORT. execute_python is unreachable until a semantic tool search over your taskSummary has been run AND every candidate it returns is EXPLICITLY ruled out with a stated reason. Flow: (1) call with taskSummary (+code) - it returns the candidate actions; (2) re-call with the same taskSummary/code PLUS ruledOut=[{action, reason}] giving a specific reason each candidate does not fit. Python runs only once every candidate is ruled out. Params: code, taskSummary (required), ruledOut?, resultVariable? (name of a top-level variable to return as `result`, separate from print()/log; #732) (#704)\n- run_python_file: Run a Python file from disk with __file__/__name__ populated (#142). Params: filePath, args?, resultVariable? (name of a top-level variable to return as `result`, separate from logs; #732)\n- purge_python_modules: Purge cached embedded-Python modules whose name starts with a prefix, so the editor drops stale code after you edit a Python tool on disk. Returns the purged module names + count. Params: prefix (required, non-empty) (#719)\n- close_sequence: Close the currently open Level Sequence editor (Sequencer). Do this before bulk-deleting actors a sequence may possess - open sequences re-resolve possessables by name during destruction and can mis-bind. Returns wasOpen + closedSequence (#718)\n- open_tab: Open a registered editor tab by ID so its UI can be screenshotted as evidence (e.g. 'ProjectSettings', 'OutputLog', 'ContentBrowserTab1'). Params: tabId (#727)\n- open_settings: Open (and navigate) a settings viewer for visual settings evidence. Params: container? (Project|Editor; default Project), category? (e.g. 'Engine'), section? (e.g. 'Physics', or a combined 'Engine.Physics') (#727)\n- set_property: Set UObject property. Saves the package to disk by default; pass save=false to leave it dirty in-memory (batch many writes, then editor(save_dirty)/asset(save)) (#674). TMap values take either { \"Key\": value } or, for struct keys, [{ key: {...}, value: ... }] - exactly what get_property/describe_object return under `value`. A write that cannot store every entry it was given fails and leaves the old value in place; containers report elementCount on success (#820). Params: objectPath, propertyName, value, save? (default true)\n- get_property: Read UObject property. `value` is structured JSON and is always safe to write straight back with set_property; `valueText` is UE export text and for a struct-keyed TMap does not read back, so valueTextRoundTrips reports whether it can be reused (#820). Params: objectPath, propertyName\n- describe_object: Describe a UObject and optionally list/read properties. Per property, `value` is the round-trippable structured form and valueTextRoundTrips flags export text that is not (#820). Params: objectPath, includeProperties?, includeValues?, propertyNames?\n- play_in_editor: PIE control. Params: pieAction (start|stop|status), waitForAssetRegistry? (start only; default true - block until the AssetRegistry initial scan completes before requesting PIE, otherwise PIE silently no-ops on cold editor starts), assetRegistryTimeoutSeconds? (default 180) (#406)\n- play_in_editor_ignore_blueprint_errors: Start PIE for one launch with the editor's unresolved-Blueprint-error prompt suppressed. PIE then runs whatever bytecode those Blueprints last compiled to, so the launch is authorized per call: set ue-mcp.pie.allowIgnoreBlueprintErrors to true in your ue-mcp config to pre-authorize it, otherwise the user answers an MCP approval prompt. The bridge refuses the launch when a Blueprint would have to be recompiled first (dirty non-data Blueprints, errored Level Blueprints) and lists every errored Blueprint it suppressed in loadedErroredBlueprints. Params: waitForAssetRegistry? (default true), assetRegistryTimeoutSeconds? (default 180).\n- get_runtime_value: Read PIE actor property. Params: actorLabel, propertyName (supports dotted paths: component.field or component.struct.field for nested reads on component subobjects, #344/#381)\n- get_pie_pawn: Resolve the controlled pawn in the active PIE world. Params: playerIndex? (default 0). Returns actorLabel/class/location/rotation (#228/#229)\n- list_pie_instances: List the running PIE worlds with their instance id, net mode (standalone|listenServer|dedicatedServer|client), player count and whether they own a game viewport. In a multiplayer PIE session every other runtime action resolves the primary world (the server) unless you pass pieInstance, so this is how you discover that a client exists and what id addresses it. Params: none (#778)\n- invoke_object_function: Call a UFUNCTION on any UObject, not just a placed actor. Target it with objectPath, or target=gameinstance|gamemode|gamestate|playercontroller|playerpawn|subsystem (subsystem also needs subsystemClass; playercontroller/playerpawn accept playerIndex). The GameInstance, GameMode and subsystems have no actor label, so invoke_function could never reach them. Returns output and return params under returnValues; an unknown function name lists the available ones. Params: functionName, objectPath? | target?, subsystemClass?, playerIndex?, args?, world? (editor|pie|auto), pieInstance? (#739)\n- invoke_object_functions: Call 1-64 UFUNCTIONs in order without yielding to the editor tick loop. Each call independently targets a UObject using the same fields as invoke_object_function, so one sequence can span an actor and its components. Calls stop at the first failure; earlier calls are not rolled back. Returns results[] in call order plus completedCalls/requestedCalls, and failedIndex when it stops early, so a retry can resume instead of replaying mutations. Params: calls[] ({functionName, objectPath? | target?, subsystemClass?, playerIndex?, args?}), world? (editor|pie|auto), pieInstance?\n- read_bone_transforms: Read live skeletal bone and socket transforms off an actor, once. This is a point-in-time read, NOT a time series - for per-frame capture over a window use the pie category's observe actions. Pass bones (bone OR socket names) or omit for every bone up to limit. space=world (default) or component; component space is independent of where the actor is standing. Pass relativeTo (bone OR socket name) to express every sample in that live reference frame; relativeTo supersedes space and is calculated in component space. Also reports the AnimInstance class/path. Params: actorLabel, componentName?, bones?, relativeTo?, space?, limit?, world? (editor|pie|auto), pieInstance? (#756/#757/#761/#764)\n- get_object_properties: Read reflected properties off any UObject, with the same targeting as invoke_object_function. Blueprint-declared variables are reflected properties, so they read the same way as native ones. Pass propertyNames to filter; entries may use the Details-panel spelling ('World Context Object' finds WorldContextObject, 'Is Active' finds bIsActive). Names that do not exist come back under missingProperties instead of silently returning nothing. Properties holding a TMap are also reported under `values` in the structured form set_property accepts, because export text cannot carry a struct-keyed map back (#820). Params: objectPath? | target?, subsystemClass?, playerIndex?, propertyNames?, world? (editor|pie|auto), pieInstance? (#739/#802)\n- set_movement_mode: Set a live PIE character's movement mode and/or velocity on its CharacterMovementComponent. Modes are named (none|walking|navwalking|falling|swimming|flying|custom) rather than raw enum numbers, because a wrong number reads as success and then behaves as None. Reports previousMode/previousVelocity and reads the mode back afterwards, since SetMovementMode can refuse a mode the character cannot enter (flying with bCanFly off, swimming outside a volume). Params: actorLabel, mode?, customMode? (only with mode='custom'), velocity? {x,y,z}, world? (default pie), pieInstance? (#757)\n- set_object_property: Write a reflected property on a live UObject instance, with the same targeting as invoke_object_function. Use this for a PIE actor, a spawned widget or any runtime instance: editor(set_property) is the asset path and marks the package dirty and saves it, which a live instance has no business doing. propertyName accepts dotted/indexed paths and the Details-panel spelling. Reports previousValue plus the value read back after the write, so a coerced or clamped write is visible. Nothing is saved; pass postEditChange=true to fire PostEditChangeProperty. Params: propertyName, value, objectPath? | target?, subsystemClass?, playerIndex?, postEditChange?, world? (editor|pie|auto), pieInstance? (#802)\n- find_object: Resolve or search for a live UObject instance and report the objectPath that addresses it, which is what invoke_object_function / get_object_properties / set_object_property need. Pass objectPath to check one path (returns found/isValid rather than failing when it is gone), or className and/or nameContains to search every loaded object. className takes a short name (StaticMeshActor), a /Script path, a generated class name (WBP_Hud_C) or a Blueprint asset path. This is how you get the path of something spawned at runtime, an editor utility widget or a UMG widget, which no naming convention predicts. Params: objectPath? | className?, nameContains?, outerPath?, exactClass?, includeDefaults?, world? (any (default)|editor|pie), pieInstance?, limit? (default 50) (#802)\n- teleport_runtime_actor: Move a live PIE actor and have it STAY moved. A plain SetActorLocation on a Character is undone by CharacterMovement on the next tick, so this stops the movement component, teleports, and stops it again. Reports actualLocation read back from the actor rather than what was requested. Params: actorLabel, location?, rotation?, stopMovement? (default true), sweep? (default false), world? (default pie), pieInstance? (#770/#777)\n- invoke_static_function: Call a static UFUNCTION on a UBlueprintFunctionLibrary (no actor instance). invoke_function needs an actor/component target; this targets the library class CDO instead, so it reaches static *_BlueprintOnly libraries (Voxel sculpt/query/stamp), GeometryScript, Kismet math, any function library. Params: className (short name or /Script/Module.Class path), functionName, args? (name -> JSON value, same marshalling as invoke_function), actorArgs? (name -> actor label for UObject* params that are actors, e.g. the sculpt actor), worldContextParam? (name of a UObject* param to fill with the editor/PIE world; auto-detected for params named WorldContextObject), world? (editor|pie). Returns return/out params under returnValues. Discover libraries + functions with list_function_libraries.\n- invoke_function: Call a BlueprintCallable / Exec UFUNCTION on a target actor or one of its components. world=editor (the default) runs the function on the actor placed in the level, no PIE session needed, and reports which instance ran it as resolvedActorLabel/resolvedActorPath. actorLabel is matched against placed actors by editor label first, then internal object name, then full object path; a miss is an error naming what was searched (#806). Params: actorLabel, functionName, component? (component subobject name; redirects target from the actor to that component, #382), args? (object; struct values accept a JSON object such as {X,Y,Z} as well as an export-text string), actorArgs? (object mapping UObject* parameter name to actor label, resolved against live actors in the active world; #383), world? (editor|pie). Returns out/return params (#228/#229)\n- list_function_libraries: Enumerate UBlueprintFunctionLibrary subclasses on this build. Filter by name (case-insensitive substring, e.g. 'GeometryScript' / 'Kismet' / 'Animation'). Returns name, module, and (by default) every static BlueprintCallable function on the library with its tooltip. Use to discover what's available for editor.invoke_function (#455). Params: pattern?, includeFunctions?\n- set_pie_time_scale: Fast-forward PIE game time. Params: factor (>0). Raises WorldSettings caps and calls SetGlobalTimeDilation.\n- hot_reload: Hot reload C++\n- undo: Undo last transaction\n- redo: Redo last transaction\n- get_perf_stats: Editor performance stats\n- run_stat: Run a stat overlay. Params: name (bare stat name, e.g. 'unit','fps','game','gpu') OR command (full console command). A bare name is prefixed with 'stat ' (#722).\n- set_scalability: Set rendering quality via the Scalability system (actually applies + persists, not just sg.* cvars). Params: level (Low|Medium|High|Epic|Cinematic). Returns appliedLevels (#591)\n- set_cvars: Bulk-set console variables. Params: cvars ({name: value} object OR [{name, value}] array). Returns per-cvar old/new values and any notFound names (#591)\n- capture_screenshot: Screenshot. target=pie synchronously captures the selected PIE client game viewport with UMG/Slate UI; target=editor captures the level viewport; target=window synchronously captures a whole Slate window via FSlateApplication::TakeScreenshot - pixel-true for ALL Slate/UMG UI, returns after the PNG is written, and works while the window is unfocused or off-screen. Multi-instance PIE automatically prefers a world with a game viewport; pass pieInstance or worldPath to select explicitly, which for target=window is what picks the PIE client window instead of the active editor window. Every mode captures at the source viewport/window size - use capture_scene_png for a chosen output size. Params: filename?, target? (auto|pie|editor|window), pieInstance?, worldPath?. Returns the resolved PIE instance/world and image dimensions (#226/#724).\n- capture_scene_png: Headless PNG screenshot via SceneCapture2D (works unfocused, guaranteed RGBA8 LDR). focusActorLabel auto-frames the camera on an actor's bounds; world:pie captures the running game world (#599). Params: outputPath, location?, rotation?, focusActorLabel?, focusDirection?, focusMargin?, world? (editor|pie), width? (default 1280), height? (default 720), fov? (default 90) (#148/#599)\n- set_realtime: Toggle realtime update on the level editor viewports so the editor-world sim (Niagara, anims) ticks - otherwise capture_scene_png renders an unticked, empty sim. Params: enabled (default true) (#537)\n- get_viewport: Get viewport camera\n- hit_test_viewport_pixel: Ray-cast from a screen pixel through the active editor viewport and return the first hit. Builds the ray from the live viewport's projection matrix (no FOV/aspect guessing). Returns hit + actorLabel/actorClass/componentName/componentClass/materialPath/location/impactPoint/normal/distance/faceIndex/boneName/physicalMaterial. Params: x, y (pixel coords), width? height? (override viewport size when picking from a different-resolution screenshot), maxDistance? (default 200000), ignoreActors? (array of actor labels) (#418)\n- get_runtime_values: Bulk runtime read across the active world. For each actor/component matching classFilter, resolves every path against the (actor|component) root and returns rows of {actorLabel, actorClass, componentName?, componentClass?, values, errors?}. Paths support property hops, sub-object hops, and zero-arg BlueprintCallable getter calls at any segment (e.g. 'PowerConnector.GetRequired' reaches a UFUNCTION on a UObject sub-object). classFilter matches actor class OR component class - omit to match everything. World defaults to PIE if running, else editor. Params: classFilter?, paths[], world? (editor|pie) (#414)\n- set_viewport: Set viewport camera. Params: location?, rotation?\n- focus_on_actor: Focus on actor. Params: actorLabel\n- create_sequence: Create Level Sequence. Params: name, packagePath?\n- get_sequence_info: Read sequence: bindings (possessable/spawnable) with their Sequencer tags (#556), tracks, and optional section detail. Params: assetPath, includeSectionDetails? (attach sockets, first transform key values per track)\n- add_sequence_track: Add an empty track. Params: assetPath, trackType, actorLabel?\n- add_sequence_section: Add a section to a track (creating the track if needed), set its start/end in seconds, and for a CameraCut track bind it to a camera. Returns the section index + channel names to key. Params: sequencePath, trackType (Transform|Float|Fade|CameraCut|Audio|Event|SkeletalAnimation), actorLabel? (binding scope), startSeconds?, endSeconds?, cameraActorLabel? (#548)\n- set_sequence_keyframes: Add keyframes to a section channel. Transform channels: Location.X/Y/Z, Rotation.X/Y/Z (or friendly x/y/z, yaw/pitch/roll); Fade/Float: the float channel. Params: sequencePath, trackType, actorLabel?, sectionIndex? (default 0), channel, keyframes ([{seconds, value}]), interpolation? (cubic|linear) (#548)\n- set_sequence_playback_range: Set a Level Sequence's playback range in seconds. Params: sequencePath, startSeconds, endSeconds (#548)\n- play_sequence: Play/stop/pause a Level Sequence in Sequencer. Pass sequencePath (or assetPath) to target a specific sequence - it is opened first, because the underlying Sequencer commands act on whatever is currently open. Omit it and the call applies to the open sequence and says so. Params: sequencePath? (or assetPath), sequenceAction? (play|pause|stop, default play)\n- build_all: Build all (geometry, lighting, paths, HLOD)\n- build_geometry: Rebuild BSP geometry\n- build_hlod: Build HLODs\n- validate_assets: Run data validation. Params: directory?\n- get_build_status: Get build/map status\n- cook_content: Cook content. Params: platform?\n- get_log: Read output log. Params: maxLines?, filter?, category?\n- search_log: Search log. Params: query\n- get_message_log: Read a Message Log listing (MapCheck, AssetCheck, PIE, LoadErrors, LightingResults...). Call with NO logName to list the registered listings with their error/warning counts, then read one. Counts come from the listing itself; message bodies come from the current page and honour the Message Log tab's severity checkboxes, so when fewer are readable than exist the response says so instead of reading clean. An unknown logName is an error, not an empty log. Blueprint COMPILE results are not here - the compiler makes a listing per Blueprint; use blueprint(compile). Params: logName?, maxLines? (default 200), severity? (severity-name substring)\n- list_crashes: List crash reports\n- get_crash_info: Get crash details. Params: crashFolder\n- check_for_crashes: Check for recent crashes\n- set_dialog_policy: Auto-respond to dialogs matching a pattern. Params: pattern, response\n- clear_dialog_policy: Clear dialog policies. Params: pattern?\n- get_dialog_policy: Get current dialog policies\n- list_dialogs: List active modal dialogs, with title, message text and button labels. Runs even while a dialog is blocking the editor, when every other handler times out\n- respond_to_dialog: Click a button on the active modal dialog, releasing the game thread. Runs even while the dialog is blocking the editor. Pass action='close' to destroy the dialog window when no button label fits. Params: buttonIndex?, buttonLabel?, action? (escape or close)\n- open_asset: Open asset in its editor. Params: assetPath\n- reload_bridge: Hot-reload Python bridge handlers from disk\n- save_dirty: Flush every dirty package and return a per-package saved/failed map. Use after multi-step CDO/component edits when set_class_default leaves the asset dirty without persisting (#378). Params: includeMaps? (default true), includeContent? (default true)\n- configure_pie: Set ULevelEditorPlaySettings - multi-client PIE, net mode, single-process flag, Play-in-New-Window resolution. Params: numClients?, netMode? (standalone|listen|client), runUnderOneProcess?, launchSeparateServer?, newWindowWidth?, newWindowHeight? (#384/#671)\n- get_pie_config: Read current ULevelEditorPlaySettings (numClients, netMode, single-process, separate-server) (#384)\n- pie_set_player_view: Point the running PIE player's view (control rotation) at a pitch/yaw/roll so a capture frames the intended direction. Requires PIE. Params: pitch?, yaw?, roll? (#671)\n- stage_game_input: Stage input for the running game: set input mode (gameOnly|gameAndUI|uiOnly) and mouse cursor so injected/simulated input reaches the pawn. This only sets the mode - the injection itself lives in the pie category (pie(inject_input*)), not here. Requires PIE. Params: inputMode? (default gameOnly), showMouseCursor? (#671)\n- run_automation_tests: Run registered Automation tests matching a filter and return per-test pass/fail plus error lines. Runs them synchronously through the test framework rather than the console queue, and suspends the editor's unfocused-CPU throttle for the duration - otherwise an unfocused editor drops to a few FPS and the framework's interactive-frame-rate gate never opens, leaving tests queued forever (#765). Params: filter?, maxTests? (default 50) (#693)\n- list_dirty_packages: Enumerate currently-dirty content + map packages, read from the editor's own dirty-package lists (the same ones Save All uses). Includes a never-saved /Temp world, because an unsaved new map is exactly the unsaved work a caller needs to see before closing or reloading (#340)\n- request_editor_shutdown: Ask the editor to close itself from inside the engine, after it has checked that closing is safe. Refuses by default when any content or map package is dirty (including an unsaved /Temp world) and reports which ones, so nothing is lost to a silent discard. Ends an active PIE/SIE session first and closes only once play has actually stopped. The response is returned before the process exits. Use editor(stop_editor) for the full stop-and-confirm flow; this action is the in-engine half of it. Params: requireClean? (default true), endPIE? (default true)\n\nEpic 5.8 toolset actions (25): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "start_editor",
+              "get_engine_state",
+              "stop_editor",
+              "restart_editor",
+              "build_project",
+              "execute_command",
+              "execute_python",
+              "run_python_file",
+              "purge_python_modules",
+              "close_sequence",
+              "open_tab",
+              "open_settings",
+              "set_property",
+              "get_property",
+              "describe_object",
+              "play_in_editor",
+              "play_in_editor_ignore_blueprint_errors",
+              "get_runtime_value",
+              "get_pie_pawn",
+              "list_pie_instances",
+              "invoke_object_function",
+              "invoke_object_functions",
+              "read_bone_transforms",
+              "get_object_properties",
+              "set_movement_mode",
+              "set_object_property",
+              "find_object",
+              "teleport_runtime_actor",
+              "invoke_static_function",
+              "invoke_function",
+              "list_function_libraries",
+              "set_pie_time_scale",
+              "hot_reload",
+              "undo",
+              "redo",
+              "get_perf_stats",
+              "run_stat",
+              "set_scalability",
+              "set_cvars",
+              "capture_screenshot",
+              "capture_scene_png",
+              "set_realtime",
+              "get_viewport",
+              "hit_test_viewport_pixel",
+              "get_runtime_values",
+              "set_viewport",
+              "focus_on_actor",
+              "create_sequence",
+              "get_sequence_info",
+              "add_sequence_track",
+              "add_sequence_section",
+              "set_sequence_keyframes",
+              "set_sequence_playback_range",
+              "play_sequence",
+              "build_all",
+              "build_geometry",
+              "build_hlod",
+              "validate_assets",
+              "get_build_status",
+              "cook_content",
+              "get_log",
+              "search_log",
+              "get_message_log",
+              "list_crashes",
+              "get_crash_info",
+              "check_for_crashes",
+              "set_dialog_policy",
+              "clear_dialog_policy",
+              "get_dialog_policy",
+              "list_dialogs",
+              "respond_to_dialog",
+              "open_asset",
+              "reload_bridge",
+              "save_dirty",
+              "configure_pie",
+              "get_pie_config",
+              "pie_set_player_view",
+              "stage_game_input",
+              "run_automation_tests",
+              "list_dirty_packages",
+              "request_editor_shutdown",
+              "epic_world_pos_to_screen_coords",
+              "epic_stop_pie",
+              "epic_start_pie",
+              "epic_set_content_browser_path",
+              "epic_set_camera_transform",
+              "epic_select_assets",
+              "epic_select_actors",
+              "epic_search_cvars",
+              "epic_screen_coords_to_world",
+              "epic_open_editor_for_asset",
+              "epic_is_pierunning",
+              "epic_get_visible_actors",
+              "epic_get_selected_assets",
+              "epic_get_selected_actors",
+              "epic_get_open_assets",
+              "epic_get_content_browser_path",
+              "epic_get_camera_transform",
+              "epic_focus_on_actors",
+              "epic_capture_viewport",
+              "epic_capture_editor_image",
+              "epic_capture_asset_image",
+              "epic_set_verbosity",
+              "epic_get_verbosity",
+              "epic_get_log_entries",
+              "epic_get_log_categories"
+            ],
+            "type": "string"
+          },
+          "actorArgs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "invoke_function: map of UObject* parameter name to actor label, resolved against live actors in the active world (#383)",
+            "type": "object"
+          },
+          "actorLabel": {
+            "type": "string"
+          },
+          "args": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": [
+                        "string",
+                        "number",
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    {
+                      "additionalProperties": true,
+                      "properties": {},
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": [
+                              "string",
+                              "number",
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          {
+                            "additionalProperties": true,
+                            "properties": {},
+                            "type": "object"
+                          },
+                          {
+                            "items": {
+                              "type": [
+                                "string",
+                                "number",
+                                "boolean",
+                                "null"
+                              ]
+                            },
+                            "type": "array"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "anyOf": [
+                        {
+                          "type": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "null"
+                          ]
+                        },
+                        {
+                          "additionalProperties": true,
+                          "properties": {},
+                          "type": "object"
+                        },
+                        {
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": [
+                                  "string",
+                                  "number",
+                                  "boolean",
+                                  "null"
+                                ]
+                              },
+                              {
+                                "additionalProperties": true,
+                                "properties": {},
+                                "type": "object"
+                              },
+                              {
+                                "items": {
+                                  "type": [
+                                    "string",
+                                    "number",
+                                    "boolean",
+                                    "null"
+                                  ]
+                                },
+                                "type": "array"
+                              }
+                            ]
+                          },
+                          "type": "array"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "run_python_file: array of positional args. invoke_function / invoke_object_function / invoke_static_function: object mapping parameter name to value, e.g. {\"bEnabled\": true}. An entry list ([{\"name\",\"value\"}]) or a JSON string of either is accepted and normalized (#811)"
+          },
+          "assetPath": {
+            "type": "string"
+          },
+          "assetRegistryTimeoutSeconds": {
+            "description": "play_in_editor start: wait budget for the AssetRegistry scan (default 180s)",
+            "type": "number"
+          },
+          "bones": {
+            "description": "read_bone_transforms: bone OR socket names; omit for every bone (#756)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "buttonIndex": {
+            "description": "Index of button to click in active dialog",
+            "type": "number"
+          },
+          "buttonLabel": {
+            "description": "Label of button to click in active dialog",
+            "type": "string"
+          },
+          "calls": {
+            "description": "invoke_object_functions: ordered UObject calls executed in one game-thread dispatch",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "args": {
+                  "$ref": "#/properties/args"
+                },
+                "functionName": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "objectPath": {
+                  "type": "string"
+                },
+                "playerIndex": {
+                  "type": "integer"
+                },
+                "subsystemClass": {
+                  "type": "string"
+                },
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "functionName"
+              ],
+              "type": "object"
+            },
+            "maxItems": 64,
+            "minItems": 1,
+            "type": "array"
+          },
+          "cameraActorLabel": {
+            "description": "add_sequence_section CameraCut: camera actor to bind (#548)",
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "channel": {
+            "description": "set_sequence_keyframes: channel name (Location.X, Rotation.Z, yaw, fade...) (#548)",
+            "type": "string"
+          },
+          "classFilter": {
+            "description": "get_runtime_values: actor or component class name (omit for all)",
+            "type": "string"
+          },
+          "className": {
+            "description": "invoke_static_function: UBlueprintFunctionLibrary class - short name or /Script/Module.Class path. find_object: class to search for, including Blueprint generated classes (#802)",
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "component": {
+            "description": "invoke_function: optional component subobject name to call the function on instead of the actor (#382)",
+            "type": "string"
+          },
+          "componentName": {
+            "description": "read_bone_transforms: which SkeletalMeshComponent to read; omit for the first one (#756)",
+            "type": "string"
+          },
+          "container": {
+            "description": "open_settings: settings container - Project | Editor (#727)",
+            "type": "string"
+          },
+          "crashFolder": {
+            "type": "string"
+          },
+          "customMode": {
+            "description": "set_movement_mode: 0-255, only with mode='custom' (#757)",
+            "type": "integer"
+          },
+          "cvars": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "type": "object"
+              },
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {}
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "set_cvars: {name: value} object or [{name, value}] array of console variables (#591)"
+          },
+          "directory": {
+            "type": "string"
+          },
+          "enabled": {
+            "description": "set_realtime: enable/disable viewport realtime update (#537)",
+            "type": "boolean"
+          },
+          "endPIE": {
+            "description": "request_editor_shutdown: end an active PIE/SIE session before closing (default true); false refuses to close while play is running",
+            "type": "boolean"
+          },
+          "endSeconds": {
+            "description": "Section/playback range end in seconds (#548)",
+            "type": "number"
+          },
+          "exactClass": {
+            "description": "find_object: match className exactly instead of including subclasses (default false) (#802)",
+            "type": "boolean"
+          },
+          "factor": {
+            "description": "Time-scale factor for set_pie_time_scale (e.g. 500)",
+            "type": "number"
+          },
+          "filePath": {
+            "description": "Absolute path to a .py file for run_python_file",
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "filter": {
+            "type": "string"
+          },
+          "focusActorLabel": {
+            "description": "capture_scene_png: auto-frame the camera on this actor's bounds (#599)",
+            "type": "string"
+          },
+          "focusDirection": {
+            "$ref": "#/properties/location",
+            "description": "capture_scene_png: framing direction from the actor (default front/above) (#599)"
+          },
+          "focusMargin": {
+            "description": "capture_scene_png: bounds fill margin, higher pulls back (default 1.5) (#599)",
+            "type": "number"
+          },
+          "fov": {
+            "description": "Capture FOV in degrees",
+            "type": "number"
+          },
+          "fullyLoadTextures": {
+            "description": "capture_scene_png: force-stream textures + flush render thread before capture to avoid the checker/stale frame (default true) (#662)",
+            "type": "boolean"
+          },
+          "functionName": {
+            "type": "string"
+          },
+          "height": {
+            "description": "Capture height in pixels",
+            "type": "number"
+          },
+          "ignoreActors": {
+            "description": "hit_test_viewport_pixel: actor labels to skip",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "includeContent": {
+            "description": "save_dirty: include content packages (default true)",
+            "type": "boolean"
+          },
+          "includeDefaults": {
+            "description": "find_object: include class default objects and archetypes (default false) (#802)",
+            "type": "boolean"
+          },
+          "includeFunctions": {
+            "description": "list_function_libraries: include each library's function listing (default true) (#455)",
+            "type": "boolean"
+          },
+          "includeMaps": {
+            "description": "save_dirty: include map packages (default true)",
+            "type": "boolean"
+          },
+          "includeProperties": {
+            "description": "describe_object: include reflected property metadata (default true)",
+            "type": "boolean"
+          },
+          "includeSectionDetails": {
+            "description": "Include attach sockets + first-key transform values in get_sequence_info",
+            "type": "boolean"
+          },
+          "includeValues": {
+            "description": "describe_object: include current property values (default false)",
+            "type": "boolean"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "inputMode": {
+            "description": "stage_game_input: gameOnly|gameAndUI|uiOnly (#671)",
+            "type": "string"
+          },
+          "interpolation": {
+            "description": "set_sequence_keyframes: cubic (default) or linear (#548)",
+            "type": "string"
+          },
+          "keyframes": {
+            "description": "set_sequence_keyframes: [{seconds, value}] (#548)",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "seconds": {
+                  "type": "number"
+                },
+                "value": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "seconds",
+                "value"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "launchSeparateServer": {
+            "description": "configure_pie: separate dedicated server",
+            "type": "boolean"
+          },
+          "level": {
+            "type": "string"
+          },
+          "limit": {
+            "description": "read_bone_transforms: max bones when 'bones' is omitted (default 200). get_object_properties: max properties returned (default 200). find_object: max matches returned (default 50) (#756/#739/#802)",
+            "type": "number"
+          },
+          "location": {
+            "additionalProperties": false,
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "z": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "z"
+            ],
+            "type": "object"
+          },
+          "logName": {
+            "description": "get_message_log: listing name; omit to enumerate the registered listings",
+            "type": "string"
+          },
+          "maxDistance": {
+            "description": "hit_test_viewport_pixel: max ray length in cm (default 200000)",
+            "type": "number"
+          },
+          "maxLines": {
+            "type": "number"
+          },
+          "maxTests": {
+            "description": "run_automation_tests: cap on tests to run (default 50) (#693)",
+            "type": "number"
+          },
+          "maxValueLength": {
+            "description": "get_object_properties: truncate each exported value past this many characters (default 2000) (#739)",
+            "type": "number"
+          },
+          "mode": {
+            "description": "set_movement_mode: none|walking|navwalking|falling|swimming|flying|custom (#757)",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nameContains": {
+            "description": "find_object: case-insensitive substring of the object name (#802)",
+            "type": "string"
+          },
+          "netMode": {
+            "description": "configure_pie: standalone | listen | client",
+            "type": "string"
+          },
+          "newWindowHeight": {
+            "description": "configure_pie: Play-in-New-Window height (#671)",
+            "type": "number"
+          },
+          "newWindowWidth": {
+            "description": "configure_pie: Play-in-New-Window width (#671)",
+            "type": "number"
+          },
+          "numClients": {
+            "description": "configure_pie: number of PIE clients",
+            "type": "number"
+          },
+          "objectPath": {
+            "type": "string"
+          },
+          "outerPath": {
+            "description": "find_object: only objects somewhere under this outer, e.g. one level or world (#802)",
+            "type": "string"
+          },
+          "outputPath": {
+            "description": "Absolute or project-relative output path for capture_scene_png (e.g. \"Saved/Screenshots/cap.png\")",
+            "type": "string"
+          },
+          "packagePath": {
+            "type": "string"
+          },
+          "paths": {
+            "description": "get_runtime_values: dotted property/function paths to evaluate per match",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "pattern": {
+            "description": "Substring filter - dialog title/message, or library name for list_function_libraries (#455)",
+            "type": "string"
+          },
+          "pieAction": {
+            "enum": [
+              "start",
+              "stop",
+              "status"
+            ],
+            "type": "string"
+          },
+          "pieInstance": {
+            "description": "Select which PIE world to target: 0 = server/primary, 1..N = clients. See list_pie_instances (#778)",
+            "type": "number"
+          },
+          "pitch": {
+            "description": "pie_set_player_view: control-rotation pitch (#671)",
+            "type": "number"
+          },
+          "platform": {
+            "type": "string"
+          },
+          "playerIndex": {
+            "description": "get_pie_pawn: 0-based player index (default 0)",
+            "type": "number"
+          },
+          "postEditChange": {
+            "description": "set_object_property: fire PostEditChangeProperty after the write (default false) (#802)",
+            "type": "boolean"
+          },
+          "prefix": {
+            "description": "purge_python_modules: purge sys.modules entries starting with this prefix (#719)",
+            "type": "string"
+          },
+          "probeWindows": {
+            "description": "get_engine_state: also enumerate native windows to catch pre-Slate dialogs (default true, costs ~2s)",
+            "type": "boolean"
+          },
+          "propertyName": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "description": "describe_object: dotted/indexed property paths. get_object_properties: only these properties (#739)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "query": {
+            "type": "string"
+          },
+          "relativeTo": {
+            "description": "read_bone_transforms: express every sample relative to this live bone OR socket; supersedes space",
+            "type": "string"
+          },
+          "requireClean": {
+            "description": "request_editor_shutdown: refuse to close while any content or map package is dirty (default true)",
+            "type": "boolean"
+          },
+          "response": {
+            "description": "Auto-response for matched dialogs",
+            "enum": [
+              "yes",
+              "no",
+              "ok",
+              "cancel",
+              "retry",
+              "continue",
+              "yesall",
+              "noall"
+            ],
+            "type": "string"
+          },
+          "resultVariable": {
+            "description": "execute_python/run_python_file: name of a top-level Python variable to return as `result`, separate from print()/log output (#732)",
+            "type": "string"
+          },
+          "roll": {
+            "description": "pie_set_player_view: control-rotation roll (#671)",
+            "type": "number"
+          },
+          "rotation": {
+            "additionalProperties": false,
+            "properties": {
+              "pitch": {
+                "type": "number"
+              },
+              "roll": {
+                "type": "number"
+              },
+              "yaw": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "pitch",
+              "yaw",
+              "roll"
+            ],
+            "type": "object"
+          },
+          "ruledOut": {
+            "description": "execute_python: reason each searched candidate action does not fit; every candidate must be ruled out before Python runs (#704)",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "action": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "action",
+                "reason"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "runUnderOneProcess": {
+            "description": "configure_pie: single-process flag",
+            "type": "boolean"
+          },
+          "save": {
+            "description": "set_property: save package to disk after the write (default true; false leaves it dirty) (#674)",
+            "type": "boolean"
+          },
+          "section": {
+            "description": "open_settings: settings section, e.g. 'Physics' or 'Engine.Physics' (#727)",
+            "type": "string"
+          },
+          "sectionIndex": {
+            "description": "set_sequence_keyframes: target section index (default 0) (#548)",
+            "type": "number"
+          },
+          "sequenceAction": {
+            "enum": [
+              "play",
+              "stop",
+              "pause"
+            ],
+            "type": "string"
+          },
+          "sequencePath": {
+            "description": "Level Sequence asset path for sequencer authoring (#548)",
+            "type": "string"
+          },
+          "severity": {
+            "description": "get_message_log: severity-name substring (Error|Warning|PerformanceWarning|Info)",
+            "type": "string"
+          },
+          "showMouseCursor": {
+            "description": "stage_game_input: show mouse cursor (#671)",
+            "type": "boolean"
+          },
+          "space": {
+            "description": "read_bone_transforms: world (default) | component (#756)",
+            "type": "string"
+          },
+          "startSeconds": {
+            "description": "Section/playback range start in seconds (#548)",
+            "type": "number"
+          },
+          "stopMovement": {
+            "description": "teleport_runtime_actor: stop the movement component so the move is not undone (default true) (#777)",
+            "type": "boolean"
+          },
+          "subsystemClass": {
+            "description": "invoke_object_function/get_object_properties: subsystem class name or /Script path (#739)",
+            "type": "string"
+          },
+          "sweep": {
+            "description": "teleport_runtime_actor: collide on the way (default false) (#777)",
+            "type": "boolean"
+          },
+          "tabId": {
+            "description": "open_tab: registered editor tab ID, e.g. 'ProjectSettings' (#727)",
+            "type": "string"
+          },
+          "target": {
+            "description": "capture_screenshot: auto (default) | pie | editor | window. invoke_object_function/get_object_properties: gameinstance | gamemode | gamestate | playercontroller | playerpawn | subsystem (#739)",
+            "type": "string"
+          },
+          "taskSummary": {
+            "description": "execute_python: plain-words intent, searched against the tool registry to gate the call (#704)",
+            "type": "string"
+          },
+          "timeout": {
+            "description": "start_editor: seconds to wait for the bridge (default 120) (#758)",
+            "type": "number"
+          },
+          "trackType": {
+            "type": "string"
+          },
+          "value": {},
+          "velocity": {
+            "additionalProperties": false,
+            "description": "set_movement_mode: velocity written to the movement component (#757)",
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "z": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "z"
+            ],
+            "type": "object"
+          },
+          "waitForAssetRegistry": {
+            "description": "play_in_editor start: block until AssetRegistry finishes the initial scan (default true)",
+            "type": "boolean"
+          },
+          "width": {
+            "description": "Capture width in pixels",
+            "type": "number"
+          },
+          "world": {
+            "description": "invoke_function world scope: editor (default) | pie",
+            "type": "string"
+          },
+          "worldContextParam": {
+            "description": "invoke_static_function: name of a UObject* param to fill with the editor/PIE world (auto-detected for params named WorldContextObject)",
+            "type": "string"
+          },
+          "worldPath": {
+            "description": "capture_screenshot: select an exact PIE UWorld path or name",
+            "type": "string"
+          },
+          "x": {
+            "description": "hit_test_viewport_pixel: viewport pixel X",
+            "type": "number"
+          },
+          "y": {
+            "description": "hit_test_viewport_pixel: viewport pixel Y",
+            "type": "number"
+          },
+          "yaw": {
+            "description": "pie_set_player_view: control-rotation yaw (#671)",
+            "type": "number"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "editor"
+    },
+    {
+      "description": "The Unreal 5.8 AI Toolset Registry itself: discovery (status/list_toolsets/describe_toolset), direct dispatch (call_tool), and the registry's own meta-tooling (agent skills, programmatic tool batching). Toolsets that map to a real editor domain are NOT here - they are injected as epic_* actions on that domain's category (GAS in gas, Sequencer in animation, Dataflow in dataflow, and so on), so reach for the domain tool first and use this one to introspect or call the registry directly. Requires UE 5.8+ with the ToolsetRegistry plugin enabled - call epic(status) first to check availability.\n\nActions:\n- status: Report whether Epic's ToolsetRegistry is available and how many toolsets are registered. Never errors (reports available=false with a reason when the plugin is absent). Params: none\n- list_toolsets: List registered toolsets: name, version, description, tool names + count. Strips the verbose per-tool input/output schemas to stay small - use describe_toolset for those (or includeSchemas). Params: nameFilter? (case-sensitive substring on the qualified name), includeSchemas? (return full tool objects with input/output schemas)\n- describe_toolset: Full schema for one toolset: every tool with its input/output JSON schema. Params: toolset (qualified name from list_toolsets, e.g. 'GASToolsets.AttributeSetToolset')\n- call_tool: Execute a registered Epic tool exactly as its MCP server would. Params: toolset (qualified), tool (qualified name from describe_toolset, e.g. 'GASToolsets.AttributeSetToolset.ListAttributeSets'), input? (object) or inputJson? (raw JSON string). Returns the tool's JSON result.\n\nEpic 5.8 toolset actions (6): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "status",
+              "list_toolsets",
+              "describe_toolset",
+              "call_tool",
+              "epic_update_skill",
+              "epic_list_skills",
+              "epic_get_skills",
+              "epic_create_skill",
+              "epic_execute_tool_script",
+              "epic_get_execution_environment"
+            ],
+            "type": "string"
+          },
+          "includeSchemas": {
+            "description": "list_toolsets: include full per-tool input/output schemas instead of just tool names",
+            "type": "boolean"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "call_tool: tool arguments as a JSON object",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "call_tool: tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "nameFilter": {
+            "description": "list_toolsets: case-sensitive substring filter on the qualified toolset name",
+            "type": "string"
+          },
+          "tool": {
+            "description": "Qualified tool name, e.g. 'GASToolsets.AttributeSetToolset.ListAttributeSets'",
+            "type": "string"
+          },
+          "toolset": {
+            "description": "Qualified toolset name, e.g. 'GASToolsets.AttributeSetToolset'",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "epic"
+    },
+    {
+      "description": "Import Fab (Epic marketplace) content: check plugin/login status, trigger login/logout, sync your owned library into the Content Browser, inspect/clear the download cache, and import owned or local source files into the project.\n\nActions:\n- status: Report Fab plugin state: whether the module is loaded, whether the native import/cache API is linked in this build, whether the Fab window has been opened this session, and the download cache location/size. Call this first.\n- login: Trigger the Fab login flow (EOS account portal). Asynchronous - returns once the flow is opened, not once authenticated. Complete any prompt, then call status.\n- logout: Clear the persistent Fab authentication for this device.\n- sync_library: Load the user's owned Fab library (\"My Folder\") into the Content Browser via TEDS. Requires an active login; items appear asynchronously. Params: batchSize? (items per sync request).\n- list_cached: List the entries currently in the local Fab download cache (already-downloaded owned assets). Params: none.\n- cache_info: Report the Fab download cache location, total size, and entry count.\n- clear_cache: Delete the local Fab download cache to reclaim disk. Does not affect assets already imported into the project.\n- import_file: Import a source file into the project through the Fab Interchange import pipeline. Use for owned assets that are downloaded/cached locally, or any local source file (fbx, textures). Single files import synchronously and report the created asset paths; pack/quixel workflows may run asynchronously. Params: source (absolute path to the source file on disk), destination (content path like /Game/Fab/Imported).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "status",
+              "login",
+              "logout",
+              "sync_library",
+              "list_cached",
+              "cache_info",
+              "clear_cache",
+              "import_file"
+            ],
+            "type": "string"
+          },
+          "batchSize": {
+            "description": "sync_library: number of library items to pull per sync request",
+            "type": "number"
+          },
+          "destination": {
+            "description": "import_file: destination content path, e.g. /Game/Fab/Imported",
+            "type": "string"
+          },
+          "source": {
+            "description": "import_file: absolute path to the source file on disk",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "fab"
+    },
+    {
+      "description": "Submit feedback when a native tool falls short: a missing action, a wrong result, a crash, or a gap you had to work around with execute_python. A python workaround is a common trigger but is not required. Reports are routed to the tracker that owns the surface - ue-mcp core, or the plugin that provides it (PIE Studio, Perforce, Meshy, ...) - by consulting the published plugin registry.\n\nActions:\n- submit: Submit feedback about a tool gap (missing action, wrong behavior, crash, or a case you had to work around). Provide a specific title and a summary; pythonWorkaround and idealTool are optional enrichment, not prerequisites. Checks the plugin registry first and files against the owning plugin's repo when one matches, then blocks on an MCP elicitation prompt that asks the USER (not the agent) to approve or decline the exact payload - and to override the tracker - before anything is posted to GitHub.\n- route: Dry run the tracker routing for a report without posting anything. Returns the repo the issue would be filed against, the matched plugin (if any), and why. Params: title, summary, idealTool?, repo?. Use it when you are unsure whether a gap belongs to ue-mcp core or to an installed/published plugin.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "submit",
+              "route"
+            ],
+            "type": "string"
+          },
+          "author": {
+            "description": "Who the issue is authored by. \"user\" (default): credit me - requires a cached GitHub OAuth token. \"bot\": anonymous as the ue-mcp-feedback bot.",
+            "enum": [
+              "user",
+              "bot"
+            ],
+            "type": "string"
+          },
+          "idealTool": {
+            "description": "What tool/action should have handled this natively (e.g. 'blueprint(action=set_variable_default)').",
+            "type": "string"
+          },
+          "pythonWorkaround": {
+            "description": "The execute_python code that was used as a workaround.",
+            "type": "string"
+          },
+          "repo": {
+            "description": "Override the tracker, as \"owner/name\". Leave it off: submit picks the right repo from the plugin registry on its own. Only ue-mcp core and repos owned by registered plugins are accepted; anything else is ignored and the report files against core.",
+            "type": "string"
+          },
+          "summary": {
+            "description": "What the user was trying to accomplish and why the native tool couldn't handle it.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Short title describing the tool gap (do not include project-specific details).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action",
+          "title",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "name": "feedback"
+    },
+    {
+      "description": "Run pre-built named sequences for this project. ALWAYS check project(action=\"get_status\") first - its 'flows' field lists what's available. If a flow matches the user's request, run it via flow(action=\"run\", flowName=\"...\") instead of composing the sequence by hand. Config reloads on every call - no restart needed.\n\nActions:\n- run: Execute a flow. Params: flowName, skip?, params?, rollback_on_failure?\n- plan: Show execution plan without running. Params: flowName\n- list: List available flows\n\nStep types supported in YAML flows: any MCP action (category.action), nested flows (flow:),\nand 'shell' for running shell/exec commands. Example shell step:\n  steps:\n    1: { task: shell, options: { command: \"npm run up:build\" } }\n\nparams: Runtime options merged into every step's options (highest priority). Use to override YAML-hardcoded values like levelPath, directory, configuration, etc.\n\nrollback_on_failure: When true, rollback records from completed steps are invoked in reverse order if a subsequent step fails.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "run",
+              "plan",
+              "list"
+            ],
+            "type": "string"
+          },
+          "flowName": {
+            "description": "Flow name from ue-mcp.yml",
+            "type": "string"
+          },
+          "params": {
+            "additionalProperties": {},
+            "description": "Runtime options merged into every step's options (highest priority)",
+            "type": "object"
+          },
+          "rollback_on_failure": {
+            "description": "Invoke inverse tasks in reverse order on failure",
+            "type": "boolean"
+          },
+          "skip": {
+            "description": "Step names or numbers to skip",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "flow"
+    },
+    {
+      "description": "Foliage painting, types, sampling, and settings.\n\nActions:\n- list_types: List foliage types in level\n- get_settings: Read foliage type settings. Params: foliageTypeName\n- sample: Query instances in region. Params: center, radius, foliageType?\n- create_type: Create foliage type from mesh. Params: meshPath, name?, packagePath?\n- set_settings: Modify type settings. Params: foliageTypeName, settings",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "list_types",
+              "get_settings",
+              "sample",
+              "create_type",
+              "set_settings"
+            ],
+            "type": "string"
+          },
+          "center": {
+            "additionalProperties": false,
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "z": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "z"
+            ],
+            "type": "object"
+          },
+          "count": {
+            "type": "number"
+          },
+          "density": {
+            "type": "number"
+          },
+          "foliageType": {
+            "type": "string"
+          },
+          "foliageTypeName": {
+            "type": "string"
+          },
+          "meshPath": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "packagePath": {
+            "type": "string"
+          },
+          "radius": {
+            "type": "number"
+          },
+          "settings": {
+            "additionalProperties": {},
+            "type": "object"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "foliage"
+    },
+    {
+      "description": "Gameplay systems: physics, collision, navigation, input, behavior trees, AI (EQS, perception, State Trees, Smart Objects), game framework.\n\nActions:\n- set_collision_profile: Set collision preset. Params: actorLabel, profileName\n- set_simulate_physics: Toggle physics. Params: actorLabel, simulate\n- add_impulse: Apply an impulse (or force with mode='force') to a (PIE) actor's simulating physics body so its motion can be observed over time - loop level(read_actor_motion) to sample the response. Params: actorLabel, impulse {x,y,z} (or force/vector), mode? (impulse|force), componentName?, boneName?, location? (apply at world point), velChange?/accelChange?, world? (editor|pie|auto) (#676)\n- set_collision_enabled: Set collision mode. Params: actorLabel, collisionEnabled\n- set_collision: Unified collision authoring for a placed actor (actorLabel) or a Blueprint component template (assetPath+componentName). Apply any of: collisionProfile, collisionEnabled (NoCollision|QueryOnly|PhysicsOnly|QueryAndPhysics), objectType (channel name), responseToAllChannels (Block|Overlap|Ignore), responses ({channel: Block|Overlap|Ignore}). Profile is applied first, then overrides. componentName optional for actors (defaults to all primitive components), required for Blueprint templates (#545)\n- set_physics_properties: Set mass/damping/gravity. Params: actorLabel, mass?, linearDamping?, angularDamping?, enableGravity?\n- rebuild_navigation: Rebuild navmesh\n- find_nav_path: Synchronous nav-path query between two world points. Returns valid/partial/length plus the polyline. The standard 'why doesn't my AI move?' diagnostic. Params: start (Vec3), end (Vec3), pathfindingContext? (actorLabel - uses its agent + filter) (#424)\n- list_nav_invokers: Enumerate actors carrying a NavigationInvokerComponent + their tile generation/removal radii. Diagnoses 'no navmesh in this region' caused by missing or mis-sized invokers (#424)\n- get_navmesh_info: Query nav system\n- project_to_nav: Project point to navmesh. Params: location, extent?\n- spawn_nav_modifier: Place a NavModifierVolume. The brush is built for real (a bare spawn leaves an AVolume with no geometry, which the engine skips entirely - it requires both Brush and AreaClass). extent is a HALF-size in world units, default 100. areaClass defaults to NavArea_Null, which cuts a hole in the navmesh; pass NavArea_Obstacle to make the region costly instead, or any UNavArea subclass. Params: location, extent?, areaClass?, label?, scale?, onConflict?\n- create_input_action: Create InputAction. Params: name, packagePath?, valueType?\n- create_input_mapping: Create InputMappingContext. Params: name, packagePath?\n- list_input_assets: List input assets. Params: directory?, recursive?\n- read_imc: Read InputMappingContext mappings. Params: imcPath. Returns {key, inputAction, triggers[], modifiers[]}.\n- get_applied_imcs: Read applied Input Mapping Contexts (name, path, priority, registrationCount), highest priority first - the order Enhanced Input resolves in. Covers EVERY running PIE world by default, so a multiplayer client can be inspected, not just the primary/server world; narrow with pieInstance and/or playerIndex. Pass mappingContext for a direct hasRequestedContext yes/no. A remote controller with no LocalPlayer says so rather than reporting an empty list. BREAKING in 1.1.36: results are now nested under worlds[].players[] (was a flat appliedContexts[] for one world), the array is mappingContexts (was appliedContexts), each entry uses path (was imc), and a call with PIE stopped returns success with worldCount 0 instead of erroring (#604/#778)\n- list_input_mappings: Alias for read_imc. List key→action bindings with triggers/modifiers. Params: imcPath\n- add_imc_mapping: Add key mapping to IMC. Params: imcPath, inputActionPath, key\n- set_mapping_modifiers: Set modifiers/triggers on an IMC mapping. Each modifier OR trigger is either {type:'<ShortName>', <prop>:<val>} or {class:'/Script/Module.Class', properties:{...}} - the class form resolves any custom UInputModifier/UInputTrigger subclass (e.g. type:'Hold' | class:'/Script/EnhancedInput.InputTriggerHold', with HoldTimeThreshold). Unresolvable trigger specs are reported in failedTriggers and never leave a null entry (#649/#725). Params: imcPath, mappingIndex?, modifiers?, triggers?\n- remove_imc_mapping: Remove an IMC mapping. Params: imcPath, mappingIndex? | (inputActionPath? + key?) (#158)\n- set_imc_mapping_key: Rebind an IMC mapping to a new key. Params: imcPath, newKey, mappingIndex? | key? | inputActionPath? (#158)\n- set_imc_mapping_action: Retarget an IMC mapping to a different InputAction. Params: imcPath, newInputActionPath, mappingIndex? | key? | inputActionPath? (#158)\n- list_behavior_trees: List behavior trees. Params: directory?, recursive?\n- get_behavior_tree_info: Inspect behavior tree (top-level + blackboard). Params: assetPath\n- read_behavior_tree_graph: Walk BT tree: composites, tasks, decorators, services with blackboard keys. Params: assetPath\n- create_blackboard: Create Blackboard. Params: name, packagePath?\n- add_blackboard_key: Add a typed key to a Blackboard asset. baseClass types an Object/Class key - Behaviour Tree nodes filter on it, so an untyped key silently will not bind. For keyType=Enum pass the enum via enumType (or baseClass). Params: blackboardPath, keyName, keyType (Bool|Int|Float|String|Name|Vector|Rotator|Object|Class|Enum), baseClass? (e.g. /Script/Engine.Actor), enumType? (#250)\n- remove_blackboard_key: Remove a key from a Blackboard asset by name. Idempotent. Params: blackboardPath, keyName (#469)\n- set_blackboard_parent: Set Parent on a BlackboardData asset (canonical UE child-of-parent pattern). Pass parentPath=\"None\" or omit to clear. autoPruneDuplicateKeys (default true) removes own-keys that the parent chain already defines so the BT compiler accepts the child (#469)\n- read_blackboard: Read a Blackboard asset: parent path, ownKeys, inheritedKeys (walks the parent chain). Params: blackboardPath (#469)\n- list_bt_node_classes: Enumerate every concrete BehaviorTree node class on this build (composites, tasks, decorators, services). Filter by kind to narrow. Useful for discovering plugin-supplied decorator/task classes without grepping engine + plugin source. Params: kind? ('composite'|'task'|'decorator'|'service') (#494)\n- set_behavior_tree_blackboard: Rebind a BehaviorTree asset's BlackboardAsset reference. Params: behaviorTreePath, blackboardPath. The C++ field is protected so reflection is the only writable path (#250)\n- create_behavior_tree: Create behavior tree. Params: name, packagePath?, blackboardPath?\n- create_eqs_query: Create EQS query. Params: name, packagePath?\n- list_eqs_queries: List EQS queries. Params: directory?\n- add_perception: Add an AIPerceptionComponent to a Blueprint and configure its senses. senses takes short names (Sight, Hearing, Damage, Touch, Team, Prediction), AISenseConfig_* names, or class paths - a component with no sense configs perceives nothing. Params: blueprintPath, senses?\n- configure_sense: Add + configure an AI perception sense config on the blueprint's AIPerceptionComponent. Params: blueprintPath, senseType (Sight|Hearing|Damage|Touch|Team|Prediction|Blueprint), settings? ({SightRadius: ...}), componentName?\n- get_state_tree_runtime: Read a running StateTreeComponent's active state names in PIE (the 'brain' state). Params: actorLabel, world? (default pie), componentName? (#654)\n- create_state_tree: Create a StateTree with a proper UStateTreeEditorData (schema + root state), so states/tasks are authorable via statetree(*) and persist across save/load (#653). Params: name, packagePath?, schema? (default /Script/GameplayStateTreeModule.StateTreeComponentSchema), onConflict?\n- list_state_trees: List StateTrees. Params: directory?\n- add_state_tree_component: Add StateTreeComponent. Params: blueprintPath\n- create_smart_object_def: Create SmartObjectDefinition. Params: name, packagePath?\n- add_smart_object_component: Add SmartObjectComponent. Params: blueprintPath\n- add_smart_object_slot: Append a FSmartObjectSlotDefinition to a SmartObjectDefinition's Slots array. Params: assetPath, name?, offset? ({x,y,z}), rotation? ({pitch,yaw,roll}), tags? (array). Returns the new slotIndex. Rollback removes the slot (#416)\n- set_smart_object_slot: Mutate an existing slot's offset/rotation/tags. Params: assetPath, slotIndex, offset? ({x,y,z}), rotation? ({pitch,yaw,roll}), tags? (array). Omitted fields keep their current values (#416)\n- remove_smart_object_slot: Remove a slot by index. Idempotent: out-of-range returns alreadyDeleted=true. Params: assetPath, slotIndex (#416)\n- list_smart_object_slots: List slots on a SmartObjectDefinition with index, offset, rotation, and raw text. Params: assetPath (#416)\n- add_smart_object_slot_behavior: Attach a behavior definition (UBehaviorDefinition asset or class) to a slot's BehaviorDefinitions array. Pass instanceProperties to seed UPROPERTYs on a freshly-spawned class-instance. Params: assetPath, slotIndex, behaviorClass (asset path or class path), instanceProperties? (#416)\n- create_game_mode: Create GameMode BP. parentClass must derive from GameModeBase (short name, /Script path, or a Blueprint asset path). Params: name, packagePath?, parentClass?\n- create_game_state: Create GameState BP. parentClass must derive from GameStateBase. Params: name, packagePath?, parentClass?\n- create_player_controller: Create PlayerController BP. parentClass must derive from PlayerController. Params: name, packagePath?, parentClass?\n- create_player_state: Create PlayerState BP. parentClass must derive from PlayerState. Params: name, packagePath?, parentClass?\n- create_hud: Create HUD BP. parentClass must derive from HUD. Params: name, packagePath?, parentClass?\n- set_world_game_mode: Set level GameMode override. Params: gameModeClass (or legacy gameModePath)\n- get_framework_info: Get level framework classes\n- get_navmesh_details: Read RecastNavMesh generation params (cellSize, agentHeight, maxStepHeight, etc.) (#163)\n\nEpic 5.8 toolset actions (32): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "accelChange": {
+            "description": "add_impulse: treat force as an acceleration change (#676)",
+            "type": "boolean"
+          },
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "set_collision_profile",
+              "set_simulate_physics",
+              "add_impulse",
+              "set_collision_enabled",
+              "set_collision",
+              "set_physics_properties",
+              "rebuild_navigation",
+              "find_nav_path",
+              "list_nav_invokers",
+              "get_navmesh_info",
+              "project_to_nav",
+              "spawn_nav_modifier",
+              "create_input_action",
+              "create_input_mapping",
+              "list_input_assets",
+              "read_imc",
+              "get_applied_imcs",
+              "list_input_mappings",
+              "add_imc_mapping",
+              "set_mapping_modifiers",
+              "remove_imc_mapping",
+              "set_imc_mapping_key",
+              "set_imc_mapping_action",
+              "list_behavior_trees",
+              "get_behavior_tree_info",
+              "read_behavior_tree_graph",
+              "create_blackboard",
+              "add_blackboard_key",
+              "remove_blackboard_key",
+              "set_blackboard_parent",
+              "read_blackboard",
+              "list_bt_node_classes",
+              "set_behavior_tree_blackboard",
+              "create_behavior_tree",
+              "create_eqs_query",
+              "list_eqs_queries",
+              "add_perception",
+              "configure_sense",
+              "get_state_tree_runtime",
+              "create_state_tree",
+              "list_state_trees",
+              "add_state_tree_component",
+              "create_smart_object_def",
+              "add_smart_object_component",
+              "add_smart_object_slot",
+              "set_smart_object_slot",
+              "remove_smart_object_slot",
+              "list_smart_object_slots",
+              "add_smart_object_slot_behavior",
+              "create_game_mode",
+              "create_game_state",
+              "create_player_controller",
+              "create_player_state",
+              "create_hud",
+              "set_world_game_mode",
+              "get_framework_info",
+              "get_navmesh_details",
+              "epic_rename_tag",
+              "epic_remove_tag",
+              "epic_list_tags",
+              "epic_get_tag_info",
+              "epic_find_referencers_by_tag",
+              "epic_add_tag",
+              "epic_set_sphere",
+              "epic_set_constraint_limits",
+              "epic_set_capsule",
+              "epic_set_box",
+              "epic_set_body_physics_mode",
+              "epic_set_body_mass_scale",
+              "epic_remove_shape",
+              "epic_remove_constraint",
+              "epic_remove_body",
+              "epic_get_constraints",
+              "epic_get_body_shapes",
+              "epic_get_body_physics_mode",
+              "epic_get_body_names",
+              "epic_get_body_mass_scale",
+              "epic_create_from_mesh",
+              "epic_add_constraint",
+              "epic_add_body",
+              "epic_get_query_description",
+              "epic_get_condition_description",
+              "epic_get_subtree",
+              "epic_get_children",
+              "epic_get_node_depths",
+              "epic_get_node_depth",
+              "epic_list_nodes",
+              "epic_get_root_decorators",
+              "epic_get_blackboard"
+            ],
+            "type": "string"
+          },
+          "actorLabel": {
+            "type": "string"
+          },
+          "angularDamping": {
+            "type": "number"
+          },
+          "areaClass": {
+            "description": "spawn_nav_modifier: a UNavArea subclass - NavArea_Null (default, cuts a hole), NavArea_Obstacle, or a /Script path",
+            "type": "string"
+          },
+          "assetPath": {
+            "type": "string"
+          },
+          "autoPruneDuplicateKeys": {
+            "description": "set_blackboard_parent: remove own-keys that the parent chain already defines (default true)",
+            "type": "boolean"
+          },
+          "baseClass": {
+            "description": "Base class path for Object/Class blackboard keys (e.g. /Script/Engine.Actor)",
+            "type": "string"
+          },
+          "behaviorClass": {
+            "description": "SmartObject behavior class or asset path for add_smart_object_slot_behavior",
+            "type": "string"
+          },
+          "behaviorTreePath": {
+            "description": "BehaviorTree asset path for set_behavior_tree_blackboard",
+            "type": "string"
+          },
+          "blackboardPath": {
+            "type": "string"
+          },
+          "blueprintPath": {
+            "type": "string"
+          },
+          "boneName": {
+            "description": "add_impulse: physics bone (#676)",
+            "type": "string"
+          },
+          "collisionEnabled": {
+            "type": "string"
+          },
+          "collisionProfile": {
+            "description": "set_collision: collision profile/preset name (applied before per-channel overrides)",
+            "type": "string"
+          },
+          "componentName": {
+            "description": "configure_sense: target AIPerceptionComponent name (default: first found)",
+            "type": "string"
+          },
+          "directory": {
+            "type": "string"
+          },
+          "enableGravity": {
+            "type": "boolean"
+          },
+          "end": {
+            "$ref": "#/properties/location",
+            "description": "find_nav_path: query end"
+          },
+          "enumType": {
+            "description": "add_blackboard_key: enum name or path for keyType=Enum",
+            "type": "string"
+          },
+          "extent": {
+            "$ref": "#/properties/location"
+          },
+          "force": {
+            "$ref": "#/properties/location",
+            "description": "add_impulse: force vector alias (#676)"
+          },
+          "gameModeClass": {
+            "description": "GameMode class or Blueprint path for set_world_game_mode",
+            "type": "string"
+          },
+          "gameModePath": {
+            "description": "Legacy alias for gameModeClass",
+            "type": "string"
+          },
+          "imcPath": {
+            "type": "string"
+          },
+          "impulse": {
+            "$ref": "#/properties/location",
+            "description": "add_impulse: impulse vector (#676)"
+          },
+          "includeActions": {
+            "description": "get_applied_imcs: include each context's action/key mappings (#778)",
+            "type": "boolean"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputActionPath": {
+            "type": "string"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "instanceProperties": {
+            "additionalProperties": {},
+            "description": "Property writes to apply to a freshly-spawned behavior instance",
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "keyName": {
+            "description": "Blackboard key name for add_blackboard_key",
+            "type": "string"
+          },
+          "keyType": {
+            "description": "Blackboard key type: Bool, Int, Float, String, Name, Vector, Rotator, Object, Class, Enum",
+            "type": "string"
+          },
+          "kind": {
+            "description": "BT node class filter for list_bt_node_classes: composite|task|decorator|service (#494)",
+            "type": "string"
+          },
+          "label": {
+            "description": "spawn_nav_modifier: actor label (also what onConflict dedupes on)",
+            "type": "string"
+          },
+          "linearDamping": {
+            "type": "number"
+          },
+          "location": {
+            "additionalProperties": false,
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "z": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "z"
+            ],
+            "type": "object"
+          },
+          "mappingContext": {
+            "description": "get_applied_imcs: name or path of one context to answer yes/no about (#778)",
+            "type": "string"
+          },
+          "mappingIndex": {
+            "description": "Index of mapping in IMC (default 0)",
+            "type": "number"
+          },
+          "mass": {
+            "type": "number"
+          },
+          "mode": {
+            "description": "add_impulse: impulse|force (#676)",
+            "type": "string"
+          },
+          "modifiers": {
+            "description": "Array of modifier objects: {type, ...props}",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "newInputActionPath": {
+            "description": "New InputAction path for set_imc_mapping_action",
+            "type": "string"
+          },
+          "newKey": {
+            "description": "New FKey name for set_imc_mapping_key",
+            "type": "string"
+          },
+          "objectType": {
+            "description": "set_collision: object-type collision channel name (e.g. WorldStatic, Pawn, ECC_GameTraceChannel1)",
+            "type": "string"
+          },
+          "offset": {
+            "$ref": "#/properties/location",
+            "description": "SmartObject slot offset"
+          },
+          "onConflict": {
+            "description": "create_state_tree: skip (default) or error when the asset already exists",
+            "type": "string"
+          },
+          "packagePath": {
+            "type": "string"
+          },
+          "parentClass": {
+            "type": "string"
+          },
+          "parentPath": {
+            "description": "Parent BlackboardData asset path for set_blackboard_parent (#469)",
+            "type": "string"
+          },
+          "pathfindingContext": {
+            "description": "find_nav_path: actor label whose agent/filter the query uses",
+            "type": "string"
+          },
+          "pieInstance": {
+            "description": "get_applied_imcs / add_impulse / get_state_tree_runtime: PIE world instance (0 = server/primary); omit for the primary world. See editor(list_pie_instances) (#778)",
+            "type": "number"
+          },
+          "playerIndex": {
+            "description": "get_applied_imcs: player index; omit for every player (#604/#778)",
+            "type": "number"
+          },
+          "profileName": {
+            "type": "string"
+          },
+          "recursive": {
+            "type": "boolean"
+          },
+          "responseToAllChannels": {
+            "description": "set_collision: Block|Overlap|Ignore applied to every channel before per-channel overrides",
+            "type": "string"
+          },
+          "responses": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "set_collision: per-channel responses map { channelName: Block|Overlap|Ignore }",
+            "type": "object"
+          },
+          "rotation": {
+            "additionalProperties": false,
+            "description": "SmartObject slot rotation",
+            "properties": {
+              "pitch": {
+                "type": "number"
+              },
+              "roll": {
+                "type": "number"
+              },
+              "yaw": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "pitch",
+              "yaw",
+              "roll"
+            ],
+            "type": "object"
+          },
+          "scale": {
+            "$ref": "#/properties/location",
+            "description": "spawn_nav_modifier: actor scale, applied after the brush is built"
+          },
+          "schema": {
+            "description": "create_state_tree: StateTree schema class path (#653)",
+            "type": "string"
+          },
+          "senseType": {
+            "type": "string"
+          },
+          "senses": {
+            "description": "add_perception: sense names (Sight, Hearing, Damage, Touch, Team, Prediction) or AISenseConfig class paths",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "settings": {
+            "additionalProperties": {},
+            "description": "configure_sense: per-sense property writes (e.g. {SightRadius: 1500})",
+            "type": "object"
+          },
+          "simulate": {
+            "type": "boolean"
+          },
+          "slotIndex": {
+            "description": "SmartObject slot index",
+            "type": "number"
+          },
+          "start": {
+            "$ref": "#/properties/location",
+            "description": "find_nav_path: query start"
+          },
+          "tags": {
+            "description": "SmartObject slot tags (gameplay tag strings or struct shapes)",
+            "items": {},
+            "type": "array"
+          },
+          "triggers": {
+            "description": "Array of trigger objects: {type, ...props}",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "valueType": {
+            "type": "string"
+          },
+          "vector": {
+            "$ref": "#/properties/location",
+            "description": "add_impulse: generic vector alias (#676)"
+          },
+          "velChange": {
+            "description": "add_impulse: treat impulse as a velocity change (#676)",
+            "type": "boolean"
+          },
+          "world": {
+            "description": "add_impulse: editor|pie|auto (#676)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "gameplay"
+    },
+    {
+      "description": "Gameplay Ability System: abilities, effects, attribute sets, cues.\n\nActions:\n- add_asc: Add AbilitySystemComponent. Params: blueprintPath, componentName?\n- create_attribute_set: Create AttributeSet BP. Params: name, packagePath?\n- add_attribute: Add attribute to set. Params: attributeSetPath, attributeName, defaultValue?\n- create_ability: Create GameplayAbility BP. Params: name, packagePath?, parentClass?\n- set_ability_tags: Set tags on ability. Params: abilityPath, ability_tags?, cancel_abilities_with_tag?, activation_required_tags?, activation_blocked_tags?\n- create_effect: Create GameplayEffect BP. Params: name, packagePath?, durationPolicy?\n- set_effect_modifier: Add modifier. Params: effectPath, attribute, operation?, magnitude?\n- create_cue: Create GameplayCue. Params: name, packagePath?, cueType?\n- get_info: Inspect GAS setup. Params: blueprintPath\n- set_asc_defaults: Wire an AttributeSet onto a Blueprint's ASC component (DefaultStartingData) so attributes exist at runtime. Params: blueprintPath, attributeSet (content path or class name), componentName?, initDataTable? (starting values). Run add_ability_system_component first.\n- apply_effect: Apply a GameplayEffect to a live actor's ASC (agnostic stat/damage stimulus - uses the game's own effect). Params: actorLabel, effectClass (content path or class name), level?, setByCaller? ({tag-or-name: magnitude}), world? (auto|pie|editor, default auto)\n- set_attribute: Set a gameplay attribute's base value on a live actor's ASC (recalculates CurrentValue through the aggregator). Params: actorLabel, attribute (Health | SetName.Health), value, world?\n- get_attribute: Read gameplay attribute base + current values on a live actor's ASC. Omit attribute to list all. Params: actorLabel, attribute?, world?\n- init_asc: Initialize a live actor's ASC (InitAbilityActorInfo) and optionally instantiate an AttributeSet so attributes are live - the runtime setup step for testing a bridge-authored GAS actor. Params: actorLabel, attributeSet? (content path or class name), world?\n- get_asc_state: Introspect a live actor's ASC: granted ability specs (class, level, inputID, active, dynamicTags) + owned gameplay tags. Params: actorLabel, world? (auto|pie|editor) (#587)\n\nEpic 5.8 toolset actions (14): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "abilityPath": {
+            "type": "string"
+          },
+          "ability_tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "add_asc",
+              "create_attribute_set",
+              "add_attribute",
+              "create_ability",
+              "set_ability_tags",
+              "create_effect",
+              "set_effect_modifier",
+              "create_cue",
+              "get_info",
+              "set_asc_defaults",
+              "apply_effect",
+              "set_attribute",
+              "get_attribute",
+              "init_asc",
+              "get_asc_state",
+              "epic_remove_cue_tag",
+              "epic_list_cues",
+              "epic_get_cue_info",
+              "epic_find_cue_tags_without_notifies",
+              "epic_find_cue_notify_assets",
+              "epic_execute_cue_on_selected_actor",
+              "epic_create_cue_notify_asset",
+              "epic_add_cue_tag",
+              "epic_list_attributes",
+              "epic_find_attribute_set_classes",
+              "epic_get_granted_abilities",
+              "epic_get_attribute_values",
+              "epic_get_active_tags",
+              "epic_get_active_effects"
+            ],
+            "type": "string"
+          },
+          "activation_blocked_tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "activation_required_tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "actorLabel": {
+            "description": "Live actor label/name for runtime GAS actions",
+            "type": "string"
+          },
+          "attribute": {
+            "type": "string"
+          },
+          "attributeName": {
+            "type": "string"
+          },
+          "attributeSet": {
+            "description": "set_asc_defaults / init_asc: AttributeSet content path or class name",
+            "type": "string"
+          },
+          "attributeSetPath": {
+            "type": "string"
+          },
+          "block_abilities_with_tag": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "blueprintPath": {
+            "type": "string"
+          },
+          "cancel_abilities_with_tag": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "componentName": {
+            "type": "string"
+          },
+          "cueType": {
+            "type": "string"
+          },
+          "defaultValue": {
+            "type": "number"
+          },
+          "durationPolicy": {
+            "type": "string"
+          },
+          "effectClass": {
+            "description": "apply_effect: GameplayEffect content path or class name",
+            "type": "string"
+          },
+          "effectPath": {
+            "type": "string"
+          },
+          "initDataTable": {
+            "description": "set_asc_defaults: optional DataTable of starting attribute values",
+            "type": "string"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "level": {
+            "description": "apply_effect: effect level (default 1)",
+            "type": "number"
+          },
+          "magnitude": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string"
+          },
+          "packagePath": {
+            "type": "string"
+          },
+          "parentClass": {
+            "type": "string"
+          },
+          "setByCaller": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "description": "apply_effect: SetByCaller magnitudes keyed by gameplay tag or name",
+            "type": "object"
+          },
+          "value": {
+            "description": "set_attribute: new base value",
+            "type": "number"
+          },
+          "world": {
+            "description": "Runtime world scope: auto (default) | pie | editor",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "gas"
+    },
+    {
+      "description": "Landscape terrain: info, layers, sculpting, weight painting, materials, splines, proxies.\n\nActions:\n- get_info: Get landscape setup\n- list_layers: List paint layers\n- sample: Sample height/layers. Params: x, y\n- sculpt: Raise, lower or flatten terrain with a circular brush. mode=raise|lower|flatten; amount is world centimetres at full strength (raise/lower), and flatten pulls toward the height under the brush centre. falloff (0..1) is the smoothstepped soft edge. Runs in one transaction and leaves the level dirty and unsaved. Writes into an edit layer (editLayer by name, else editLayerIndex, default 0) - required on UE 5.8, where a write without one is regenerated away by the layer system. Params: center ({x,y} world space), radius (default 500), mode? (default raise), amount? (default 100), falloff? (default 0.5), actorLabel?, editLayer?, editLayerIndex?, maxVertices? (#742)\n- paint_layer: Paint a weight layer with a circular brush. The layer must already have a LayerInfo on this landscape (see add_layer_info) - an unregistered name errors and lists the layers that ARE registered instead of silently painting nothing. Weights are written as given - the engine no longer renormalises other layers for you, so set them explicitly if they must sum to 1. Writes into an edit layer (editLayer by name, else editLayerIndex, default 0). Params: layerName, center ({x,y} world space), radius (default 500), strength? (0..1, default 1), falloff? (default 0.5), actorLabel?, editLayer?, editLayerIndex?, maxVertices? (#742)\n- list_splines: Read landscape splines\n- get_component: Inspect component. Params: componentIndex\n- set_material: Set landscape material. Params: materialPath\n- add_layer_info: Register paint layer (creates LayerInfo asset + binds to active landscape). Params: layerName, packagePath?\n- create_layer_info: Standalone LayerInfo asset creation - no landscape required. Params: layerName, name? (default LI_<layerName>), packagePath? (default /Game/Landscape/LayerInfos), physMaterial? (asset path), hardness? (#251)\n- create: Spawn a new ALandscape with a flat heightmap. Defaults match the Editor's Landscape Mode 'create new' (8x8 components, 63 quads/subsection, 2 subsections/component = 1016x1016 quads). Params: location? (Vec3), scale? (Vec3, default 100,100,100), componentCountX? (default 8), componentCountY? (default 8), subsectionSizeQuads? (one of 7|15|31|63|127|255, default 63), numSubsections? (1|2, default 2), heightOffset? (uint16, default 32768 = mid-elevation), label? (#303)\n- get_material_usage_summary: Per-proxy summary: landscape/hole material paths + component/grass/nanite counts (#150)\n- list_proxies: Enumerate loaded World Partition LandscapeStreamingProxy actors with per-proxy worldBounds (origin/extent), plus loadedProxies + parentLandscapes counts. Unloaded proxies are not spawned as actors, so only loaded ones appear - use this to confirm a proxy is streamed in before trusting a layer/height readback (#733)\n- find_proxy_at: Resolve which loaded LandscapeStreamingProxy covers a world X/Y. Returns found/loaded + label, or loaded:false when the covering proxy is streamed out (so a 0-weight readback there is ambiguous, not real). Params: worldX, worldY (#733)",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "get_info",
+              "list_layers",
+              "sample",
+              "sculpt",
+              "paint_layer",
+              "list_splines",
+              "get_component",
+              "set_material",
+              "add_layer_info",
+              "create_layer_info",
+              "create",
+              "get_material_usage_summary",
+              "list_proxies",
+              "find_proxy_at"
+            ],
+            "type": "string"
+          },
+          "actorLabel": {
+            "description": "sculpt/paint_layer: which Landscape actor, when the level has more than one (#742)",
+            "type": "string"
+          },
+          "amount": {
+            "description": "sculpt: world centimetres to move at full brush strength (#742)",
+            "type": "number"
+          },
+          "center": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "description": "sculpt/paint_layer: brush centre {x, y} in world space (#742)",
+            "type": "object"
+          },
+          "componentCountX": {
+            "type": "number"
+          },
+          "componentCountY": {
+            "type": "number"
+          },
+          "componentIndex": {
+            "type": "number"
+          },
+          "editLayer": {
+            "description": "sculpt/paint_layer: edit layer NAME to write into; without one the write targets the merged heightmap and is regenerated away (#742)",
+            "type": "string"
+          },
+          "editLayerIndex": {
+            "description": "sculpt/paint_layer: edit layer index (default 0) when editLayer is not given (#742)",
+            "type": "number"
+          },
+          "falloff": {
+            "type": "number"
+          },
+          "filePath": {
+            "type": "string"
+          },
+          "hardness": {
+            "type": "number"
+          },
+          "heightOffset": {
+            "type": "number"
+          },
+          "label": {
+            "type": "string"
+          },
+          "layerName": {
+            "type": "string"
+          },
+          "location": {
+            "additionalProperties": false,
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "z": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "z"
+            ],
+            "type": "object"
+          },
+          "materialPath": {
+            "type": "string"
+          },
+          "maxVertices": {
+            "description": "sculpt/paint_layer: refuse a brush covering more than this many vertices (default 4,000,000) (#742)",
+            "type": "number"
+          },
+          "mode": {
+            "description": "sculpt: raise | lower | flatten (#742)",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "numSubsections": {
+            "type": "number"
+          },
+          "onConflict": {
+            "type": "string"
+          },
+          "packagePath": {
+            "type": "string"
+          },
+          "physMaterial": {
+            "type": "string"
+          },
+          "radius": {
+            "type": "number"
+          },
+          "scale": {
+            "$ref": "#/properties/location"
+          },
+          "strength": {
+            "type": "number"
+          },
+          "subsectionSizeQuads": {
+            "type": "number"
+          },
+          "worldX": {
+            "description": "find_proxy_at: world-space X (#733)",
+            "type": "number"
+          },
+          "worldY": {
+            "description": "find_proxy_at: world-space Y (#733)",
+            "type": "number"
+          },
+          "x": {
+            "type": "number"
+          },
+          "y": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "landscape"
+    },
+    {
+      "description": "Level actors, selection, components, level management, volumes, lights, and splines.\n\nActions:\n- get_outliner: List actors (each row includes editorHidden - hidden in the viewport but still rendering in game). Params: classFilter?, nameFilter?, editorHidden? (filter to only hidden/only visible), world? (editor|pie|auto), limit?, includeStreaming? (#717)\n- set_editor_visibility: Bulk set editor-only visibility (temporarily-hidden-in-editor) on actors. Targets actorLabels[] or all=true. Params: hidden (required; true=hide, false=show), actorLabels?, all? (#717)\n- place_actor: Spawn actor. Pass world:pie to spawn into the running PIE world (#585). Params: actorClass, label?, location?, rotation?, scale?, staticMesh?, material?, world? (editor|pie)\n- delete_actor: Remove actor. Params: actorLabel\n- get_actor_details: Inspect actor. Params: actorLabel OR actorPath, includeProperties?, propertyName?, world? (editor|pie)\n- move_actor: Transform actor. Pass world:pie to move a live PIE actor (resolves labels/names from get_outliner {world:pie}) (#586). Params: actorLabel, location?, rotation?, scale?, world? (editor|pie)\n- aim_actor_at: Rotate an actor so its forward (+X) points at a target. Params: actorLabel, targetPoint (Vec3) OR targetActor (label), roll? (default 0), world? (editor|pie) (#566)\n- nav_project_point: Project a world point onto the navmesh. Returns onNavMesh + projectedLocation. Params: point (Vec3), extent? (Vec3, default 100), world? (editor|pie) (#585)\n- select: Select actors. Params: actorLabels[]\n- get_selected: Get selection\n- add_component: Add component to actor. Params: actorLabel, componentClass, componentName?\n- remove_component: Remove instance component from a level actor by name. Idempotent: returns alreadyDeleted=true if no matching component exists. Params: actorLabel, componentName (#426)\n- set_component_property: Set component prop. Pass value=null to clear a TObjectPtr/SoftObject/WeakObject/UClass/Interface reference (#420). Resolves inherited/SCS components on placed Blueprint instances case-insensitively, and refreshes the scene transform after RelativeLocation/RelativeRotation/RelativeScale3D writes (#539). Pass world='pie' (with optional pieInstance) to write to a LIVE PIE component rather than the editor one (#763). Params: actorLabel, componentName, propertyName, value, world?, pieInstance?\n- get_component_details: Read a placed actor's component transforms. With componentName returns that component's relative+world location/rotation/scale, class, and attach parent; without it lists every component. With includeValues=true also dumps arbitrary UPROPERTY values (custom fields, CharacterMovement MaxWalkSpeed, etc.); world='pie' reads the live PIE instance (#539/#584). Params: actorLabel, componentName?, includeValues?, propertyNames? (filter), world? (editor|pie)\n- get_current: Get current level name and path\n- load: Load level. Params: levelPath\n- save: Save current level\n- list: List levels. Params: directory?, recursive?\n- create: Create new level. Params: levelPath?, templateLevel?\n- spawn_volume: Place volume. Params: volumeType, location?, extent?, label?\n- list_volumes: List volumes. Params: volumeType?\n- set_volume_properties: Edit volume. Params: actorLabel, properties\n- spawn_light: Place light. Params: lightType (point|spot|directional|rect|sky), location?, rotation?, intensity?, color? ({r,g,b} 0-255), attenuationRadius? (point/spot/rect only; #723), mobility? (static|stationary|movable; default movable so the light renders without a build), label? (#331/#310)\n- set_light_properties: Edit a light OR SkyLight (intensity/color now work on SkyLight too, #608). Params: actorLabel, intensity?, color?, rotation? (DirectionalLight sun angle), mobility? (static|stationary|movable), recaptureSky?, volumetricScatteringIntensity?, sourceRadius? (point/spot), innerConeAngle?/outerConeAngle? (spot)\n- set_fog_properties: Edit ExponentialHeightFog incl. volumetric fog (#608). Params: actorLabel?, fogDensity?, fogHeightFalloff?, startDistance?, fogInscatteringColor?, enableVolumetricFog?, volumetricFogScatteringDistribution?, volumetricFogExtinctionScale?, volumetricFogDistance?, volumetricFogAlbedo?\n- get_actors_by_class: List actors by class. Matches Blueprint subclasses of a native base via IsChildOf when className resolves to a UClass (short name, /Script path, or BP class path), else falls back to name-substring. Each actor includes location/rotation/scale. Params: className, world? (editor|pie), matchSubclasses? (default true), includeTransforms? (default true) (#675)\n- get_actors_by_component_class: List actors that own a component of a given class (exact or substring match). Returns each actor plus its matchedComponents. Params: componentClass, world? (editor|pie) (#582)\n- count_actors_by_class: Histogram of actor classes in the level (sorted desc). Params: world? (editor|pie), topN? (#146)\n- get_runtime_virtual_texture_summary: List RuntimeVirtualTextureVolume actors + their bound VirtualTexture assets (#150)\n- set_water_body_property: Set a property on an actor's WaterBodyComponent (ShapeDilation, WaterLevel, etc.). Params: actorLabel, propertyName, value. Requires Water plugin. For spline edits use level(set_spline_points) (#151)\n- build_lighting: Build lights. Params: quality?\n- get_spline_info: Read a spline component's points, closedLoop, length, and per-point tangents/types. Works in editor or PIE (#553). Optional componentName picks a specific (custom) spline; projectPoint (Vec3) returns the closest location, inputKey, distanceAlongSpline, distanceToSpline, and tangent (#555). Params: actorLabel, componentName?, world? (editor|pie), projectPoint?\n- set_spline_points: Set spline points. Params: actorLabel, points[], closedLoop?\n- set_actor_material: Set material on actor. Params: actorLabel, materialPath, slotIndex?\n- get_world_settings: Read world settings (GameMode, KillZ, gravity, etc.)\n- set_world_settings: Set world settings. Params: defaultGameMode?, killZ?, globalGravityZ?, enableWorldBoundsChecks?\n- get_actor_bounds: Get actor AABB. Params: actorLabel. Returns origin + extent (#188)\n- get_component_tree: Deep component-tree dump for an actor. Returns per-component: name, class, attachParent, attachSocket, mobility, visibility, relative+world transforms, tags. For PrimitiveComponents adds collisionProfile/collisionEnabled/bounds/castShadow. For StaticMeshComponent adds staticMesh + materials[]. For SkeletalMeshComponent adds skeletalMesh + skeleton + materials[]. For NiagaraComponent adds niagara{asset,active,visible} and for AudioComponent audio{sound,playing} - runtime FX state in PIE (#581). Params: actorLabel | actorPath, world? (editor|pie), componentClass? (substring filter), includeProperties? (dump UPROPERTY name/type/value per component) (#240/#241/#302/#320/#370/#353/#581)\n- get_relative_transform: Compute target's transform in reference's local space (location/rotation/scale). Common dungeon/calibration workflow. Params: target (actor label), reference (actor label), world? (#386/#387)\n- resolve_actor: Resolve internal/runtime actor name to editor label. Params: internalName (e.g. StaticMeshActor_141). Returns actorLabel, actorPath, className, location (#178)\n- set_actor_property: Set per-instance UPROPERTY on a level actor. Params: actorLabel ('WorldSettings' targets the world settings actor), propertyName (dotted paths like 'Foo.Bar' supported), value (string/number/bool/object/array; a label string resolves to an AActor* ref, and a JSON array of labels populates a TArray of actor refs #538), force? (bypass EditDefaultsOnly), world? (editor|pie) (#202/#230)\n- read_actor_motion: Snapshot motion telemetry for one or many actors: location, rotation, velocity, scale, angularVelocity (when simulating physics), grounded + distanceToGround (downward 200u trace). Defaults to the PIE world with editor fallback. Loop at your sample interval for long telemetry probes. Params: actorLabel? OR actorLabels (string[]), world? ('pie'|'editor'), pieInstance? (#453)\n- add_hismc_instances: Bulk-add transforms to a HISMC / ISMC component on an actor (Python add_instance crashes on UE 5.7; this is the C++ path). Params: actorLabel, componentName? (default: first ISMC/HISMC found), transforms ([{location: {x,y,z}, rotation?: {pitch,yaw,roll}, scale?: {x,y,z}}]), worldSpace? (default true) (#434)\n- get_instance_transforms: Read every instance transform on an actor's ISMC/HISMC. Params: actorLabel, componentName? (default first), worldSpace? (default true). Returns instances[{index, location, rotation, scale}] (#697)\n- update_instance_transform: Update a single ISMC/HISMC instance by index; unspecified location/rotation/scale are preserved. Params: actorLabel, componentName?, index, location?, rotation?, scale?, worldSpace? (default true) (#697)\n- remove_instance: Remove a single ISMC/HISMC instance by index. Params: actorLabel, componentName?, index (#697)\n- set_nanite_settings: Enable/disable + force-build Nanite on a UStaticMesh asset (rebuilds render data immediately, not on next cook). Params: assetPath, enabled? (default true), positionPrecision? (#696)\n- get_nanite_info: Read a UStaticMesh's Nanite state (naniteEnabled, positionPrecision, numLODs). Params: assetPath (#696)\n- add_post_process_blendable: Add a material blendable (post-process material or MID, e.g. a toon/outline pass) to a PostProcessVolume's WeightedBlendables. Params: actorLabel (the PPV), materialPath, weight? (default 1) (#666)\n- export_actor_fbx: Export an actor's skeletal/static mesh to FBX and write a metadata sidecar JSON (actor transform, mesh, materials, skeleton) for a downstream bridge (e.g. MetaTailor). Params: actorLabel, outputPath (.fbx). Returns fbx + metadata paths (#637)\n- spawn_skeletal_mesh_actor: Spawn a SkeletalMeshActor for visual/deform verification. Optional per-slot materials and single-node animation preview (animSequence + loop). Returns actorLabel + boxExtent. The animSequence is written to the component's editable AnimationData, so it persists across a level save/reload instead of only driving the runtime preview and coming back in A-pose (#790). Params: skeletalMesh, label?, location?, rotation?, scale?, materials? (path[]), animSequence?, loop? (#679/#677)\n- delete_actors: Bulk-delete actors. Params: at least one of labelPrefix, className, tag; dryRun? to preview. Returns matched/deleted/labels (#220)\n- delete_exact_labeled_actors_in_levels: Delete actors by EXACT label across several map packages in one call, without leaving the maps open or dirty. Previews by default (dryRun defaults to TRUE, the opposite of delete_actors), and every level is loaded and preflighted before anything is deleted, so a bad label in the last map cannot half-commit the first. Refuses the whole request on duplicate labels, a class that does not match expectedClassPath, actors living in a streaming sublevel, WorldSettings/default brush/level blueprint, World Partition maps, a read-only .umap, or an editor that is already dirty. Saves only the maps it actually changed, then returns to the map that was open. Limits: 16 levels, 256 labels per level. Params: levels[] ({levelPath, actorLabels[], expectedClassPath?}), dryRun? (default true), onMissing? (error|ignore, default error), restoreOriginalLevel? (default true)\n- list_actor_descs: World Partition ONLY: list on-disk actor descriptors, including actors whose cell is not loaded and which every other actor query therefore reports as absent. Returns guid/label/class/bounds/runtimeGrid/dataLayers plus a loaded flag, and separate loadedMatches/unloadedMatches counts so 'not streamed in' is distinguishable from 'does not exist'. Needs UE 5.5 or newer. Params: filter? (case-insensitive over label/name/class/path), className?, guids?, bounds? ({min:{x,y,z},max:{x,y,z}} intersection test), loadedOnly?, unloadedOnly?, limit? (default 500) (#746)\n- load_actor_descs: World Partition ONLY: pin matched actors so they become resident and the normal actor actions can reach them, or unpin to release. Pinning is used rather than transient streaming because a transient load is dropped again by the streaming system mid-measurement. Takes the same filters as list_actor_descs and refuses to act on more than maxActors (default 256) so an unfiltered call cannot pin a whole map by accident. Reports residentAfter, read back from the world rather than assumed. Needs UE 5.5 or newer. Params: mode? (pin|unpin, default pin), filter?, className?, guids?, bounds?, maxActors?, dryRun? (#746)\n- set_actor_folder_path: Assign World Outliner folder paths in bulk. Filter with actorLabels (exact), labelPrefix, className or tag; pass an empty folderPath to move actors back to the root. Runs in one transaction so the whole move is a single undo, reads each write back (verified), and reports missingLabels for names that matched no actor. Editor-only organisation: the level is left dirty and is NOT saved. Params: folderPath, actorLabels?, labelPrefix?, className?, tag?, dryRun?, transactionLabel? (#767)\n- add_actor_tag: Append a tag to an actor's Tags array. Params: actorLabel, tag (#219)\n- remove_actor_tag: Remove a tag from an actor's Tags array. Params: actorLabel, tag (#219)\n- set_actor_tags: Replace an actor's Tags array. Params: actorLabel, tags[] (#219)\n- list_actor_tags: List an actor's Tags. Params: actorLabel (#219)\n- attach_actor: Attach actor as child. Params: childLabel, parentLabel, attachRule? (KeepWorld|KeepRelative|SnapToTarget; default KeepWorld), socketName? (#205)\n- detach_actor: Detach actor from parent. Params: childLabel (#205)\n- attach_component: Attach an actor root or exact named child SceneComponent to an actor root or exact named parent SceneComponent. A non-root child changes only component hierarchy, not actor parentage. An already-matching attachment is a no-op and does not reapply transform rules. Returns verified resolved component and socket details; native attachment failure is an error. Params: childLabel, parentLabel, childComponentName? (default child root), parentComponentName? (default parent root), socketName?, attachRule? (KeepWorld|KeepRelative|SnapToTarget; default KeepWorld), weldSimulatedBodies? (default false)\n- detach_component: Detach an actor root or exact named child SceneComponent while preserving world transform. Omitted childComponentName selects the actor root. An already-detached component is a verified no-op. Returns previous parent component/socket details plus alreadyDetached and detachmentChanged. Params: childLabel, childComponentName?\n- set_actor_mobility: Set actor root component Mobility. Params: actorLabel, mobility (static|stationary|movable) (#205)\n- get_current_edit_level: Read the active edit-target sub-level (#204)\n- set_current_edit_level: Set the active edit-target sub-level so subsequent spawns land in it. Params: levelName (e.g. SubLevel_A) (#204)\n- list_streaming_sublevels: List streaming sub-levels with transform + initially-loaded/visible flags (#206)\n- add_streaming_sublevel: Add a streaming sub-level. Params: levelPath, streamingClass? (LevelStreamingDynamic|LevelStreamingAlwaysLoaded), location?, initiallyLoaded?, initiallyVisible? (#206)\n- remove_streaming_sublevel: Remove a streaming sub-level. Params: levelName | levelPath (#206)\n- set_streaming_sublevel_properties: Update sub-level transform/visibility flags. Params: levelName | levelPath, location?, initiallyLoaded?, initiallyVisible?, editorVisible? (#206)\n- spawn_grid: Batch-spawn StaticMeshActors on a grid. Params: staticMesh, min, max (Vec3 bounds), countX?, countY?, countZ?, jitter?, labelPrefix? (#203)\n- batch_translate: Translate a set of actors by an offset. Params: offset (Vec3), actorLabels[] OR tag (#203)\n- place_actors_batch: Bulk-spawn StaticMeshActors with per-instance mesh + transform. Params: actors[]: [{staticMesh, location?, rotation?, scale?, label?}]. Mesh loads cached per path. Returns spawned/failedMesh/failedSpawn counts + labels (#264)\n- line_trace: Line trace in the editor world. Traces simple collision by default, the same as a gameplay trace, so the result matches what the running game hits; pass traceComplex to trace per-triangle instead. channel picks the collision channel, including channels this project renamed in its collision settings. The response echoes traceComplex and channel, and faceIndex is only present on a complex hit. Returns hit + actorLabel/actorClass/componentName/componentClass/location/impactPoint/normal/distance/faceIndex/boneName/physicalMaterial. Params: start (Vec3), end? (Vec3) OR direction? (Vec3) + distance? (default 200000), traceComplex? (default false), channel? (default Visibility), ignoreActors? (array of labels) (#420, #807)\n- snap_actor_to_floor: Snap an actor's bounds-bottom to the first downward line-trace hit. Equivalent of the End-key shortcut, works on arbitrary geometry (not just Landscape). Params: actorLabel, floorOffset? (added to impact Z, default 0), maxDistance? (default 100000) (#419)\n\nEpic 5.8 toolset actions (41): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "get_outliner",
+              "set_editor_visibility",
+              "place_actor",
+              "delete_actor",
+              "get_actor_details",
+              "move_actor",
+              "aim_actor_at",
+              "nav_project_point",
+              "select",
+              "get_selected",
+              "add_component",
+              "remove_component",
+              "set_component_property",
+              "get_component_details",
+              "get_current",
+              "load",
+              "save",
+              "list",
+              "create",
+              "spawn_volume",
+              "list_volumes",
+              "set_volume_properties",
+              "spawn_light",
+              "set_light_properties",
+              "set_fog_properties",
+              "get_actors_by_class",
+              "get_actors_by_component_class",
+              "count_actors_by_class",
+              "get_runtime_virtual_texture_summary",
+              "set_water_body_property",
+              "build_lighting",
+              "get_spline_info",
+              "set_spline_points",
+              "set_actor_material",
+              "get_world_settings",
+              "set_world_settings",
+              "get_actor_bounds",
+              "get_component_tree",
+              "get_relative_transform",
+              "resolve_actor",
+              "set_actor_property",
+              "read_actor_motion",
+              "add_hismc_instances",
+              "get_instance_transforms",
+              "update_instance_transform",
+              "remove_instance",
+              "set_nanite_settings",
+              "get_nanite_info",
+              "add_post_process_blendable",
+              "export_actor_fbx",
+              "spawn_skeletal_mesh_actor",
+              "delete_actors",
+              "delete_exact_labeled_actors_in_levels",
+              "list_actor_descs",
+              "load_actor_descs",
+              "set_actor_folder_path",
+              "add_actor_tag",
+              "remove_actor_tag",
+              "set_actor_tags",
+              "list_actor_tags",
+              "attach_actor",
+              "detach_actor",
+              "attach_component",
+              "detach_component",
+              "set_actor_mobility",
+              "get_current_edit_level",
+              "set_current_edit_level",
+              "list_streaming_sublevels",
+              "add_streaming_sublevel",
+              "remove_streaming_sublevel",
+              "set_streaming_sublevel_properties",
+              "spawn_grid",
+              "batch_translate",
+              "place_actors_batch",
+              "line_trace",
+              "snap_actor_to_floor",
+              "epic_remove_component",
+              "epic_add_component",
+              "epic_get_components",
+              "epic_get_actor_bounds",
+              "epic_set_parent_component",
+              "epic_get_parent_component",
+              "epic_get_component_actor",
+              "epic_get_root_component",
+              "epic_look_at",
+              "epic_set_actor_transform",
+              "epic_get_actor_transform",
+              "epic_remove_tag",
+              "epic_add_tag",
+              "epic_has_tag",
+              "epic_get_tags",
+              "epic_set_label",
+              "epic_get_label",
+              "epic_add_cone",
+              "epic_add_cylinder",
+              "epic_add_sphere",
+              "epic_add_cube",
+              "epic_save_actor",
+              "epic_is_checked_out",
+              "epic_can_edit",
+              "epic_commit_level_instance",
+              "epic_edit_level_instance",
+              "epic_create_level_instance",
+              "epic_merge_actors",
+              "epic_trace_world",
+              "epic_delete_folder",
+              "epic_rename_folder",
+              "epic_set_actor_folder",
+              "epic_get_actors_in_folder",
+              "epic_get_folders",
+              "epic_remove_from_scene",
+              "epic_add_to_scene_from_asset",
+              "epic_add_to_scene_from_class",
+              "epic_find_actors",
+              "epic_get_collision_channels",
+              "epic_get_current_level",
+              "epic_load_level"
+            ],
+            "type": "string"
+          },
+          "actorClass": {
+            "type": "string"
+          },
+          "actorLabel": {
+            "type": "string"
+          },
+          "actorLabels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "actorPath": {
+            "description": "Full actor object path; alternative to actorLabel",
+            "type": "string"
+          },
+          "actors": {
+            "description": "place_actors_batch: per-instance mesh+transform records",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "location": {
+                  "$ref": "#/properties/location"
+                },
+                "rotation": {
+                  "$ref": "#/properties/rotation"
+                },
+                "scale": {
+                  "$ref": "#/properties/location"
+                },
+                "staticMesh": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "staticMesh"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "all": {
+            "description": "set_editor_visibility: target every actor (#717)",
+            "type": "boolean"
+          },
+          "animSequence": {
+            "description": "spawn_skeletal_mesh_actor: single-node preview animation (#679)",
+            "type": "string"
+          },
+          "assetPath": {
+            "description": "set_nanite_settings/get_nanite_info: UStaticMesh path (#696)",
+            "type": "string"
+          },
+          "attachRule": {
+            "description": "attach_actor/attach_component: KeepWorld | KeepRelative | SnapToTarget",
+            "type": "string"
+          },
+          "attenuationRadius": {
+            "type": "number"
+          },
+          "bounds": {
+            "additionalProperties": {},
+            "description": "list_actor_descs/load_actor_descs: {min:{x,y,z}, max:{x,y,z}} intersection test (#746)",
+            "type": "object"
+          },
+          "castShadows": {
+            "type": "boolean"
+          },
+          "channel": {
+            "description": "line_trace: collision channel to trace on, e.g. Visibility, Camera, WorldStatic, Pawn, or a channel renamed in this project's collision settings (default Visibility) (#807)",
+            "type": "string"
+          },
+          "childComponentName": {
+            "description": "attach_component/detach_component: exact child SceneComponent instance name; omitted selects the actor root",
+            "type": "string"
+          },
+          "childLabel": {
+            "type": "string"
+          },
+          "classFilter": {
+            "type": "string"
+          },
+          "className": {
+            "description": "Class name filter for get_actors_by_class",
+            "type": "string"
+          },
+          "closedLoop": {
+            "type": "boolean"
+          },
+          "color": {
+            "additionalProperties": false,
+            "properties": {
+              "a": {
+                "type": "number"
+              },
+              "b": {
+                "type": "number"
+              },
+              "g": {
+                "type": "number"
+              },
+              "r": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "r",
+              "g",
+              "b"
+            ],
+            "type": "object"
+          },
+          "componentClass": {
+            "type": "string"
+          },
+          "componentName": {
+            "type": "string"
+          },
+          "countX": {
+            "type": "number"
+          },
+          "countY": {
+            "type": "number"
+          },
+          "countZ": {
+            "type": "number"
+          },
+          "defaultGameMode": {
+            "type": "string"
+          },
+          "direction": {
+            "$ref": "#/properties/location",
+            "description": "line_trace: ray direction (unit-normalized internally)"
+          },
+          "directory": {
+            "type": "string"
+          },
+          "distance": {
+            "description": "line_trace: ray length when direction is supplied (default 200000)",
+            "type": "number"
+          },
+          "dryRun": {
+            "description": "delete_actors / set_actor_folder_path: report matches without writing. delete_exact_labeled_actors_in_levels: same, but defaults to true",
+            "type": "boolean"
+          },
+          "editorHidden": {
+            "description": "get_outliner: filter to only editor-hidden (true) / only visible (false) actors (#717)",
+            "type": "boolean"
+          },
+          "editorVisible": {
+            "description": "set_streaming_sublevel_properties: editor viewport visibility",
+            "type": "boolean"
+          },
+          "enableVolumetricFog": {
+            "description": "set_fog_properties: enable volumetric fog (#608)",
+            "type": "boolean"
+          },
+          "enableWorldBoundsChecks": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "description": "set_nanite_settings: enable Nanite (default true) (#696)",
+            "type": "boolean"
+          },
+          "end": {
+            "$ref": "#/properties/location",
+            "description": "line_trace: ray end (use this OR direction+distance)"
+          },
+          "extent": {
+            "$ref": "#/properties/location"
+          },
+          "filter": {
+            "description": "list_actor_descs/load_actor_descs: case-insensitive substring over label, name, class and path (#746)",
+            "type": "string"
+          },
+          "floorOffset": {
+            "description": "snap_actor_to_floor: vertical offset added to impact Z",
+            "type": "number"
+          },
+          "fogDensity": {
+            "type": "number"
+          },
+          "fogHeightFalloff": {
+            "type": "number"
+          },
+          "fogInscatteringColor": {
+            "$ref": "#/properties/color"
+          },
+          "folderPath": {
+            "description": "set_actor_folder_path: World Outliner folder, e.g. 'Gameplay/Spawners'. Empty string moves actors to the root (#767)",
+            "type": "string"
+          },
+          "force": {
+            "description": "set_actor_property: bypass EditDefaultsOnly to write per-instance overrides",
+            "type": "boolean"
+          },
+          "globalGravityZ": {
+            "type": "number"
+          },
+          "guids": {
+            "description": "list_actor_descs/load_actor_descs: exact actor GUIDs (#746)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "hidden": {
+            "description": "set_editor_visibility: true = hide in editor, false = show (#717)",
+            "type": "boolean"
+          },
+          "ignoreActors": {
+            "description": "line_trace: actor labels to skip",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "includeProperties": {
+            "description": "Include reflected UPROPERTY values in get_actor_details",
+            "type": "boolean"
+          },
+          "includeStreaming": {
+            "description": "get_outliner: include World Partition streaming-proxy / HLOD actors (default false)",
+            "type": "boolean"
+          },
+          "includeTransforms": {
+            "description": "get_actors_by_class: include per-actor location/rotation/scale (default true) (#675)",
+            "type": "boolean"
+          },
+          "includeValues": {
+            "description": "get_component_details: dump arbitrary UPROPERTY values (#584)",
+            "type": "boolean"
+          },
+          "index": {
+            "description": "update_instance_transform/remove_instance: instance index (#697)",
+            "type": "number"
+          },
+          "initiallyLoaded": {
+            "type": "boolean"
+          },
+          "initiallyVisible": {
+            "type": "boolean"
+          },
+          "innerConeAngle": {
+            "type": "number"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "intensity": {
+            "type": "number"
+          },
+          "internalName": {
+            "description": "Internal/runtime UObject name for resolve_actor (e.g. StaticMeshActor_141)",
+            "type": "string"
+          },
+          "jitter": {
+            "description": "spawn_grid: per-axis location jitter",
+            "type": "number"
+          },
+          "killZ": {
+            "type": "number"
+          },
+          "label": {
+            "type": "string"
+          },
+          "labelPrefix": {
+            "description": "delete_actors / set_actor_folder_path: actor label prefix filter",
+            "type": "string"
+          },
+          "levelName": {
+            "type": "string"
+          },
+          "levelPath": {
+            "type": "string"
+          },
+          "levels": {
+            "description": "delete_exact_labeled_actors_in_levels: per-map targets, max 16 maps",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "actorLabels": {
+                  "description": "Exact editor labels to delete in that map (max 256, no duplicates)",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "expectedClassPath": {
+                  "description": "Optional actor class the matched actors must be, e.g. /Script/Engine.StaticMeshActor",
+                  "type": "string"
+                },
+                "levelPath": {
+                  "description": "Long package name of the .umap, e.g. /Game/Maps/Arena",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "levelPath",
+                "actorLabels"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "lightType": {
+            "type": "string"
+          },
+          "limit": {
+            "description": "list_actor_descs: max descriptors returned (default 500) (#746)",
+            "type": "number"
+          },
+          "loadedOnly": {
+            "description": "list_actor_descs: only actors currently streamed in (#746)",
+            "type": "boolean"
+          },
+          "location": {
+            "additionalProperties": false,
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "z": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "z"
+            ],
+            "type": "object"
+          },
+          "loop": {
+            "description": "spawn_skeletal_mesh_actor: loop the preview animation (#679)",
+            "type": "boolean"
+          },
+          "matchSubclasses": {
+            "description": "get_actors_by_class: match Blueprint subclasses via IsChildOf (default true) (#675)",
+            "type": "boolean"
+          },
+          "material": {
+            "description": "Asset path for material to apply at slot 0",
+            "type": "string"
+          },
+          "materialPath": {
+            "description": "Material asset path for set_actor_material",
+            "type": "string"
+          },
+          "materials": {
+            "description": "spawn_skeletal_mesh_actor: per-slot material paths (#679)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "max": {
+            "$ref": "#/properties/location",
+            "description": "spawn_grid upper bound"
+          },
+          "maxActors": {
+            "description": "load_actor_descs: refuse to act on more than this many actors (default 256) (#746)",
+            "type": "number"
+          },
+          "maxDistance": {
+            "description": "snap_actor_to_floor: line-trace length downward (default 100000)",
+            "type": "number"
+          },
+          "min": {
+            "$ref": "#/properties/location",
+            "description": "spawn_grid lower bound"
+          },
+          "mobility": {
+            "description": "set_actor_mobility: static | stationary | movable",
+            "type": "string"
+          },
+          "mode": {
+            "description": "load_actor_descs: pin (make resident, default) | unpin (release) (#746)",
+            "type": "string"
+          },
+          "nameFilter": {
+            "type": "string"
+          },
+          "offset": {
+            "$ref": "#/properties/location"
+          },
+          "onConflict": {
+            "description": "spawn_skeletal_mesh_actor: label conflict policy (skip|error)",
+            "type": "string"
+          },
+          "onMissing": {
+            "description": "delete_exact_labeled_actors_in_levels: error (default, a label matching nothing fails the whole request) | ignore (makes a replay idempotent)",
+            "type": "string"
+          },
+          "outerConeAngle": {
+            "type": "number"
+          },
+          "outputPath": {
+            "description": "export_actor_fbx: output .fbx path (#637)",
+            "type": "string"
+          },
+          "parentComponentName": {
+            "description": "attach_component: exact parent SceneComponent instance name; omitted selects the actor root",
+            "type": "string"
+          },
+          "parentLabel": {
+            "type": "string"
+          },
+          "pieInstance": {
+            "description": "Which PIE world to target when world='pie': 0 = server/primary, 1..N = clients. See editor(list_pie_instances) (#778)",
+            "type": "number"
+          },
+          "point": {
+            "$ref": "#/properties/location",
+            "description": "nav_project_point: world-space point to project onto the navmesh (#585)"
+          },
+          "points": {
+            "items": {
+              "$ref": "#/properties/location"
+            },
+            "type": "array"
+          },
+          "positionPrecision": {
+            "description": "set_nanite_settings: Nanite position precision (#696)",
+            "type": "number"
+          },
+          "projectPoint": {
+            "$ref": "#/properties/location",
+            "description": "get_spline_info: world-space point to project onto the spline (#555)"
+          },
+          "properties": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "propertyName": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "description": "get_component_details: restrict includeValues to these property names (#584)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "quality": {
+            "type": "string"
+          },
+          "recaptureSky": {
+            "type": "boolean"
+          },
+          "recursive": {
+            "type": "boolean"
+          },
+          "reference": {
+            "description": "Reference actor label for get_relative_transform",
+            "type": "string"
+          },
+          "restoreOriginalLevel": {
+            "description": "delete_exact_labeled_actors_in_levels: reopen the map that was loaded before the call (default true)",
+            "type": "boolean"
+          },
+          "roll": {
+            "description": "aim_actor_at: roll angle in degrees (default 0)",
+            "type": "number"
+          },
+          "rotation": {
+            "additionalProperties": false,
+            "properties": {
+              "pitch": {
+                "type": "number"
+              },
+              "roll": {
+                "type": "number"
+              },
+              "yaw": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "pitch",
+              "yaw",
+              "roll"
+            ],
+            "type": "object"
+          },
+          "scale": {
+            "$ref": "#/properties/location"
+          },
+          "skeletalMesh": {
+            "description": "spawn_skeletal_mesh_actor: USkeletalMesh path (#679)",
+            "type": "string"
+          },
+          "slotIndex": {
+            "description": "Material slot index (default 0)",
+            "type": "number"
+          },
+          "socketName": {
+            "description": "attach_actor/attach_component: socket or bone on the resolved parent component",
+            "type": "string"
+          },
+          "sourceRadius": {
+            "description": "set_light_properties: point/spot light source radius (#608)",
+            "type": "number"
+          },
+          "start": {
+            "$ref": "#/properties/location",
+            "description": "line_trace: ray start"
+          },
+          "startDistance": {
+            "type": "number"
+          },
+          "staticMesh": {
+            "description": "Asset path for static mesh (e.g. /Engine/BasicShapes/Cube.Cube)",
+            "type": "string"
+          },
+          "streamingClass": {
+            "description": "add_streaming_sublevel: LevelStreamingDynamic (default) | LevelStreamingAlwaysLoaded",
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "target": {
+            "description": "Target actor label for get_relative_transform",
+            "type": "string"
+          },
+          "targetActor": {
+            "description": "aim_actor_at: label of the actor to look at (alternative to targetPoint)",
+            "type": "string"
+          },
+          "targetPoint": {
+            "$ref": "#/properties/location",
+            "description": "aim_actor_at: world-space point to look at (alternative to targetActor)"
+          },
+          "temperature": {
+            "type": "number"
+          },
+          "templateLevel": {
+            "type": "string"
+          },
+          "topN": {
+            "description": "Limit for count_actors_by_class result",
+            "type": "number"
+          },
+          "traceComplex": {
+            "description": "line_trace: trace per-triangle (complex) collision instead of the simple collision a gameplay trace uses (default false) (#807)",
+            "type": "boolean"
+          },
+          "transactionLabel": {
+            "description": "set_actor_folder_path: undo-stack entry name (#767)",
+            "type": "string"
+          },
+          "transforms": {
+            "description": "add_hismc_instances transform list (#434)",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "unloadedOnly": {
+            "description": "list_actor_descs: only actors that exist on disk but are not streamed in (#746)",
+            "type": "boolean"
+          },
+          "value": {},
+          "volumeType": {
+            "type": "string"
+          },
+          "volumetricFogAlbedo": {
+            "$ref": "#/properties/color",
+            "description": "set_fog_properties: volumetric fog albedo (#608)"
+          },
+          "volumetricFogDistance": {
+            "description": "set_fog_properties: volumetric fog distance (#608)",
+            "type": "number"
+          },
+          "volumetricFogExtinctionScale": {
+            "description": "set_fog_properties: volumetric fog extinction scale (#608)",
+            "type": "number"
+          },
+          "volumetricFogScatteringDistribution": {
+            "description": "set_fog_properties: volumetric fog scattering distribution (#608)",
+            "type": "number"
+          },
+          "volumetricScatteringIntensity": {
+            "description": "set_light_properties: light/skylight volumetric scattering intensity (#608)",
+            "type": "number"
+          },
+          "weight": {
+            "description": "add_post_process_blendable: blend weight (default 1)",
+            "type": "number"
+          },
+          "weldSimulatedBodies": {
+            "description": "attach_component: weld simulated bodies during attachment (default false; welding may outlive detach)",
+            "type": "boolean"
+          },
+          "world": {
+            "description": "World scope: editor (default) or pie",
+            "type": "string"
+          },
+          "worldSpace": {
+            "description": "add_hismc_instances/instance ops: treat transforms as world-space (default true) (#434)",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "level"
+    },
+    {
+      "description": "Materials: create, read, parameters, shading, textures, and graph authoring (expression nodes, connections).\n\nActions:\n- read: Read material structure. Params: assetPath\n- list_parameters: List overridable parameters. Params: assetPath\n- set_parameter: Set parameter on MaterialInstance. Params: assetPath, parameterName, parameterType, value\n- read_instance: Read a MaterialInstanceConstant parent and override summary. Params: assetPath\n- set_instance_parent: Set a MaterialInstanceConstant parent. Params: assetPath, newParentPath (or parentPath)\n- batch_set_instances: Batch reparent + reassign parameters across many Material Instances in one call. Params: instances[] = [{assetPath, parentPath?, parameters?:[{name, type (scalar|vector|texture), value}]}]. value: number (scalar), {r,g,b,a} (vector), or texture path (texture). Returns per-instance results (#594)\n- clear_instance_parameters: Clear all MaterialInstanceConstant parameter overrides. Params: assetPath\n- list_static_switches: List static switch parameters on a Material or MaterialInstance. Params: assetPath\n- set_static_switch: Set a MaterialInstanceConstant static switch parameter. Params: assetPath, parameterName, value, association?, parameterIndex?\n- set_expression_value: Set a value on an expression node. Common typed knobs: value (constant/param default), texturePath (TextureSample/TextureSampleParameter2D default texture). For any OTHER UPROPERTY on the expression (e.g. SamplerType, SamplerSource, Group), pass propertyName + value to hit the generic reflection setter. Params: materialPath, expressionIndex, value?, texturePath?, propertyName? (#663)\n- set_custom_expression: Read/write a MaterialExpressionCustom (HLSL) node: code, named inputs[] (rebuilds input pins; wire them with connect_expressions targetInput=<name>), outputType (float1|float2|float3|float4|materialAttributes), description. Omit code/inputs to read. Add the node first via add_expression expressionType=Custom. Params: materialPath, expressionIndex, code?, inputs?, outputType?, description? (#617)\n- disconnect_property: Disconnect a material property input. Params: materialPath, property\n- create_instance: Create material instance. Params: parentPath, name?, packagePath?\n- create: Create material. Params: name, packagePath?\n- create_function: Create a MaterialFunction asset. Params: name, packagePath? (default /Game/Materials/Functions), description? (#463)\n- add_function_expression: Add an expression node to a MaterialFunction graph. Params: functionPath, expressionType (e.g. Constant3Vector, FunctionInput, FunctionOutput, If), positionX?, positionY?, inputName? (for FunctionInput), inputType? (Scalar|Vector2|Vector3|Vector4|Texture2D|TextureCube|StaticBool|MaterialAttributes), outputName? (for FunctionOutput) (#463)\n- connect_function_expressions: Wire two expressions inside a MaterialFunction. Params: functionPath, sourceExpression (name or index), sourceOutput?, targetExpression (name or index), targetInput? (#463)\n- list_function_expressions: List expression nodes inside a MaterialFunction. Params: functionPath (#463)\n- create_simple: Single-call simple material. Params: name, packagePath?, baseColor? ({r,g,b}), metallic?, specular?, roughness?, emissive?, usages?[] (e.g. InstancedStaticMeshes, Nanite, NiagaraSprites). Recompiles + saves in one shot (#225)\n- set_usage: Set EMaterialUsage flag(s) on a material. Params: assetPath, usage OR usages[], enabled? (default true). Recompiles + saves (#225)\n- set_shading_model: Set shading model. Params: assetPath, shadingModel\n- set_blend_mode: Set blend mode. Params: assetPath, blendMode\n- set_domain: Set material domain. Params: assetPath, materialDomain (Surface | DeferredDecal | LightFunction | Volume | PostProcess | UI | RuntimeVirtualTexture). Required for post-process / decal / UI authoring (#299/#356).\n- set_base_color: Set base color. Params: assetPath, color\n- connect_texture: Connect texture to property. Params: materialPath, texturePath, property\n- add_expression: Add expression node. Params: materialPath, expressionType, name?, parameterName?, group?, sortPriority?, defaultValue? (scalar number or {r,g,b,a} for vector params), value? (number for Constant, {r,g,b} for Constant3Vector, {x,y} for Constant2Vector), channels? ({r,g,b,a} bools for ComponentMask), positionX?, positionY? (#318)\n- connect_expressions: Wire two expressions. Params: materialPath, sourceExpression, sourceOutput?, targetExpression, targetInput?\n- connect_to_property: Wire expression to material output. Params: materialPath, expressionName, outputName?, property\n- list_expressions: List expression nodes. Params: materialPath\n- delete_expression: Remove expression. Params: materialPath, expressionName\n- list_expression_types: List available expression types\n- recompile: Recompile material. Pass recompileChildren=true to cascade to every MaterialInstanceConstant whose parent chain reaches this material (#421). Params: materialPath, recompileChildren?\n- duplicate: Duplicate material asset. Params: sourcePath, destinationPath\n- validate: Validate material graph - find orphans, broken refs. Params: assetPath\n- get_shader_stats: Shader compile stats, sampler+param counts. Params: assetPath\n- export_graph: Export material graph as JSON. Params: assetPath\n- import_graph: Rebuild graph from JSON. Params: assetPath, nodes, propertyConnections?\n- build_graph: Build graph from spec. Params: assetPath, nodes, propertyConnections?\n- render_preview: Render preview PNG. Params: assetPath, outputPath, width?, height?\n- begin_transaction: Begin undo transaction. Params: label?\n- end_transaction: End undo transaction\n\nEpic 5.8 toolset actions (35): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "read",
+              "list_parameters",
+              "set_parameter",
+              "read_instance",
+              "set_instance_parent",
+              "batch_set_instances",
+              "clear_instance_parameters",
+              "list_static_switches",
+              "set_static_switch",
+              "set_expression_value",
+              "set_custom_expression",
+              "disconnect_property",
+              "create_instance",
+              "create",
+              "create_function",
+              "add_function_expression",
+              "connect_function_expressions",
+              "list_function_expressions",
+              "create_simple",
+              "set_usage",
+              "set_shading_model",
+              "set_blend_mode",
+              "set_domain",
+              "set_base_color",
+              "connect_texture",
+              "add_expression",
+              "connect_expressions",
+              "connect_to_property",
+              "list_expressions",
+              "delete_expression",
+              "list_expression_types",
+              "recompile",
+              "duplicate",
+              "validate",
+              "get_shader_stats",
+              "export_graph",
+              "import_graph",
+              "build_graph",
+              "render_preview",
+              "begin_transaction",
+              "end_transaction",
+              "epic_get_referencing_materials",
+              "epic_recompile",
+              "epic_delete_unused_expressions",
+              "epic_disconnect_from_output",
+              "epic_connect_to_output",
+              "epic_get_property_input",
+              "epic_get_expression_inputs",
+              "epic_disconnect_expressions",
+              "epic_connect_expressions",
+              "epic_get_expression_output_names",
+              "epic_get_expression_input_names",
+              "epic_delete_parameter_group",
+              "epic_rename_parameter_group",
+              "epic_list_parameter_groups",
+              "epic_layout_expressions",
+              "epic_get_expressions",
+              "epic_delete_expression",
+              "epic_add_expression",
+              "epic_list_expression_classes",
+              "epic_create_parameter_collection",
+              "epic_create_function",
+              "epic_create_material",
+              "epic_set_parameter_override",
+              "epic_clear_parameters",
+              "epic_set_parent",
+              "epic_set_static_switch_parameter",
+              "epic_get_static_switch_parameter",
+              "epic_set_texture_parameter",
+              "epic_get_texture_parameter",
+              "epic_set_vector_parameter",
+              "epic_get_vector_parameter",
+              "epic_set_scalar_parameter",
+              "epic_get_scalar_parameter",
+              "epic_list_parameters",
+              "epic_create"
+            ],
+            "type": "string"
+          },
+          "assetPath": {
+            "type": "string"
+          },
+          "association": {
+            "description": "Material parameter association: Global, Layer, or Blend",
+            "type": "string"
+          },
+          "baseColor": {
+            "$ref": "#/properties/color",
+            "description": "create_simple base color"
+          },
+          "blendMode": {
+            "description": "Blend mode: Opaque, Masked, Translucent, Additive, Modulate, AlphaComposite, AlphaHoldout",
+            "type": "string"
+          },
+          "channels": {
+            "additionalProperties": {},
+            "description": "ComponentMask channels {r,g,b,a} bools",
+            "type": "object"
+          },
+          "code": {
+            "description": "set_custom_expression: HLSL code body (#617)",
+            "type": "string"
+          },
+          "color": {
+            "additionalProperties": false,
+            "properties": {
+              "a": {
+                "type": "number"
+              },
+              "b": {
+                "type": "number"
+              },
+              "g": {
+                "type": "number"
+              },
+              "r": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "r",
+              "g",
+              "b"
+            ],
+            "type": "object"
+          },
+          "defaultValue": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "additionalProperties": {},
+                "type": "object"
+              }
+            ],
+            "description": "ScalarParameter default (number) or VectorParameter default ({r,g,b,a})"
+          },
+          "description": {
+            "description": "MaterialFunction description (#463)",
+            "type": "string"
+          },
+          "destinationPath": {
+            "type": "string"
+          },
+          "domain": {
+            "description": "Alias for materialDomain",
+            "type": "string"
+          },
+          "emissive": {
+            "type": "number"
+          },
+          "enabled": {
+            "description": "set_usage: enable (default true) or disable",
+            "type": "boolean"
+          },
+          "expressionIndex": {
+            "type": "number"
+          },
+          "expressionName": {
+            "type": "string"
+          },
+          "expressionType": {
+            "description": "Expression type: Constant, TextureSample, Multiply, Lerp, ScalarParameter, etc.",
+            "type": "string"
+          },
+          "functionPath": {
+            "description": "MaterialFunction asset path (#463)",
+            "type": "string"
+          },
+          "group": {
+            "description": "Parameter Group on add_expression for parameter nodes (#318)",
+            "type": "string"
+          },
+          "height": {
+            "type": "number"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "inputName": {
+            "description": "FunctionInput name (#463)",
+            "type": "string"
+          },
+          "inputType": {
+            "description": "FunctionInput type: Scalar|Vector2|Vector3|Vector4|Texture2D|TextureCube|StaticBool|MaterialAttributes (#463)",
+            "type": "string"
+          },
+          "inputs": {
+            "description": "set_custom_expression: named input pins (#617)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "instances": {
+            "description": "batch_set_instances: [{assetPath, parentPath?, parameters?}] (#594)",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "label": {
+            "description": "Transaction label",
+            "type": "string"
+          },
+          "materialDomain": {
+            "description": "Material domain for set_domain: Surface, DeferredDecal, LightFunction, Volume, PostProcess, UI, RuntimeVirtualTexture",
+            "type": "string"
+          },
+          "materialFunctionPath": {
+            "description": "Alias for functionPath",
+            "type": "string"
+          },
+          "materialPath": {
+            "type": "string"
+          },
+          "metallic": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "newParentPath": {
+            "description": "New parent material or material instance path",
+            "type": "string"
+          },
+          "nodes": {
+            "description": "Graph spec: [{name,class,posX,posY,...}]",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "onConflict": {
+            "description": "create_simple: skip (default) | error",
+            "type": "string"
+          },
+          "outputName": {
+            "type": "string"
+          },
+          "outputPath": {
+            "description": "Absolute file path for render_preview PNG output",
+            "type": "string"
+          },
+          "outputType": {
+            "description": "set_custom_expression: float1|float2|float3|float4|materialAttributes (#617)",
+            "type": "string"
+          },
+          "packagePath": {
+            "type": "string"
+          },
+          "parameterIndex": {
+            "description": "Material layer/blend parameter index",
+            "type": "number"
+          },
+          "parameterName": {
+            "type": "string"
+          },
+          "parameterType": {
+            "description": "Parameter type for set_parameter: scalar, vector, texture",
+            "type": "string"
+          },
+          "parentPath": {
+            "type": "string"
+          },
+          "positionX": {
+            "type": "number"
+          },
+          "positionY": {
+            "type": "number"
+          },
+          "properties": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "property": {
+            "description": "Material property: BaseColor, Normal, Roughness, Metallic, EmissiveColor, etc.",
+            "type": "string"
+          },
+          "propertyConnections": {
+            "description": "[{property,from,outputIndex}]",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "propertyName": {
+            "description": "set_expression_value: name of an arbitrary UPROPERTY on the expression to set via reflection, e.g. SamplerType (#663)",
+            "type": "string"
+          },
+          "recompileChildren": {
+            "description": "recompile_material: cascade to MaterialInstances whose parent chain reaches this material",
+            "type": "boolean"
+          },
+          "roughness": {
+            "type": "number"
+          },
+          "shadingModel": {
+            "type": "string"
+          },
+          "sortPriority": {
+            "description": "SortPriority within a parameter Group",
+            "type": "number"
+          },
+          "sourceExpression": {
+            "type": "string"
+          },
+          "sourceOutput": {
+            "type": "string"
+          },
+          "sourcePath": {
+            "type": "string"
+          },
+          "specular": {
+            "type": "number"
+          },
+          "targetExpression": {
+            "type": "string"
+          },
+          "targetInput": {
+            "type": "string"
+          },
+          "texturePath": {
+            "type": "string"
+          },
+          "usage": {
+            "description": "set_usage: single MATUSAGE flag name",
+            "type": "string"
+          },
+          "usages": {
+            "description": "MATUSAGE flag names for create_simple/set_usage (InstancedStaticMeshes, Nanite, NiagaraSprites, ...)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "value": {},
+          "width": {
+            "type": "number"
+          },
+          "x": {
+            "type": "number"
+          },
+          "y": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "material"
+    },
+    {
+      "description": "Networking and replication: actor replication, property replication, net relevancy, dormancy.\n\nActions:\n- set_replicates: Enable actor replication. Params: blueprintPath, replicates?\n- set_property_replicated: Mark a Blueprint variable as replicated. replicationType is 'None' | 'Replicated' | 'RepNotify'; repNotify=true is shorthand for RepNotify and replicated=true for Replicated. Params: blueprintPath, variableName (alias: propertyName), replicationType? | replicated? | repNotify? (#768)\n- configure_net_frequency: Set update frequency. Params: blueprintPath, netUpdateFrequency?, minNetUpdateFrequency?\n- set_dormancy: Set net dormancy. Params: blueprintPath, dormancy\n- set_net_load_on_client: Control client loading. Params: blueprintPath, loadOnClient?\n- set_always_relevant: Always network relevant. Params: blueprintPath, alwaysRelevant?\n- set_only_relevant_to_owner: Only relevant to owner. Params: blueprintPath, onlyRelevantToOwner?\n- configure_cull_distance: Net cull distance. Params: blueprintPath, netCullDistanceSquared?\n- set_priority: Net priority. Params: blueprintPath, netPriority?\n- set_replicate_movement: Replicate movement. Params: blueprintPath, replicateMovement?\n- get_info: Get networking info. Params: blueprintPath",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "set_replicates",
+              "set_property_replicated",
+              "configure_net_frequency",
+              "set_dormancy",
+              "set_net_load_on_client",
+              "set_always_relevant",
+              "set_only_relevant_to_owner",
+              "configure_cull_distance",
+              "set_priority",
+              "set_replicate_movement",
+              "get_info"
+            ],
+            "type": "string"
+          },
+          "alwaysRelevant": {
+            "type": "boolean"
+          },
+          "blueprintPath": {
+            "type": "string"
+          },
+          "dormancy": {
+            "type": "string"
+          },
+          "loadOnClient": {
+            "type": "boolean"
+          },
+          "minNetUpdateFrequency": {
+            "type": "number"
+          },
+          "netCullDistanceSquared": {
+            "type": "number"
+          },
+          "netPriority": {
+            "type": "number"
+          },
+          "netUpdateFrequency": {
+            "type": "number"
+          },
+          "onlyRelevantToOwner": {
+            "type": "boolean"
+          },
+          "propertyName": {
+            "type": "string"
+          },
+          "repNotify": {
+            "type": "boolean"
+          },
+          "replicateMovement": {
+            "type": "boolean"
+          },
+          "replicated": {
+            "type": "boolean"
+          },
+          "replicates": {
+            "type": "boolean"
+          },
+          "replicationType": {
+            "description": "set_property_replicated: None | Replicated | RepNotify (#768)",
+            "type": "string"
+          },
+          "variableName": {
+            "description": "set_property_replicated: Blueprint variable name (propertyName is accepted too) (#768)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "networking"
+    },
+    {
+      "description": "Niagara VFX: systems, emitters, spawning, parameters, and graph authoring.\n\nActions:\n- list: List Niagara assets. Params: directory?, recursive?\n- get_info: Inspect system. Params: assetPath\n- validate: Verify gate: does this system actually emit? Reports per emitter whether it is enabled and has a spawn module + an enabled renderer. valid=false means empty shell. Params: systemPath\n- spawn: Spawn VFX as a transient component (GC's before offscreen capture). For a findable preview use spawn_actor. Params: systemPath, location, rotation?, label?\n- spawn_actor: Spawn a PERSISTENT, labeled NiagaraActor in the editor world (findable, re-activatable, survives capture - unlike spawn). Assigns the system and activates. Params: systemPath, location?, rotation?, label?, activate? (default true) (#537)\n- reactivate: Reset + reactivate the NiagaraComponent on a placed actor (replay a burst before capturing). Params: actorLabel (#537)\n- set_parameter: Set parameter. Params: actorLabel, parameterName, value, parameterType?\n- create: Create system. Params: name, packagePath?\n- create_emitter: Create a Niagara emitter asset. templatePath copies an existing emitter as the starting point (the content browser's create-from-template path); omit it for the default empty emitter with the standard modules and a sprite renderer. inherit=true makes it a child that tracks the template instead, which then refuses local edits to inherited modules. Params: name, packagePath?, templatePath?, inherit? (default false), onConflict?\n- add_emitter: Add emitter to system. Params: systemPath, emitterPath\n- remove_emitter: Remove an emitter from a system (CRUD delete). Params: systemPath, emitterName? or emitterIndex?\n- list_emitters: List emitters in system. Params: systemPath\n- set_emitter_property: Set emitter property. Params: systemPath, emitterName?, propertyName, value\n- list_modules: List Niagara modules. Params: directory?\n- get_emitter_info: Inspect emitter. Params: assetPath\n- list_renderers: List renderers on an emitter. Params: systemPath, emitterName?, emitterIndex?\n- add_renderer: Add renderer (sprite/mesh/ribbon or full class). Params: systemPath, rendererType, emitterName?, emitterIndex?\n- remove_renderer: Remove renderer by index. Params: systemPath, rendererIndex, emitterName?, emitterIndex?\n- set_renderer_property: Set any renderer property. Bools, numbers and strings are taken directly; object properties (a sprite/mesh renderer's Material, the mesh on a mesh renderer) take an asset path and are class-checked; structs, enums, names and arrays go through the shared JSON property setter, so there is no longer a type whitelist to fall off (#783). Params: systemPath, rendererIndex, propertyName, value, emitterName?, emitterIndex?\n- inspect_data_interfaces: List user-scope data interfaces. Params: systemPath\n- create_system_from_spec: Declaratively create a system + emitters. Params: name, packagePath?, emitters?:[{path}]\n- get_compiled_hlsl: Read GPU compute script info for an emitter. Params: systemPath, emitterName?, emitterIndex?\n- list_system_parameters: List user-exposed system parameters. Params: systemPath\n- list_module_inputs: List an emitter's modules with the inputs you can actually SET - Spawn Rate, Lifetime, Colour, Sprite Size - each with its name, qualifiedName, type and a settable flag. Current values are NOT returned: the binder's value reader is not exported from NiagaraEditor, so the names and types are readable but the live value is not. Compile-time switches and enums are reported separately under switchPins; note that 'inputs' now means override-map inputs, NOT the function-call node pins it meant before (those are switchPins) (#784). Params: systemPath, emitterName?, emitterIndex?, stackContext? (ParticleSpawn|ParticleUpdate|EmitterSpawn|EmitterUpdate|all - default all), moduleName?\n- set_module_input: Set a module input value. Override-map-bound inputs (the numeric/colour values that matter) are written through the stack override map, the same path the Niagara stack editor uses; others fall back to the pin default. Reports writePath ('overrideMap'|'pinDefault'). On the overrideMap path previousValue cannot be read back (NiagaraEditor does not export the binder's reader), so it reports '(unread: override map)' and NO rollback is offered - re-set the value explicitly instead. The pinDefault path reports a real previousValue and is rollback-safe (#769). value accepts a scalar, [x,y,z], {x,y,z[,w]} or {r,g,b[,a]} (alpha defaults to 1); anything the input's type cannot parse is REJECTED rather than written, including gapped component objects and non-finite numbers. Params: systemPath, moduleName, inputName, value, emitterName?, emitterIndex?, stackContext?\n- add_module: Add a stock /Niagara/Modules script to an emitter stack (the modules that make an emitter actually do anything). Params: systemPath, moduleScript (e.g. /Niagara/Modules/Emitter/SpawnRate), stackContext (ParticleSpawn|ParticleUpdate|EmitterSpawn|EmitterUpdate), emitterName?, emitterIndex?, targetIndex? (-1 appends). Then set_module_input to tune it.\n- list_static_switches: List static switch inputs on a module. Params: systemPath, moduleName, emitterName?, emitterIndex?, stackContext?\n- set_static_switch: Set static switch value on a module's function call node. Params: systemPath, moduleName, switchName, value, emitterName?, emitterIndex?, stackContext?\n- create_module_from_hlsl: Create a NiagaraScript module backed by a custom HLSL node. Params: name, hlsl, packagePath?, inputs?:[{name,type}], outputs?:[{name,type}]\n- create_scratch_module: Create empty Niagara scratch module. Params: name, packagePath?, inputs?:[{name,type}], outputs?:[{name,type}] (#185)\n- batch: Run a sequence of niagara operations against the bridge in order. Fails fast on the first error (returns results up to that point + error). Params: ops:[{action, params}] where action is any niagara subaction listed above.\n\nEpic 5.8 toolset actions (56): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "list",
+              "get_info",
+              "validate",
+              "spawn",
+              "spawn_actor",
+              "reactivate",
+              "set_parameter",
+              "create",
+              "create_emitter",
+              "add_emitter",
+              "remove_emitter",
+              "list_emitters",
+              "set_emitter_property",
+              "list_modules",
+              "get_emitter_info",
+              "list_renderers",
+              "add_renderer",
+              "remove_renderer",
+              "set_renderer_property",
+              "inspect_data_interfaces",
+              "create_system_from_spec",
+              "get_compiled_hlsl",
+              "list_system_parameters",
+              "list_module_inputs",
+              "set_module_input",
+              "add_module",
+              "list_static_switches",
+              "set_static_switch",
+              "create_module_from_hlsl",
+              "create_scratch_module",
+              "batch",
+              "epic_uenum_info",
+              "epic_set_variable",
+              "epic_set_system",
+              "epic_get_variable",
+              "epic_get_user_variables",
+              "epic_construct_niagara_bpwrapper_from_system",
+              "epic_construct_niagara_bpwrapper_from_component",
+              "epic_set_system_data",
+              "epic_set_stack_input_data",
+              "epic_set_renderer_data",
+              "epic_set_module_enabled",
+              "epic_set_emitter_data",
+              "epic_remove_user_variables",
+              "epic_remove_set_parameter_entry",
+              "epic_remove_renderer",
+              "epic_remove_module",
+              "epic_remove_emitter",
+              "epic_get_user_variables__niagara_toolset_system",
+              "epic_get_system_summary",
+              "epic_get_system_schema",
+              "epic_get_system_dependencies",
+              "epic_get_system_data",
+              "epic_get_system_compile_state",
+              "epic_get_stack_issues",
+              "epic_get_stack_input_topology",
+              "epic_get_stack_input_schema",
+              "epic_get_stack_input_data",
+              "epic_get_script_stack_topology",
+              "epic_get_script_stack_input_values",
+              "epic_get_renderer_schema",
+              "epic_get_renderer_data",
+              "epic_get_module_topology",
+              "epic_get_module_schema_from_asset",
+              "epic_get_module_schema",
+              "epic_get_module_input_values",
+              "epic_get_emitter_topology",
+              "epic_get_emitter_summary",
+              "epic_get_emitter_schema",
+              "epic_get_emitter_input_values",
+              "epic_get_emitter_data",
+              "epic_get_dynamic_input_schema_from_asset",
+              "epic_get_dynamic_input_schema",
+              "epic_get_dynamic_input_chain",
+              "epic_get_data_interface_schema",
+              "epic_get_available_dynamic_inputs",
+              "epic_create_niagara_system",
+              "epic_apply_stack_issue_fix",
+              "epic_add_user_variables",
+              "epic_add_set_parameters_module",
+              "epic_add_set_parameter_entry",
+              "epic_add_renderer",
+              "epic_add_module",
+              "epic_add_emitter",
+              "epic_get_niagara_script_digest",
+              "epic_get_asset_discovery_info",
+              "epic_find_niagara_scripts"
+            ],
+            "type": "string"
+          },
+          "activate": {
+            "description": "spawn_actor: activate the system on spawn (default true) (#537)",
+            "type": "boolean"
+          },
+          "actorLabel": {
+            "type": "string"
+          },
+          "assetPath": {
+            "type": "string"
+          },
+          "directory": {
+            "type": "string"
+          },
+          "emitterIndex": {
+            "type": "number"
+          },
+          "emitterName": {
+            "type": "string"
+          },
+          "emitterPath": {
+            "type": "string"
+          },
+          "emitters": {
+            "description": "Spec: [{path:'/Game/VFX/E_Fire'}]",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "hlsl": {
+            "description": "For create_module_from_hlsl: HLSL body",
+            "type": "string"
+          },
+          "inherit": {
+            "description": "create_emitter: inherit from templatePath instead of copying it (default false)",
+            "type": "boolean"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "inputName": {
+            "description": "For set_module_input: module input pin name",
+            "type": "string"
+          },
+          "inputs": {
+            "description": "For create_module_from_hlsl: [{name, type}]",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "label": {
+            "type": "string"
+          },
+          "location": {
+            "additionalProperties": false,
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "z": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "z"
+            ],
+            "type": "object"
+          },
+          "moduleName": {
+            "description": "For module input / static switch ops: name of the module function call node",
+            "type": "string"
+          },
+          "moduleScript": {
+            "description": "For add_module: stock module script path, e.g. /Niagara/Modules/Emitter/SpawnRate",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "onConflict": {
+            "description": "skip|error when asset exists",
+            "type": "string"
+          },
+          "ops": {
+            "description": "For batch: [{action, params}]",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "outputs": {
+            "description": "For create_module_from_hlsl: [{name, type}]",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "packagePath": {
+            "type": "string"
+          },
+          "parameterName": {
+            "type": "string"
+          },
+          "parameterType": {
+            "type": "string"
+          },
+          "propertyName": {
+            "type": "string"
+          },
+          "recursive": {
+            "type": "boolean"
+          },
+          "rendererIndex": {
+            "type": "number"
+          },
+          "rendererType": {
+            "description": "sprite|mesh|ribbon or full class name",
+            "type": "string"
+          },
+          "rotation": {
+            "additionalProperties": false,
+            "properties": {
+              "pitch": {
+                "type": "number"
+              },
+              "roll": {
+                "type": "number"
+              },
+              "yaw": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "pitch",
+              "yaw",
+              "roll"
+            ],
+            "type": "object"
+          },
+          "stackContext": {
+            "description": "ParticleSpawn|ParticleUpdate|EmitterSpawn|EmitterUpdate|all (default all)",
+            "type": "string"
+          },
+          "switchName": {
+            "description": "For set_static_switch: static switch input name",
+            "type": "string"
+          },
+          "systemPath": {
+            "type": "string"
+          },
+          "targetIndex": {
+            "description": "For add_module: stack insert position; -1 (default) appends",
+            "type": "number"
+          },
+          "templatePath": {
+            "description": "create_emitter: emitter asset to copy as a starting point",
+            "type": "string"
+          },
+          "value": {}
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "niagara"
+    },
+    {
+      "description": "Procedural Content Generation: graphs, nodes, connections, execution, volumes.\n\nActions:\n- list_graphs: List PCG graphs. Params: directory?, recursive?\n- read_graph: Read graph structure. Params: assetPath\n- read_node_settings: Read node settings. Params: assetPath, nodeName\n- get_components: List PCG components in level\n- get_component_details: Inspect PCG component. Params: actorLabel\n- create_graph: Create graph. Params: name, packagePath?\n- add_node: Add node. Params: assetPath, nodeType, nodeName?\n- connect_nodes: Wire nodes. Params: assetPath, sourceNode, sourcePin, targetNode, targetPin. Returns edgeVerified=true after confirming the UPCGEdge persisted; surfaces an error if AddEdge succeeded but no edge object was instantiated (#304).\n- disconnect_nodes: Remove a wired edge between two PCG nodes. Params: assetPath, sourceNode, targetNode, sourcePin? (default: any), targetPin? (default: any). Returns removedEdges count (#346).\n- set_node_settings: Set node params. Params: assetPath, nodeName, settings\n- set_static_mesh_spawner_meshes: Populate weighted MeshEntries on a PCGStaticMeshSpawner node (#145). Params: assetPath, nodeName, entries=[{mesh, weight?}], replace? (default true)\n- remove_node: Remove node. Params: assetPath, nodeName\n- execute: Regenerate PCG. Params: actorLabel\n- force_regenerate: Force a stuck PCG component to regenerate (clears graph ref, re-sets, cleanup+generate). Params: actorLabel (#146)\n- cleanup: Cleanup a PCG component (remove spawned content). Params: actorLabel, removeComponents? (default true) (#146)\n- toggle_graph: Toggle a PCG component's graph assignment to force reinit (no generate). Params: actorLabel, graphPath? (#146)\n- add_volume: Place PCG volume. Params: graphPath, location?, extent?\n- import_graph: Bulk-author a PCG graph from JSON. Params: assetPath, nodes=[{name,class,posX?,posY?,settings?}], connections=[{from,fromPin?,to,toPin?}], replace? (default false). One call replaces N add_node + M connect_nodes + K set_node_settings (#213).\n- export_graph: Export a PCG graph as JSON. Params: assetPath, includeSettings? (default true). Round-trip safe with import_graph (#213).\n\nEpic 5.8 toolset actions (31): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "list_graphs",
+              "read_graph",
+              "read_node_settings",
+              "get_components",
+              "get_component_details",
+              "create_graph",
+              "add_node",
+              "connect_nodes",
+              "disconnect_nodes",
+              "set_node_settings",
+              "set_static_mesh_spawner_meshes",
+              "remove_node",
+              "execute",
+              "force_regenerate",
+              "cleanup",
+              "toggle_graph",
+              "add_volume",
+              "import_graph",
+              "export_graph",
+              "epic_update_node",
+              "epic_update_comment_box",
+              "epic_spawn_graph_instance",
+              "epic_set_node_comment",
+              "epic_set_graph_params",
+              "epic_set_graph_instance_params",
+              "epic_set_graph_description",
+              "epic_reset_graph_instance_params",
+              "epic_reposition_node",
+              "epic_remove_node",
+              "epic_remove_graph_params",
+              "epic_remove_comment_box",
+              "epic_list_native_nodes",
+              "epic_list_graph_instances",
+              "epic_list_available_subgraphs",
+              "epic_get_node_info",
+              "epic_get_node_data_view",
+              "epic_get_native_node_schema",
+              "epic_get_graph_structure",
+              "epic_get_graph_schema",
+              "epic_get_graph_instance_params",
+              "epic_get_graph_description",
+              "epic_execute_graph_instance",
+              "epic_draw_spline",
+              "epic_disconnect_node_pins",
+              "epic_create_graph",
+              "epic_connect_node_pins",
+              "epic_add_subgraph_node",
+              "epic_add_node",
+              "epic_add_comment_box",
+              "epic_run_pcginstant_graph"
+            ],
+            "type": "string"
+          },
+          "actorLabel": {
+            "type": "string"
+          },
+          "assetPath": {
+            "type": "string"
+          },
+          "connections": {
+            "description": "import_graph: [{from, fromPin?, to, toPin?}]",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "directory": {
+            "type": "string"
+          },
+          "entries": {
+            "description": "Array of {mesh, weight?} entries for set_static_mesh_spawner_meshes",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "extent": {
+            "$ref": "#/properties/location"
+          },
+          "graphPath": {
+            "type": "string"
+          },
+          "includeSettings": {
+            "description": "export_graph: include per-node editable settings in the response (default true)",
+            "type": "boolean"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "location": {
+            "additionalProperties": false,
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "z": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "z"
+            ],
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nodeName": {
+            "type": "string"
+          },
+          "nodeType": {
+            "type": "string"
+          },
+          "nodes": {
+            "description": "import_graph: [{name, class, posX?, posY?, settings?}]",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "packagePath": {
+            "type": "string"
+          },
+          "recursive": {
+            "type": "boolean"
+          },
+          "removeComponents": {
+            "description": "cleanup: remove managed spawned components (default true)",
+            "type": "boolean"
+          },
+          "replace": {
+            "description": "set_static_mesh_spawner_meshes: overwrite existing MeshEntries (default true). import_graph: wipe existing user nodes first (default false).",
+            "type": "boolean"
+          },
+          "settings": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "sourceNode": {
+            "type": "string"
+          },
+          "sourcePin": {
+            "type": "string"
+          },
+          "targetNode": {
+            "type": "string"
+          },
+          "targetPin": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "pcg"
+    },
+    {
+      "description": "Introspect npm-distributed plugins that contribute actions into other categories. Read-only.\n\nActions:\n- list: Every plugin loaded from ue-mcp.yml: name, version, prefix, status, and injected actions\n- describe: Full detail for one plugin including knowledge files and flows. Params: name\n\nEpic 5.8 toolset actions (24): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "list",
+              "describe",
+              "epic_request_deactivate_game_feature",
+              "epic_request_activate_game_feature",
+              "epic_list_enabled_game_feature_plugins",
+              "epic_list_discovered_game_feature_plugins",
+              "epic_is_game_feature_plugin",
+              "epic_is_game_feature_active",
+              "epic_get_game_feature_state",
+              "epic_validate_new_plugin_name_and_location",
+              "epic_update_plugin_descriptor",
+              "epic_set_plugin_enabled",
+              "epic_remove_plugin_dependency",
+              "epic_list_enabled_plugins",
+              "epic_list_discovered_plugins",
+              "epic_is_plugin_modification_allowed",
+              "epic_is_plugin_creation_allowed",
+              "epic_is_enabled",
+              "epic_get_plugin_template_descriptions",
+              "epic_get_plugin_info",
+              "epic_get_plugin_for_asset",
+              "epic_get_plugin_descriptor",
+              "epic_get_plugin_dependents",
+              "epic_get_plugin_dependencies",
+              "epic_create_plugin",
+              "epic_add_plugin_dependency"
+            ],
+            "type": "string"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "name": {
+            "description": "Plugin npm package name (describe action)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "plugins"
+    },
+    {
+      "description": "Project status and editor connection: get_status (is the editor connected?), set_project (switch/redirect the bridge to another .uproject), get_info. Also config INI files, module load state, and C++ source inspection. Call project(get_status) first in any session.\n\nActions:\n- get_status: Check server mode and editor connection. Also reports pluginBuildStale when the compiled bridge is older than its source, which is the real cause of 'Unknown method' on handlers that do exist (#785)\n- set_project: Switch project: moves both path resolution and the editor connection to the new .uproject. Params: projectPath\n- list_editors: List every editor session this server drives: name, project, bridge port, whether the socket is connected, whether anything is answering on that port, and which session untargeted calls fall through to (#817)\n- use_editor: Make one editor session the default target for untargeted calls. Does not change the session set and never touches any editor process. Params: editorTarget (session name, project name, or .uproject path) (#817)\n- add_editor: Register another project as an addressable editor session, with its own bridge connection and port. Optionally launch its editor. Every category then accepts editor=\"<name>\" to run a call there. Params: projectPath, editorName? (defaults to the project name), start? (launch the editor and wait for it to be ready), timeout? (seconds, default 300) (#817)\n- drop_editor: Forget an editor session and close its bridge socket. The editor process is LEFT RUNNING and untouched - this detaches, it does not stop anything (use editor(stop_editor) for that). Params: editorTarget (#817)\n- get_info: Read .uproject file details\n- read_config: Read INI config. Params: configName (e.g. 'Engine', 'Game')\n- search_config: Search INI files. Params: query\n- list_config_tags: Extract gameplay tags from config\n- read_cpp_header: Parse a .h file. Params: headerPath\n- read_module: Read module source. Params: moduleName\n- list_modules: List C++ modules\n- search_cpp: Search .h/.cpp files. Params: query, directory?\n- read_engine_header: Parse a .h file from the engine source tree. Params: headerPath (relative to Engine/Source, or absolute)\n- find_engine_symbol: Grep engine headers for a symbol. Params: symbol, maxResults?\n- list_engine_modules: List modules in Engine/Source/Runtime\n- search_engine_cpp: Search engine .h/.cpp/.inl files across Runtime/Editor/Developer/Plugins. Params: query, tree? (Runtime|Editor|Developer|Plugins|all - default Runtime), subdirectory?, maxResults? (default 500)\n- search_tools: Search every ue-mcp tool + action by keyword or task INTENT (a synonym layer maps 'screenshot'->capture_scene_png, 'tile a texture'->the texture-bomb flow, etc.) and return ranked matches (tool, action, description, score). The first step before editor(execute_python); most tasks already have a dedicated action. Params: query (space-separated keywords/intent), limit? (default 20) (#704)\n- execute_python_report: Measurement for #704: reads this session's execute_python calls and, for each, runs its taskSummary back through search_tools to flag calls that OVERLAPPED an existing dedicated action ('you used Python for X, but tool Y does X'). Returns totalCalls, overlapping[] and an overlapRate. Params: none (#704)\n- list_files: List files on disk under a directory, optionally filtered by extension(s). Runs in the MCP server process (no editor round-trip). Params: directory (absolute, or relative to the project dir), extensions? (e.g. ['png','exr'] or 'png'), recursive? (default false), maxResults? (default 1000) (#608)\n- set_config: Write to INI. Params: configName, section, key, value\n- build: Build C++ project. Params: configuration?, platform?, clean?\n- generate_project_files: Generate IDE project files (Visual Studio, Xcode, etc.)\n- create_cpp_class: Create a new native UCLASS in a project module. Uses the same engine template path as File → New C++ Class. Writes .h + .cpp; returns both paths plus needsEditorRestart (true unless Live Coding successfully hot-reloaded). Params: className (no prefix), parentClass? (default UObject; accepts short names like 'Actor' or /Script/<Module>.<Class> paths), moduleName? (default: first project module, use list_project_modules to pick), classDomain? ('public'|'private'|'classes', default public), subPath?\n- list_project_modules: List native modules in the current project (name, host type, source path). Feed moduleName from here into create_cpp_class.\n- list_loaded_modules: Enumerate ALL engine+project modules with runtime load state (loaded/gameModule), not just uproject-declared ones. Params: filter? (case-insensitive substring), loadedOnly? (default false) (#689)\n- is_module_loaded: Report whether a named module is currently loaded in the editor. Params: moduleName (#689)\n- live_coding_compile: Trigger a Live Coding compile (Windows only). Hot-patches method bodies of existing UCLASSes without editor restart - the fast inner loop for UFUNCTION implementations. Does NOT reliably register brand-new UCLASSes; use build_project + editor restart for those. Params: wait? (default false - fire and return 'in_progress').\n- live_coding_status: Report Live Coding availability/state (available, started, enabledForSession, compiling). Helps choose between live_coding_compile and build_project.\n- write_cpp_file: Write a .h / .cpp / .inl file under the project's Source/ tree. Used to append UPROPERTYs/UFUNCTIONs or method bodies after create_cpp_class. Writes are scoped to Source/ for safety. Params: path (relative to Source/ or absolute within Source/), content (full file contents). After editing, call live_coding_compile (for existing classes) or build_project (for new classes).\n- read_cpp_source: Read a .cpp file from the project Source/ tree. Companion to read_cpp_header for round-trip edits. Params: sourcePath (relative to Source/ or absolute).\n- write_source_file: Write a .h/.cpp/.inl into a named module's Public/Private folder (resolves the module dir for you, including plugin modules under Plugins/*/Source/ that write_cpp_file refuses). After a new file, build_project + restart; after a body edit, live_coding_compile. Params: module (module name, default the project's primary module), visibility (Public|Private, default Private), fileName, content.\n- read_source_file: Read a .h/.cpp/.inl from a named module's folder (companion to write_source_file; resolves plugin modules too). With no visibility it tries Public then Private then the module root. Params: module, visibility?, fileName.\n- add_module_dependency: Add a module to a target module's Build.cs dependency array. Params: moduleName (the Build.cs to edit - must exist in the project), dependency (module name to add, e.g. 'UMG'), access? ('public'|'private', default 'private'). Creates the corresponding AddRange block if missing. Rebuild required afterward.\n- add_cpp_member: Append a UPROPERTY/UFUNCTION declaration to an existing UCLASS header inside the access specifier you choose. Idempotent: if a declaration containing the same memberName is already present, returns existed:true. Params: headerPath (relative to Source/ or absolute), declaration (full multi-line UPROPERTY(...) / UFUNCTION(...) block plus its single-line member or function signature), memberName (the identifier the declaration introduces - used for idempotency), access? ('public'|'protected'|'private', default 'public').\n\nEpic 5.8 toolset actions (15): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "access": {
+            "description": "For add_module_dependency: 'public' (PublicDependencyModuleNames) or 'private' (default).",
+            "enum": [
+              "public",
+              "private"
+            ],
+            "type": "string"
+          },
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "get_status",
+              "set_project",
+              "list_editors",
+              "use_editor",
+              "add_editor",
+              "drop_editor",
+              "get_info",
+              "read_config",
+              "search_config",
+              "list_config_tags",
+              "read_cpp_header",
+              "read_module",
+              "list_modules",
+              "search_cpp",
+              "read_engine_header",
+              "find_engine_symbol",
+              "list_engine_modules",
+              "search_engine_cpp",
+              "search_tools",
+              "execute_python_report",
+              "list_files",
+              "set_config",
+              "build",
+              "generate_project_files",
+              "create_cpp_class",
+              "list_project_modules",
+              "list_loaded_modules",
+              "is_module_loaded",
+              "live_coding_compile",
+              "live_coding_status",
+              "write_cpp_file",
+              "read_cpp_source",
+              "write_source_file",
+              "read_source_file",
+              "add_module_dependency",
+              "add_cpp_member",
+              "epic_stop_tests",
+              "epic_run_tests_by_filter",
+              "epic_run_tests",
+              "epic_list_tests",
+              "epic_get_test_status",
+              "epic_get_test_results",
+              "epic_discover_tests",
+              "epic_set_section_properties",
+              "epic_save_section",
+              "epic_reset_section_to_defaults",
+              "epic_list_sections",
+              "epic_list_containers",
+              "epic_list_categories",
+              "epic_get_section_schema",
+              "epic_get_section_property_values"
+            ],
+            "type": "string"
+          },
+          "classDomain": {
+            "description": "For create_cpp_class: which folder under the module (Public/Private/Classes). Default 'public'.",
+            "enum": [
+              "public",
+              "private",
+              "classes"
+            ],
+            "type": "string"
+          },
+          "className": {
+            "description": "For create_cpp_class: new class name (no A/U prefix - handled by parent type)",
+            "type": "string"
+          },
+          "clean": {
+            "description": "Clean build",
+            "type": "boolean"
+          },
+          "configName": {
+            "description": "For read_config/set_config: config file name",
+            "type": "string"
+          },
+          "configuration": {
+            "description": "Build configuration: Development, Debug, Shipping",
+            "type": "string"
+          },
+          "content": {
+            "description": "For write_cpp_file: full file contents.",
+            "type": "string"
+          },
+          "declaration": {
+            "description": "For add_cpp_member: full UPROPERTY(...) / UFUNCTION(...) block plus the member or function signature.",
+            "type": "string"
+          },
+          "dependency": {
+            "description": "For add_module_dependency: module name to add (e.g. 'UMG').",
+            "type": "string"
+          },
+          "directory": {
+            "description": "For search_cpp: subdirectory",
+            "type": "string"
+          },
+          "editorName": {
+            "description": "For add_editor: name to address the new session by (default the project name) (#817)",
+            "type": "string"
+          },
+          "editorTarget": {
+            "description": "For use_editor / drop_editor: session name, project name, or .uproject path (#817)",
+            "type": "string"
+          },
+          "extensions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "For list_files: extension filter (#608)"
+          },
+          "fileName": {
+            "description": "For write_source_file/read_source_file: file name e.g. MyComponent.h.",
+            "type": "string"
+          },
+          "filter": {
+            "description": "For list_loaded_modules: case-insensitive name substring (#689)",
+            "type": "string"
+          },
+          "headerPath": {
+            "description": "For read_cpp_header: path to .h file",
+            "type": "string"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "key": {
+            "description": "For set_config: INI key",
+            "type": "string"
+          },
+          "limit": {
+            "description": "For search_tools: max results (default 20) (#704)",
+            "type": "number"
+          },
+          "loadedOnly": {
+            "description": "For list_loaded_modules: only loaded modules (#689)",
+            "type": "boolean"
+          },
+          "maxResults": {
+            "description": "Cap on find_engine_symbol / search_engine_cpp hits (default 100 / 500)",
+            "type": "number"
+          },
+          "memberName": {
+            "description": "For add_cpp_member: the identifier the declaration introduces (used for idempotency).",
+            "type": "string"
+          },
+          "module": {
+            "description": "For write_source_file/read_source_file: module name (default project's primary module). Plugin modules are resolved too (#543).",
+            "type": "string"
+          },
+          "moduleName": {
+            "description": "For read_module / is_module_loaded: module name",
+            "type": "string"
+          },
+          "parentClass": {
+            "description": "For create_cpp_class: parent UClass. Short native names ('Actor') or /Script/<Module>.<Class> paths work. Default UObject.",
+            "type": "string"
+          },
+          "path": {
+            "description": "For write_cpp_file: path to write (relative to Source/ or absolute within Source/).",
+            "type": "string"
+          },
+          "platform": {
+            "description": "Target platform: Win64, Linux, Mac",
+            "type": "string"
+          },
+          "projectPath": {
+            "description": "For set_project / add_editor: path to .uproject",
+            "type": "string"
+          },
+          "query": {
+            "description": "For search_config/search_cpp: search text",
+            "type": "string"
+          },
+          "recursive": {
+            "description": "For list_files: recurse into subdirectories (#608)",
+            "type": "boolean"
+          },
+          "section": {
+            "description": "For set_config: INI section",
+            "type": "string"
+          },
+          "sourcePath": {
+            "description": "For read_cpp_source: path to .cpp (relative to Source/ or absolute).",
+            "type": "string"
+          },
+          "start": {
+            "description": "For add_editor: launch the editor for that project and wait until it is ready (#817)",
+            "type": "boolean"
+          },
+          "subPath": {
+            "description": "For create_cpp_class: nested folder under the class domain (e.g. 'Gameplay/Abilities').",
+            "type": "string"
+          },
+          "subdirectory": {
+            "description": "For search_engine_cpp: subdirectory within the chosen tree",
+            "type": "string"
+          },
+          "symbol": {
+            "description": "Symbol name for find_engine_symbol",
+            "type": "string"
+          },
+          "timeout": {
+            "description": "For add_editor with start: seconds to wait for readiness (default 300)",
+            "type": "number"
+          },
+          "tree": {
+            "description": "For search_engine_cpp: Runtime|Editor|Developer|Plugins|all (default Runtime)",
+            "type": "string"
+          },
+          "value": {
+            "description": "For set_config: INI value",
+            "type": "string"
+          },
+          "visibility": {
+            "description": "For write_source_file/read_source_file: Public or Private (default Private on write).",
+            "type": "string"
+          },
+          "wait": {
+            "description": "For live_coding_compile: block until compile finishes. Default false.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "project"
+    },
+    {
+      "description": "UE reflection: classes, structs, enums, gameplay tags, and SaveGame instances.\n\nActions:\n- reflect_class: Reflect UClass. className accepts the C++ spelling with or without the A/U/F/E prefix (UMyConfig and MyConfig both resolve), a /Script/Module.ClassName path, or a Blueprint class path; a failed lookup lists the spellings tried and the closest matches (#823). Params: className, includeInherited?\n- reflect_struct: Reflect UScriptStruct. Params: structName\n- reflect_enum: Reflect UEnum by full path, short name, or short name without the E prefix. Resolves native enums in any loaded module and loads unloaded Blueprint (UserDefinedEnum) assets via the asset registry. Returns enumPath, userDefined, and per-value name/value/displayName/tooltip; a failed lookup lists close matches (#762). Params: enumName\n- list_classes: List classes. parentFilter resolves with or without the C++ A/U/F/E prefix (#823). Params: parentFilter?, limit?\n- list_tags: List gameplay tags. Params: filter?\n- create_tag: Create gameplay tag. Params: tag, comment?\n- create_enum: Create UUserDefinedEnum asset, optionally seeded with entries. Params: name, packagePath?, entries?: (string|{name, displayName?})[], onConflict? (#274)\n- set_enum_entries: Replace entries on an existing UUserDefinedEnum. Params: assetPath, entries[] (#274)\n- is_class_loaded: Report whether a UClass is currently loaded in the editor (loaded), whether it exists/is loadable (exists), and its owning module + that module's load state. Distinguishes 'not loaded yet' from 'does not exist'. Params: className (short name, /Script/<Module>.<Class>, or BP class path) (#689)\n- is_module_loaded: Report whether a named module is currently loaded. Params: moduleName (#689)\n- list_loaded_modules: Enumerate modules with runtime load state. Params: filter? (case-insensitive substring), loadedOnly? (default false). Returns modules[{name, loaded, gameModule}] + totalLoaded/totalModules (#689)\n- inspect_save_game: Load a SaveGame slot read-only and return its reflected UPROPERTY(SaveGame) values. Non-serializable properties are listed in skippedProperties instead of failing the call. Params: slotName, userIndex? (default 0)\n\nEpic 5.8 toolset actions (6): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "reflect_class",
+              "reflect_struct",
+              "reflect_enum",
+              "list_classes",
+              "list_tags",
+              "create_tag",
+              "create_enum",
+              "set_enum_entries",
+              "is_class_loaded",
+              "is_module_loaded",
+              "list_loaded_modules",
+              "inspect_save_game",
+              "epic_reset_properties",
+              "epic_set_properties",
+              "epic_get_properties",
+              "epic_list_properties",
+              "epic_get_class",
+              "epic_search_subclasses"
+            ],
+            "type": "string"
+          },
+          "assetPath": {
+            "description": "Existing UserDefinedEnum path (set_enum_entries)",
+            "type": "string"
+          },
+          "className": {
+            "type": "string"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "entries": {
+            "description": "Enum entries - strings or {name, displayName?}",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "enumName": {
+            "type": "string"
+          },
+          "filter": {
+            "type": "string"
+          },
+          "includeInherited": {
+            "type": "boolean"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "loadedOnly": {
+            "description": "list_loaded_modules: only loaded modules (#689)",
+            "type": "boolean"
+          },
+          "moduleName": {
+            "description": "is_module_loaded: module name (#689)",
+            "type": "string"
+          },
+          "name": {
+            "description": "Enum asset name (create_enum)",
+            "type": "string"
+          },
+          "onConflict": {
+            "description": "Asset-creation conflict policy: skip (default) | error | overwrite",
+            "type": "string"
+          },
+          "packagePath": {
+            "description": "Package path (default /Game)",
+            "type": "string"
+          },
+          "parentFilter": {
+            "type": "string"
+          },
+          "slotName": {
+            "description": "inspect_save_game: logical save slot name without a path",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "structName": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "userIndex": {
+            "description": "inspect_save_game: platform user index (default 0)",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "reflection"
+    },
+    {
+      "description": "StateTree asset editing: read, modify states/tasks/conditions/transitions/bindings/evaluators/global tasks/colors/state parameters/root parameters, compile and validate.\n\nActions:\n- read: Full dump of a StateTree asset: state hierarchy (with description, tag, customTickRate, color), tasks, conditions, transitions, evaluators, global tasks, root params, bindings. Params: assetPath\n- list_states: List all states with IDs and paths. Params: assetPath\n- add_state: Add child state. Params: assetPath, stateId? (parent GUID, omit for root), name, stateType? (State|Group|LinkedAsset|Subtree), selectionBehavior?, insertIndex?\n- remove_state: Remove a state by ID. Params: assetPath, stateId\n- set_state_property: Set a property on a state. Params: assetPath, stateId, propertyName (name|type|selectionBehavior|bEnabled|weight|linkedAsset|description|tag|customTickRate|color), value. For tag: gameplay tag string or empty to clear. For customTickRate: number in seconds or empty to disable. For color: palette color display name, GUID, or empty to clear.\n- clear_state_nodes: Remove all tasks/conditions/transitions from a state. Params: assetPath, stateId\n- add_task: Add a task to a state. Params: assetPath, stateId, structType (C++ struct name e.g. FMyStateTreeTask or an engine-shipped task like FStateTreeRunParallelStateTreesTask), instanceProperties?\n- add_enter_condition: Add an enter condition to a state. Params: assetPath, stateId, structType (C++ struct name), instanceProperties?, operand? (And|Or)\n- remove_enter_condition: Remove an enter condition by index. Params: assetPath, stateId, conditionIndex\n- remove_task: Remove a task by index. Params: assetPath, stateId, taskIndex\n- set_task_instance_property: Set a property on a task's instance data. Params: assetPath, stateId, taskIndex, propertyName, value\n- set_task_property: Set a property on the task's node struct (FStateTreeTaskBase-level: bConsideredForCompletion, bTaskEnabled, bShouldStateChangeOnReselect). Distinct from set_task_instance_property which targets instance data. Params: assetPath, stateId, taskIndex, propertyName, value (string-encoded e.g. 'true'/'false')\n- add_transition: Add a transition to a state. Params: assetPath, stateId, trigger (OnStateCompleted|OnStateSucceeded|OnStateFailed|OnTick|OnEvent; combine with | e.g. OnStateSucceeded|OnStateFailed), transitionType (GotoState|NextState|Succeeded|Failed), eventTag?, targetStateId?, targetStatePath?, priority? (Low|Normal|Medium|High|Critical), delayDuration?, bDelayTransition?\n- add_transition_condition: Add a condition to an existing transition. Params: assetPath, stateId, transitionIndex, structType, instanceProperties?, operand?\n- remove_transition: Remove a transition by index. Params: assetPath, stateId, transitionIndex\n- add_binding: Add a property binding. Params: assetPath, sourceStructId, sourcePath, targetStructId, targetPath\n- remove_binding: Remove a property binding. Params: assetPath, targetStructId, targetPath\n- list_bindings: List all property bindings. Params: assetPath, structId? (filter)\n- list_bindable_sources: Enumerate the context/bindable sources in a StateTree (context objects, parameters, evaluators, global tasks, per-state nodes) with their structId + struct type - what a property can bind FROM. Params: assetPath (#681)\n- add_evaluator: Add an evaluator to the StateTree (tree-level). Params: assetPath, structType (must derive from FStateTreeEvaluatorBase), instanceProperties?\n- remove_evaluator: Remove an evaluator by node ID. Params: assetPath, nodeId\n- set_evaluator_instance_property: Set a property on an evaluator's instance data. Params: assetPath, nodeId, propertyName, value\n- set_evaluator_property: Set a property on the evaluator's node struct (FStateTreeEvaluatorBase-level). Params: assetPath, nodeId, propertyName, value\n- add_global_task: Add a global task to the StateTree (tree-level). Params: assetPath, structType (must derive from FStateTreeTaskBase), instanceProperties?\n- remove_global_task: Remove a global task by node ID. Params: assetPath, nodeId\n- set_global_task_instance_property: Set a property on a global task's instance data. Params: assetPath, nodeId, propertyName, value\n- set_global_task_property: Set a property on a global task's node struct (FStateTreeTaskBase-level). Params: assetPath, nodeId, propertyName, value\n- list_colors: List all color palette entries for a StateTree. Params: assetPath. Returns: colors[] with id, displayName, color.\n- add_color: Add a new color to the StateTree palette. Params: assetPath, displayName, color? (FLinearColor string e.g. '(R=1.0,G=0.0,B=0.0,A=1.0)')\n- list_state_parameters: List parameters defined on a state. Params: assetPath, stateId. Returns: parameters[] with name, id, type, value; also bFixedLayout.\n- add_state_parameter: Add a parameter to a state's property bag. Rejects fixed-layout (linked) states. Params: assetPath, stateId, paramName, paramType (Bool|Int32|Int64|Float|Double|Name|String|Text)\n- remove_state_parameter: Remove a parameter from a state's property bag by name. Rejects fixed-layout (linked) states. Params: assetPath, stateId, paramName\n- set_state_parameter: Set the value of an existing state parameter. On fixed-layout states, also marks the parameter as overridden. Params: assetPath, stateId, paramName, value\n- set_root_parameters: Define root parameters (property bag). Params: assetPath, parameters[] ({name, type}) where type is float|int32|bool|string|name|double\n- compile: Compile a StateTree asset. Returns success, errors[], warnings[]. Params: assetPath\n- validate: Validate a StateTree asset without compiling. Params: assetPath\n\nEpic 5.8 toolset actions (9): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "read",
+              "list_states",
+              "add_state",
+              "remove_state",
+              "set_state_property",
+              "clear_state_nodes",
+              "add_task",
+              "add_enter_condition",
+              "remove_enter_condition",
+              "remove_task",
+              "set_task_instance_property",
+              "set_task_property",
+              "add_transition",
+              "add_transition_condition",
+              "remove_transition",
+              "add_binding",
+              "remove_binding",
+              "list_bindings",
+              "list_bindable_sources",
+              "add_evaluator",
+              "remove_evaluator",
+              "set_evaluator_instance_property",
+              "set_evaluator_property",
+              "add_global_task",
+              "remove_global_task",
+              "set_global_task_instance_property",
+              "set_global_task_property",
+              "list_colors",
+              "add_color",
+              "list_state_parameters",
+              "add_state_parameter",
+              "remove_state_parameter",
+              "set_state_parameter",
+              "set_root_parameters",
+              "compile",
+              "validate",
+              "epic_get_node_description",
+              "epic_get_evaluators",
+              "epic_get_global_tasks",
+              "epic_get_transitions",
+              "epic_get_enter_conditions",
+              "epic_get_tasks",
+              "epic_get_children",
+              "epic_get_root_states",
+              "epic_get_editor_data"
+            ],
+            "type": "string"
+          },
+          "assetPath": {
+            "description": "StateTree asset path, e.g. /Game/Path/To/ST_Asset",
+            "type": "string"
+          },
+          "bDelayTransition": {
+            "description": "Enable transition delay",
+            "type": "boolean"
+          },
+          "color": {
+            "description": "FLinearColor string e.g. '(R=1.0,G=0.0,B=0.0,A=1.0)' for add_color",
+            "type": "string"
+          },
+          "conditionIndex": {
+            "description": "Enter condition index for remove_enter_condition",
+            "type": "number"
+          },
+          "delayDuration": {
+            "description": "Transition delay in seconds",
+            "type": "number"
+          },
+          "displayName": {
+            "description": "Display name for a new color palette entry",
+            "type": "string"
+          },
+          "eventTag": {
+            "description": "Gameplay tag for OnEvent transitions, e.g. MyGame.SomeEvent",
+            "type": "string"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "insertIndex": {
+            "description": "Insert position for add_state",
+            "type": "number"
+          },
+          "instanceProperties": {
+            "additionalProperties": {},
+            "description": "Key-value map of instance data properties to set on new tasks/conditions/evaluators/global tasks",
+            "type": "object"
+          },
+          "linkedSubtree": {
+            "description": "Asset path for LinkedAsset/Subtree states",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name for a new state",
+            "type": "string"
+          },
+          "nodeId": {
+            "description": "GUID of an evaluator or global task node (for remove/set_*_property operations)",
+            "type": "string"
+          },
+          "operand": {
+            "description": "Expression operand for conditions: And or Or",
+            "type": "string"
+          },
+          "paramName": {
+            "description": "Parameter name for state parameter operations",
+            "type": "string"
+          },
+          "paramType": {
+            "description": "Parameter type for add_state_parameter: Bool, Int32, Int64, Float, Double, Name, String, Text",
+            "type": "string"
+          },
+          "parameters": {
+            "description": "Root parameter definitions: [{name, type}] where type is float, int32, bool, string, name, double",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "type"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "priority": {
+            "description": "Transition priority: Low, Normal, Medium, High, Critical",
+            "type": "string"
+          },
+          "propertyName": {
+            "description": "Property name for set_state_property / set_task_instance_property / set_evaluator_instance_property / set_global_task_instance_property",
+            "type": "string"
+          },
+          "selectionBehavior": {
+            "description": "Selection behavior: TryEnterState, TrySelectChildrenInOrder, TrySelectChildrenAtRandom, etc.",
+            "type": "string"
+          },
+          "sourcePath": {
+            "description": "Source property path for bindings",
+            "type": "string"
+          },
+          "sourceStructId": {
+            "description": "Source struct GUID for bindings",
+            "type": "string"
+          },
+          "stateId": {
+            "description": "GUID of the target state (or parent state for add_state)",
+            "type": "string"
+          },
+          "statePath": {
+            "description": "Dot-path to state as alternative to stateId",
+            "type": "string"
+          },
+          "stateType": {
+            "description": "State type: State, Group, LinkedAsset, Subtree",
+            "type": "string"
+          },
+          "structId": {
+            "description": "Filter bindings by struct GUID",
+            "type": "string"
+          },
+          "structType": {
+            "description": "C++ struct name for tasks/conditions/evaluators, e.g. FMyStateTreeTask",
+            "type": "string"
+          },
+          "targetPath": {
+            "description": "Target property path for bindings",
+            "type": "string"
+          },
+          "targetStateId": {
+            "description": "Target state GUID for GotoState transitions",
+            "type": "string"
+          },
+          "targetStatePath": {
+            "description": "Target state dot-path for GotoState transitions",
+            "type": "string"
+          },
+          "targetStructId": {
+            "description": "Target struct GUID for bindings",
+            "type": "string"
+          },
+          "taskIndex": {
+            "description": "Task index within the state for remove/set operations",
+            "type": "number"
+          },
+          "transitionIndex": {
+            "description": "Transition index for remove/condition operations",
+            "type": "number"
+          },
+          "transitionType": {
+            "description": "Transition type: GotoState, NextState, Succeeded, Failed, NextSelectableState",
+            "type": "string"
+          },
+          "trigger": {
+            "description": "Transition trigger: OnStateCompleted, OnStateSucceeded, OnStateFailed, OnTick, OnEvent",
+            "type": "string"
+          },
+          "value": {
+            "description": "Property value to set (as string)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "action",
+          "assetPath"
+        ],
+        "type": "object"
+      },
+      "name": "statetree"
+    },
+    {
+      "description": "UMG Widget Blueprints, Editor Utility Widgets, and Editor Utility Blueprints. One parameter contract across every action (#798): the asset is always `assetPath`, an Unreal package path such as `/Game/UI/WBP_Example`; a widget inside the tree is always `widgetName`; its parent panel is always `parentWidgetName`; arguments for the `epic_*` actions always go in `input`, and a top-level `assetPath` is folded into the asset reference of the wrapped tool for you. A `.uasset` suffix, an object suffix (`.WBP_Example`), backslashes, and the legacy `path` / `widgetBlueprintPath` / `widgetBlueprint` spellings are accepted and normalized. Create actions take `assetPath` too; `name` plus `packagePath` remains valid and is composed into it. See [Widget parameter contract](widget-parameters.md).\n\nActions:\n- read_tree: Read widget hierarchy. Params: assetPath\n- get_details: Inspect widget (curated subset). Params: assetPath, widgetName\n- get_properties: Full reflected property dump for a widget - every UPROPERTY (RenderOpacity, Visibility, ColorAndOpacity, Border padding/colors, Image brush TintColor/ImageSize, fonts, etc.) plus the slot block, for diagnosing visual bugs get_details omits. Pass includeSubtree to also dump children (#547). Params: assetPath, widgetName, includeSubtree?\n- list_bindings: List designer property bindings on a WidgetBlueprint (the UE 5.7 Python API keeps them protected). Returns {widgetName, propertyName, functionName, bindingType}. Optional filterWidgetName/filterProperty (#530). Params: assetPath, filterWidgetName?, filterProperty?\n- clear_binding: Remove designer binding(s) matching widgetName (and optional propertyName) from a WidgetBlueprint without opening the editor. Idempotent (#530). Params: assetPath, widgetName, propertyName?\n- set_property: Set widget property. Slot struct props take UE struct text that persists every field - `Slot.Size`=`(Value=1.0,SizeRule=Fill)`, `Slot.Padding`=`(Left=8,Top=8,Right=8,Bottom=8)` - or a nested field path like `Slot.Size.Value` / `Slot.Padding.Left`; an invalid value errors instead of silently writing 0 (#532). Params: assetPath, widgetName, propertyName, value\n- set_style: Set a full/nested style struct on a widget from JSON (FButtonStyle, FEditableTextBoxStyle, FSlateFontInfo, FSlateColor and their nested brushes) - what set_property's scalar path can't express. value is a JSON object mirroring the struct. Params: assetPath, widgetName, propertyName (e.g. WidgetStyle), value (#563)\n- reorder_child: Reorder a widget among its parent panel's children (move to a sibling index) - e.g. insert a new row BETWEEN two existing children. move_widget only reparents. Params: assetPath, widgetName, index (#635)\n- bulk_set_properties: Apply many {widgetName, propertyName, value} style/property writes to a WidgetBlueprint in one call (single compile+save) - font/color/style stylesheet across many widgets. Params: assetPath, properties[] (#563)\n- list: List Widget BPs. Params: directory?, recursive?\n- read_animations: Read UMG animations. Params: assetPath\n- create: Create Widget BP. assetPath is the full destination, e.g. /Game/UI/WBP_Example; name + packagePath is the older spelling of the same thing and is composed into it. Params: assetPath, name?, packagePath?, parentClass?\n- create_utility_widget: Create editor utility widget. Params: assetPath, name?, packagePath?\n- run_utility_widget: Open editor utility widget. Params: assetPath\n- create_utility_blueprint: Create editor utility blueprint. Params: assetPath, name?, packagePath?\n- run_utility_blueprint: Run editor utility blueprint. Params: assetPath\n- add_widget: Add widget to widget tree. Idempotent by assetPath + widgetName: passing widgetName makes a retry safe, and the result carries requestedWidgetName/persistedWidgetName/renamed plus compileStatus. Params: assetPath, widgetClass, widgetName?, parentWidgetName?\n- remove_widget: Remove widget from tree. Idempotent, and clears the widget's Widget Blueprint GUID metadata so later compiles stop reporting a deleted variable (#799). Params: assetPath, widgetName\n- move_widget: Reparent widget. Params: assetPath, widgetName, newParentWidgetName\n- set_root: Replace WBP root with an existing widget by name (#365). Params: assetPath, widgetName\n- wrap_root: Wrap the current root in a new panel widget (UMG 'Wrap With'). Params: assetPath, wrapperClass (must be a UPanelWidget subclass), wrapperName? (#365)\n- list_classes: List available widget classes\n- extract_subtree: Lift an authored designer subtree out of one WidgetBlueprint into a standalone one, using UMG's own clipboard serializer so hierarchy, child order, editable properties, panel slot data and named-slot content survive. The selected widget becomes the destination root. dryRun defaults to true and only returns the name mapping - pass dryRun=false to actually write the asset. The destination must be absent or empty; an exact-shape replay returns existed. The source is never compiled or saved. Params: sourceAssetPath, sourceWidgetName, destinationAssetPath, destinationParentClass?, destinationRootName?, dryRun?\n- list_runtime: (#160) List live UUserWidget instances in the PIE world. Params: classFilter?, namePrefix?, viewportOnly?\n- get_runtime: (#160) Inspect a live PIE widget tree with text/visibility/brush/percent plus style values: renderOpacity (all), colorAndOpacity (TextBlock/Image), Border brushColor/contentColorAndOpacity (#592). includeLayout adds read-only layout diagnostics to every node - geometry (desired/local/absolute size, layout and render bounds), render transform, effective opacity, reflected slot properties including structured Canvas anchors/offsets/alignment, derived clipping, parent and viewport overlap, and a diagnostics array - plus the host UserWidget node under `host`, a `layoutCapture` summary, and per-node `deltaSincePreviousCapture` against the previous includeLayout call on that instance, so capture / reproduce / capture again isolates position-dependent sizing. Off by default: it is a much larger payload. Params: widgetName? | className?, childName?, maxDepth?, includeLayout?\n- inspect_runtime_instances: Inspect every matching live widget instance (never an implicit first match), with stable identity/owning-player metadata and selected reflected properties on the widget or subtree. Requires a running PIE/Game world and errors instead of falling back to the editor world. Passing childName or childClassFilter implies includeSubtree. Provide widgetName or classFilter. Params: widgetName?, classFilter?, propertyNames[]?, includeSubtree?, childName?, childClassFilter?, viewportOnly?, world?, pieInstance?, maxInstances?, maxNodesPerInstance?\n- get_runtime_delegates: (#161) Read delegate binding state on a live PIE widget. Params: widgetName, className?. Returns array of {delegateName, isBound, numBindings}\n- add_to_viewport: (#602) Instantiate a WidgetBlueprint and add it to the live PIE viewport for visual verification. Requires PIE running. Params: assetPath (WidgetBlueprint path), zOrder?\n- invoke_runtime_function: (#559/#812) Fire a UI interaction on a live PIE widget: a parameterless UFUNCTION (functionName) on the located UserWidget, OR drive an interactive child via childName - Button (click), CheckBox (value true/false/toggle), Slider and SpinBox (numeric value), EditableText/EditableTextBox/MultiLineEditableText/MultiLineEditableTextBox (string value), ComboBoxString (option string or index). The matching delegate is broadcast so bound Blueprint logic runs. functionName alongside childName picks the delegate (e.g. OnPressed, OnTextChanged). Locate the widget with widgetName or className. Params: widgetName?|className?, functionName?, childName?, value?, commitMethod?\n\nEpic 5.8 toolset actions (37): the epic_* actions above wrap Unreal's native ToolsetRegistry tools for this domain. Pass tool arguments via 'input'. A top-level parameter named by the wrapped tool's own schema is folded into 'input' for you, as is this category's canonical asset path when the tool takes a single asset reference. A call that is still missing a required argument is refused with the exact shape to send, instead of being dispatched (#798).",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "read_tree",
+              "get_details",
+              "get_properties",
+              "list_bindings",
+              "clear_binding",
+              "set_property",
+              "set_style",
+              "reorder_child",
+              "bulk_set_properties",
+              "list",
+              "read_animations",
+              "create",
+              "create_utility_widget",
+              "run_utility_widget",
+              "create_utility_blueprint",
+              "run_utility_blueprint",
+              "add_widget",
+              "remove_widget",
+              "move_widget",
+              "set_root",
+              "wrap_root",
+              "list_classes",
+              "extract_subtree",
+              "list_runtime",
+              "get_runtime",
+              "inspect_runtime_instances",
+              "get_runtime_delegates",
+              "add_to_viewport",
+              "invoke_runtime_function",
+              "epic_windows",
+              "epic_wait_for",
+              "epic_unobserve",
+              "epic_type",
+              "epic_snapshot",
+              "epic_select_option",
+              "epic_screenshot",
+              "epic_press_key",
+              "epic_observe",
+              "epic_list_observers",
+              "epic_hover",
+              "epic_fill_form",
+              "epic_drag",
+              "epic_click",
+              "epic_wrap_widgets",
+              "epic_toggle_widget_as_variable",
+              "epic_set_named_slot_content",
+              "epic_replace_widget_with_template",
+              "epic_replace_widget_with_named_slot",
+              "epic_replace_widget_with_child",
+              "epic_rename_widget",
+              "epic_remove_widget",
+              "epic_remove_uicomponent",
+              "epic_move_widget",
+              "epic_move_uicomponent",
+              "epic_list_widget_classes",
+              "epic_list_widget_blueprints",
+              "epic_get_widget_tree_depth",
+              "epic_get_widgets",
+              "epic_get_widget_description",
+              "epic_get_widget_class_info",
+              "epic_get_named_slots",
+              "epic_create_widget_blueprint",
+              "epic_compile_widget_blueprint",
+              "epic_bind_to_event_property",
+              "epic_add_widget",
+              "epic_add_uicomponent"
+            ],
+            "type": "string"
+          },
+          "assetPath": {
+            "description": "Canonical Widget Blueprint / Editor Utility asset path, e.g. /Game/UI/WBP_Example (#798)",
+            "type": "string"
+          },
+          "childClassFilter": {
+            "description": "inspect_runtime_instances: class substring filter for subtree nodes (implies includeSubtree)",
+            "type": "string"
+          },
+          "childName": {
+            "description": "get_runtime/invoke_runtime_function/inspect_runtime_instances: named child inside the UserWidget (#559)",
+            "type": "string"
+          },
+          "classFilter": {
+            "description": "Class name substring filter for runtime widget queries",
+            "type": "string"
+          },
+          "className": {
+            "description": "Widget class name for get_runtime (first match wins)",
+            "type": "string"
+          },
+          "commitMethod": {
+            "description": "invoke_runtime_function: text/spin box commit type - OnEnter (default), OnUserMovedFocus, OnCleared, Default (#812)",
+            "type": "string"
+          },
+          "destinationAssetPath": {
+            "description": "extract_subtree: destination package path, including the new asset name",
+            "type": "string"
+          },
+          "destinationParentClass": {
+            "description": "extract_subtree: UUserWidget subclass for the destination (default UserWidget)",
+            "type": "string"
+          },
+          "destinationRootName": {
+            "description": "extract_subtree: name override for the extracted root; descendants keep their names",
+            "type": "string"
+          },
+          "directory": {
+            "type": "string"
+          },
+          "dryRun": {
+            "description": "extract_subtree: plan only, no asset is created or saved (default true)",
+            "type": "boolean"
+          },
+          "filterProperty": {
+            "description": "list_bindings: only bindings of this property (#530)",
+            "type": "string"
+          },
+          "filterWidgetName": {
+            "description": "list_bindings: only bindings on this widget (#530)",
+            "type": "string"
+          },
+          "functionName": {
+            "description": "invoke_runtime_function: parameterless UFUNCTION to call on the live widget (#559), or with childName the child delegate to fire (#812)",
+            "type": "string"
+          },
+          "includeLayout": {
+            "description": "get_runtime: add read-only layout diagnostics (geometry, slot, clipping, viewport, per-node deltas) to every node and report the host UserWidget under `host` (#775)",
+            "type": "boolean"
+          },
+          "includeSubtree": {
+            "description": "get_properties/inspect_runtime_instances: also dump descendant widgets (#547)",
+            "type": "boolean"
+          },
+          "index": {
+            "description": "reorder_child: target sibling index within the parent panel (#635)",
+            "type": "number"
+          },
+          "input": {
+            "additionalProperties": {},
+            "description": "Epic tool arguments as a JSON object (for epic_* actions)",
+            "type": "object"
+          },
+          "inputJson": {
+            "description": "Epic tool arguments as a raw JSON string (alternative to input)",
+            "type": "string"
+          },
+          "maxDepth": {
+            "description": "get_runtime: max widget-tree depth to walk (default 6)",
+            "type": "number"
+          },
+          "maxInstances": {
+            "description": "inspect_runtime_instances: maximum matching widget instances returned",
+            "maximum": 500,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "maxNodesPerInstance": {
+            "description": "inspect_runtime_instances: maximum root/subtree nodes per instance",
+            "maximum": 2000,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "name": {
+            "description": "create actions: bare asset name, used with packagePath. assetPath is the canonical alternative (#798)",
+            "type": "string"
+          },
+          "namePrefix": {
+            "description": "Instance name prefix filter for list_runtime",
+            "type": "string"
+          },
+          "newParentWidgetName": {
+            "type": "string"
+          },
+          "packagePath": {
+            "description": "create actions: destination folder, used with name (#798)",
+            "type": "string"
+          },
+          "parentClass": {
+            "type": "string"
+          },
+          "parentWidget": {
+            "description": "Alias for parentWidgetName. Use parentWidgetName (#798)",
+            "type": "string"
+          },
+          "parentWidgetName": {
+            "description": "Canonical name of the parent panel widget (#798)",
+            "type": "string"
+          },
+          "path": {
+            "description": "Legacy alias for assetPath. Use assetPath (#798)",
+            "type": "string"
+          },
+          "pieInstance": {
+            "description": "inspect_runtime_instances: PIE instance id for multi-client sessions",
+            "type": "integer"
+          },
+          "properties": {
+            "description": "bulk_set_properties: [{widgetName, propertyName, value}] (#563)",
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "propertyName": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "description": "inspect_runtime_instances: exact reflected property names to serialize",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "recursive": {
+            "type": "boolean"
+          },
+          "sourceAssetPath": {
+            "description": "extract_subtree: WidgetBlueprint the subtree is read from",
+            "type": "string"
+          },
+          "sourceWidgetName": {
+            "description": "extract_subtree: widget in the source that becomes the extracted root",
+            "type": "string"
+          },
+          "value": {},
+          "viewportOnly": {
+            "description": "list_runtime/inspect_runtime_instances: only return widgets currently added to the viewport",
+            "type": "boolean"
+          },
+          "widgetBlueprint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": {},
+                "type": "object"
+              }
+            ],
+            "description": "Alias for assetPath, also accepted as the engine's {refPath} object reference. Use assetPath (#798)"
+          },
+          "widgetBlueprintPath": {
+            "description": "Alias for assetPath. Use assetPath (#798)",
+            "type": "string"
+          },
+          "widgetClass": {
+            "type": "string"
+          },
+          "widgetDisplayName": {
+            "description": "Alias for widgetName. Use widgetName (#798)",
+            "type": "string"
+          },
+          "widgetName": {
+            "description": "Canonical name of a widget inside the tree (#798)",
+            "type": "string"
+          },
+          "world": {
+            "description": "inspect_runtime_instances: runtime world scope (default pie). The editor world is never a valid target",
+            "enum": [
+              "pie",
+              "game",
+              "auto"
+            ],
+            "type": "string"
+          },
+          "wrapperClass": {
+            "description": "wrap_root: panel widget class (CanvasPanel, VerticalBox, Overlay, etc.)",
+            "type": "string"
+          },
+          "wrapperName": {
+            "description": "wrap_root: optional name for the new wrapper widget",
+            "type": "string"
+          },
+          "zOrder": {
+            "description": "add_to_viewport: viewport Z-order (#602)",
+            "type": "number"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "name": "widget"
+    }
+  ]
+}

--- a/tests/unit/golden-editor-down.test.ts
+++ b/tests/unit/golden-editor-down.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The editor-down golden baseline (#817, plan item 1.10).
+ *
+ * Plan item 1.10 asks for the single-editor surface recorded twice, once with
+ * an editor connected and once with it down, because Epic-toolset enrichment
+ * legitimately changes the surface between those two states and one baseline
+ * cannot tell a regression apart from a cold start. The connected half needs
+ * an Unreal install and cannot run on a CI runner. The editor-down half needs
+ * nothing but Node, so it is recorded here and it gates merges.
+ *
+ * What it guards: the `initialize` instructions and every tool in
+ * `tools/list` with its full input schema. That is the entire contract a
+ * client sees before it makes a single call, and it is the thing the
+ * multi-editor work is required to leave byte-identical at one editor (plan
+ * items 2.1, 3.1, 4.2, 5.1).
+ *
+ * To re-record on purpose:  npm run golden:record
+ */
+import * as os from "node:os";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  GOLDEN_EDITOR_DOWN,
+  GOLDEN_SCHEMA_VERSION,
+  captureEditorDownSurface,
+  readGoldenBaseline,
+  serializeGolden,
+  writeGoldenBaseline,
+  type GoldenRecording,
+} from "../golden/capture.js";
+
+/**
+ * Set by `npm run golden:record`. Rewrites the baseline instead of asserting
+ * against it, so an intentional surface change is a reviewable diff in the
+ * committed file rather than an edit nobody sees.
+ */
+const RECORDING = process.env.UE_MCP_RECORD_GOLDEN === "1";
+
+/** Recording spawns a real server process, so the budget is generous. */
+const CAPTURE_TIMEOUT_MS = 180_000;
+
+let recording: GoldenRecording;
+let serialized: string;
+
+beforeAll(async () => {
+  recording = await captureEditorDownSurface();
+  serialized = serializeGolden(recording.surface);
+  if (RECORDING) writeGoldenBaseline(serialized);
+}, CAPTURE_TIMEOUT_MS);
+
+describe("golden baseline: single editor, editor down", () => {
+  it("records a surface worth guarding", () => {
+    const captured = recording.surface;
+    expect(captured.scenario).toBe("editor-down");
+    expect(captured.schemaVersion).toBe(GOLDEN_SCHEMA_VERSION);
+    expect(captured.server.name).toBe("ue-mcp");
+    // A capture that lost the instructions or the tool list would still
+    // compare equal to a baseline recorded from the same broken capture.
+    expect(captured.instructions.length).toBeGreaterThan(500);
+    expect(captured.toolCount).toBeGreaterThan(10);
+    expect(captured.tools.every((t) => t.description.length > 0)).toBe(true);
+    expect(captured.tools.every((t) => t.inputSchema !== undefined)).toBe(true);
+  });
+
+  it("carries no directory from the recording machine", () => {
+    // Portability is the only reason this file can be verified anywhere but
+    // the machine that wrote it, so assert it rather than assume it. Both
+    // separator spellings, because JSON from Windows carries either.
+    const machinePaths = [recording.sandbox, recording.projectDir, recording.repoRoot, os.homedir()];
+    for (const dir of machinePaths) {
+      if (dir.length < 4) continue;
+      for (const spelling of [dir, dir.replace(/\\/g, "/")]) {
+        expect(serialized.toLowerCase()).not.toContain(spelling.toLowerCase());
+      }
+    }
+  });
+
+  it("is deterministic: two recordings in one run are byte-identical", async () => {
+    const second = serializeGolden((await captureEditorDownSurface()).surface);
+    expect(second).toBe(serialized);
+  }, CAPTURE_TIMEOUT_MS);
+
+  it("matches the committed baseline", () => {
+    const baseline = readGoldenBaseline();
+    if (baseline === null) {
+      throw new Error(
+        `No golden baseline at ${GOLDEN_EDITOR_DOWN}.\n` +
+          `Record one with:  npm run golden:record\n` +
+          `then review and commit the file.`,
+      );
+    }
+    if (baseline !== serialized) {
+      throw new Error(
+        "The editor-down surface changed.\n\n" +
+          "This test compares the `initialize` instructions and every `tools/list` input\n" +
+          "schema against the baseline committed at tests/golden/editor-down.json.\n\n" +
+          "If the change is intentional, re-record and commit the diff:\n\n" +
+          "    npm run golden:record\n\n" +
+          "and read the resulting diff before you commit it: it is the contract every\n" +
+          "client sees at startup. If the change is NOT intentional, something altered\n" +
+          "the advertised surface at one editor, which plan item 1.10 of #817 exists to\n" +
+          "catch.\n\n" +
+          firstDifference(baseline, serialized),
+      );
+    }
+    expect(serialized).toBe(baseline);
+  });
+});
+
+/** Point at the first differing line, so a large diff names its own cause. */
+function firstDifference(expected: string, actual: string): string {
+  const a = expected.split("\n");
+  const b = actual.split("\n");
+  const clip = (line: string | undefined) =>
+    line === undefined ? "<end of file>" : line.length > 200 ? `${line.slice(0, 200)}...` : line;
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    if (a[i] === b[i]) continue;
+    return `First difference at line ${i + 1}:\n  baseline: ${clip(a[i])}\n  recorded: ${clip(b[i])}`;
+  }
+  return `Files differ in length only: baseline ${a.length} lines, recorded ${b.length} lines.`;
+}


### PR DESCRIPTION
Plan item 1.10 of #817 asks for the single-editor surface recorded twice, once with an editor connected and once with it down. Enrichment picks a live editor, then the project cache, then the snapshot baked into the package, so the surface legitimately differs between those two states and one baseline cannot tell a regression from a cold start.

The editor-down half needs nothing but Node. It was previously run by hand and thrown away. This checks it in.

## What ships

- `tests/golden/editor-down.json` - the recorded surface: the `initialize` instructions plus every tool from `tools/list` with its full input schema. 27 tools, keys sorted, tools sorted by name.
- `tests/golden/capture.ts` - the recorder. Starts the shipped entry point over stdio and reads back what a client actually receives. Going through the real handshake rather than reassembling the surface in-process is the point: a baseline built from a copy of the construction code only proves the copy still agrees with itself.
- `tests/unit/golden-editor-down.test.ts` - the guard. Runs in `npm run test:unit`, so CI gates on it.
- `npm run golden:record` - the re-record path, which runs the same test with `UE_MCP_RECORD_GOLDEN=1` so it writes the file instead of asserting against it. One code path, deliberately.

## Why the committed file is portable

The recording is hermetic: a throwaway project in a fresh temp directory, `UE_MCP_PORT=1` (privileged on every platform we run on, so nothing can be listening and the connect is refused immediately), every inherited `UE_MCP_*` variable dropped, the global config / user state / auth directory redirected into the sandbox, and the update check off. Absolute paths are rewritten before serialization, and a test asserts none survived.

## Why the guard can actually fail

Three properties are asserted rather than assumed:

1. The capture is non-empty and well formed before it is compared. A capture that silently lost the tool list would otherwise match a baseline recorded from the same broken capture.
2. Two recordings in one run are byte-identical.
3. Perturbing the surface fails the test. Adding one throwaway action locally produced:

```
First difference at line 2:
  baseline:   "instructions": "... 24 category tools covering 783 actions ...
  recorded:   "instructions": "... 24 category tools covering 784 actions ...
```

reverted before commit.

## Not in scope

The editor-connected half of 1.10 still needs an Unreal install and stays out of this tier.

No `plugin/` changes, no version bump.