### PR TITLE
Run the em dash gate on every branch push, not only pull requests and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,43 +17,10 @@ concurrency:
 permissions:
   contents: read
 
+# The em dash gate used to be a job here. It moved to em-dash.yml so it can
+# run on every branch push without dragging this workflow's install, tests and
+# audit along with it. It is still not in `needs:` for publish.
 jobs:
-  em_dash:
-    # The style rule that bans U+2014 used to live only in CLAUDE.md, which
-    # made every commit a memory test. This job is the enforcement point: it
-    # runs on pull requests, where all work lands, and on main as a tripwire.
-    #
-    # Deliberately not in `needs:` for publish. A lint finding on main should
-    # be visible and fixed, not able to hold a release hostage mid-pipeline.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          # The commit message scan needs both ends of the pull request range.
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      # No install step: the checker uses only node builtins, on purpose, so
-      # this gate keeps working when the dependency tree is broken.
-      - name: Tracked files
-        run: node scripts/check-em-dashes.mjs
-
-      - name: Commit messages
-        if: github.event_name == 'pull_request'
-        env:
-          BASE: ${{ github.event.pull_request.base.sha }}
-          HEAD: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          if ! git cat-file -e "$BASE^{commit}" 2>/dev/null || ! git cat-file -e "$HEAD^{commit}" 2>/dev/null; then
-            echo "::warning::Base or head commit missing from this checkout; commit message scan skipped."
-            exit 0
-          fi
-          node scripts/check-em-dashes.mjs --commits "$BASE..$HEAD"
-
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/em-dash.yml
+++ b/.github/workflows/em-dash.yml
@@ -26,17 +26,28 @@ on:
     # here for pull requests from forks, whose pushes never reach this repo.
     branches: [main]
 
-# One run per head branch. Three pushes in a row fire three times, and without
-# this they all run to completion to report the same answer about a tree that
-# only the newest of them describes.
+# One run per head branch per event. Three pushes in a row fire three times,
+# and without this they all run to completion to report the same answer about
+# a tree that only the newest of them describes.
 #
-# The identity is the head branch plus the repository it lives in, so a fork
-# whose branch happens to share a name with one here does not cancel it.
+# The identity is the event, the head branch, and the repository the branch
+# lives in. All three parts earn their place:
+#
+#   - The event, because a run enters its concurrency group before any job's
+#     `if:` is evaluated. Grouping the two events together had the pull request
+#     run cancel the in-progress push run for the same commit and then skip
+#     itself, which left that commit with no scan at all. Measured, not
+#     theorised: run 31050424894 was cancelled by run 31050428238 doing exactly
+#     this. The two events no longer overlap by design, so they must not share
+#     a group either.
+#   - The branch, so an unrelated branch is never cancelled.
+#   - The repository, so a fork whose branch happens to share a name with one
+#     here does not cancel it.
 #
 # Main never cancels. Superseding a main run would drop the commit messages in
 # its range, and no later run's range covers them again.
 concurrency:
-  group: em-dash-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  group: em-dash-${{ github.event_name }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/em-dash.yml
+++ b/.github/workflows/em-dash.yml
@@ -1,0 +1,107 @@
+name: Em dash
+
+# The style rule that bans U+2014 used to live only in CLAUDE.md, which made
+# every commit a memory test. This workflow is the enforcement point.
+#
+# It runs on every branch push, not just on pull requests and main. The gate
+# shipped covering pull requests and main only, and the two commits that put
+# the character back into the tree during the very cleanup pass that removed it
+# were both feature-branch pushes. They were caught after landing on main
+# rather than at push time. A push trigger is the earliest moment CI can see
+# the work at all, so that is where the gate belongs.
+#
+# It lives in its own workflow rather than in ci.yml because ci.yml's push
+# trigger deliberately stays on main: widening it would run the install,
+# type-check, unit tier and audit on every branch push, a duplicate of the same
+# work the pull request run already does. This job installs nothing and needs
+# nothing, so running it everywhere is close to free.
+on:
+  push:
+    # Branches only. Listing `branches` at all excludes tag pushes, which
+    # matters because the publish job pushes a vX.Y.Z tag for every release and
+    # that tag points at a commit main already scanned.
+    branches: ["**"]
+  pull_request:
+    # Same-repo branches are already covered by the push trigger above. This is
+    # here for pull requests from forks, whose pushes never reach this repo.
+    branches: [main]
+
+# One run per head branch. A push to a branch that has an open pull request
+# fires both triggers, and three pushes in a row fire three times; without this
+# they would all run to completion and report the same answer.
+#
+# The identity is the head branch plus the repository it lives in, so a fork
+# whose branch happens to share a name with one here does not cancel it.
+#
+# Cancelling either of the two runs for a push is safe because they are
+# equivalent: both scan the whole tracked tree, and the commit message scan
+# below derives its range from whichever event it got. Main is the exception
+# and never cancels. Superseding a main run would drop the commit messages in
+# its range, which no later run's range covers again.
+concurrency:
+  group: em-dash-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  em_dash:
+    # Deliberately not in `needs:` for the publish job in ci.yml. A style
+    # finding on main should be visible and fixed, not able to hold a release
+    # hostage mid-pipeline.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The commit message scan needs both ends of the pushed or proposed
+          # range, and the new-branch fallback needs origin/main.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # No install step: the checker uses only node builtins, on purpose, so
+      # this gate keeps working when the dependency tree is broken.
+      - name: Tracked files
+        run: node scripts/check-em-dashes.mjs
+
+      - name: Commit messages
+        env:
+          EVENT: ${{ github.event_name }}
+          # Pull request: the range the pull request proposes.
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          # Push: the range the push moved the branch across. `before` is all
+          # zeros when the branch is new and can name a commit that no longer
+          # exists after a force push, so both cases fall back to the default
+          # branch below.
+          PUSH_BASE: ${{ github.event.before }}
+          PUSH_HEAD: ${{ github.sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          have() { git cat-file -e "$1^{commit}" 2>/dev/null; }
+
+          if [ "$EVENT" = "pull_request" ]; then
+            if ! have "$PR_BASE" || ! have "$PR_HEAD"; then
+              echo "::warning::Base or head commit missing from this checkout; commit message scan skipped."
+              exit 0
+            fi
+            RANGE="$PR_BASE..$PR_HEAD"
+          elif have "${PUSH_BASE:-none}"; then
+            RANGE="$PUSH_BASE..$PUSH_HEAD"
+          elif have "origin/$DEFAULT_BRANCH"; then
+            # New branch, or a force push whose previous tip is unreachable.
+            # Everything this branch carries that the default branch does not
+            # is this branch's work, so scan all of it.
+            RANGE="origin/$DEFAULT_BRANCH..$PUSH_HEAD"
+          else
+            echo "::warning::No usable commit range for this push; commit message scan skipped."
+            exit 0
+          fi
+
+          echo "Scanning commit messages in $RANGE"
+          node scripts/check-em-dashes.mjs --commits "$RANGE"

--- a/.github/workflows/em-dash.yml
+++ b/.github/workflows/em-dash.yml
@@ -26,18 +26,15 @@ on:
     # here for pull requests from forks, whose pushes never reach this repo.
     branches: [main]
 
-# One run per head branch. A push to a branch that has an open pull request
-# fires both triggers, and three pushes in a row fire three times; without this
-# they would all run to completion and report the same answer.
+# One run per head branch. Three pushes in a row fire three times, and without
+# this they all run to completion to report the same answer about a tree that
+# only the newest of them describes.
 #
 # The identity is the head branch plus the repository it lives in, so a fork
 # whose branch happens to share a name with one here does not cancel it.
 #
-# Cancelling either of the two runs for a push is safe because they are
-# equivalent: both scan the whole tracked tree, and the commit message scan
-# below derives its range from whichever event it got. Main is the exception
-# and never cancels. Superseding a main run would drop the commit messages in
-# its range, which no later run's range covers again.
+# Main never cancels. Superseding a main run would drop the commit messages in
+# its range, and no later run's range covers them again.
 concurrency:
   group: em-dash-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -47,6 +44,24 @@ permissions:
 
 jobs:
   em_dash:
+    # A same-repo pull request adds nothing the push trigger did not already
+    # do. Its head commit was pushed here, so it was scanned then, and the
+    # result shows up on the pull request regardless because a check run
+    # attaches to a commit rather than to an event. Skipping it means the pair
+    # never both run, which is a stronger guarantee than relying on one to
+    # cancel the other: cancellation only fires while a run is still in
+    # progress, so opening a pull request minutes after the push leaves two
+    # completed runs behind.
+    #
+    # A fork's head commit is the case the pull_request trigger exists for. It
+    # never lands in this repo, so nothing else can see it.
+    #
+    # Nothing is lost by not scanning the merge result. A textual merge cannot
+    # introduce a character that neither parent had, the branch tip is scanned
+    # here, and main is scanned on its own pushes.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     # Deliberately not in `needs:` for the publish job in ci.yml. A style
     # finding on main should be visible and fixed, not able to hold a release
     # hostage mid-pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ Each category has a paired `Private/Handlers/<Category>Handlers.{h,cpp}`. Handle
 ### Writing style - public artifacts
 
 - **No em dashes (`—`).** Use hyphens (` - `), colons, parentheses, or split into sentences. Applies to commit messages, release notes, docs, PR bodies, code comments. <!-- em-dash-allowed: the rule has to show the character it bans -->
+  CI enforces this in `.github/workflows/em-dash.yml`, which runs on **every branch push** as well as on pull requests, so a bad character is caught when you push rather than after it reaches main. It scans the whole tracked tree plus the commit messages in the pushed range. Run `npm run audit:em-dash` locally to get the same answer, and `npm run audit:em-dash -- --explain` for the exemption policy.
 - **Never name competitor or comparison projects in public artifacts.** Commit messages, release notes, PR bodies, GitHub release bodies, code comments, docs - any of these. Even when the work is literally closing a gap against another project, describe the work on its own terms ("adds module input authoring"), not as "catching up to X" or "matching Y". Gap-analysis context belongs in private discussion, never in public git history.
 
 ### MCP design principle


### PR DESCRIPTION
## Why

The em dash gate shipped in `6140fb9` covering pull requests and pushes to `main`. That leaves open the exact window it was written for. The two commits that put U+2014 back into the tree during the cleanup pass that removed 695 of them (`a0421ee`, `603084c`) were feature branch pushes, and both reached `main` before anything noticed. A push trigger is the earliest moment CI can see the work at all.

## What changed

The job moves out of `ci.yml` into `.github/workflows/em-dash.yml`, triggered on `push` to `"**"` and on `pull_request` into `main`.

- **Why a separate workflow.** Widening `ci.yml`'s push trigger would run its install, type-check, unit tier and audit on every branch push, a straight duplicate of what the pull request run already does. The gate installs nothing (node builtins only, on purpose), so running it everywhere is close to free.
- **Tag pushes excluded.** Listing `branches` at all drops tag pushes, which matters because the publish job pushes a `vX.Y.Z` tag whose commit `main` already scanned.
- **The commit message scan now runs on pushes too.** It was `if: github.event_name == 'pull_request'`. It now derives its range from whichever event it got: `github.event.before..github.sha` for a push, falling back to `origin/<default>..HEAD` for a new branch or a force push whose previous tip is unreachable.

## How the duplicate is avoided

A push to a branch with an open pull request fires both triggers. Two mechanisms, and the split between them is the part worth reviewing.

**Same-repo pull request runs are skipped outright** (`if:` on the job). Their head commit was pushed to this repo, so the push trigger already scanned it, and the result still shows on the pull request because a check run attaches to a commit rather than to an event. Fork pull requests still run, since a fork's head never lands here. Nothing is lost by not scanning the merge result: a textual merge cannot introduce a character neither parent had.

**The concurrency group is keyed by event, branch and repository**, cancelling superseded runs. The event is part of the key because a run joins its concurrency group *before* any job `if:` is evaluated. I had the two events sharing a group first, and it was actively harmful: push run `31050424894` was cancelled by pull request run `31050428238` for the same commit, which then skipped itself, leaving that commit with no scan at all. Third commit in this PR fixes that. `main` is excluded from cancellation, since superseding a `main` run would drop the commit messages in its range and no later range covers them again.

## The publish job

The gate stays out of `publish`'s `needs`, and I agree with the original call. `publish` only fires on `main`, by which point the finding is already in the tree, so blocking it prevents nothing. It only leaves npm and the draft GitHub release out of step with the repo, which is worse than a stray character. Widening the trigger to branch pushes is what makes that position defensible: the gate's job is to stop the character before `main`, and now it does.

## Verification

- The push of this branch triggered the new workflow on a feature branch and passed: run `31050536278`, with the same-repo pull request run `31050538826` correctly skipped. One scan per commit, no cancellation.
- A scratch branch with no pull request proved both halves fail. Run `31050661955` failed the tracked-file scan on `PROOF_SCRATCH.md`; run `31050754939` failed the commit message scan over range `2f1fb12..af7974d`. Branch deleted afterwards.
- `npx tsc --noEmit` clean, `npx vitest run tests/unit` 753 passed, `npm run audit:em-dash` clean.
