### PR TITLE
Compile on UE 5.7 again: gate the two 5.8-only APIs (#865)

### DIFF
--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/MaterialHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/MaterialHandlers.cpp
@@ -2360,6 +2360,21 @@ namespace
 		if (Hit(TEXT("geometrycollections")) || Hit(TEXT("geometry_collections"))) { OutUsage = MATUSAGE_GeometryCollections; return true; }
 		return false;
 	}
+
+	// UMaterial::SetMaterialUsage became a one-argument virtual in UE 5.8. The
+	// only form before that takes a bNeedsRecompile out param, and the 5.8
+	// build keeps it as a deprecated inline shim that forwards and ignores the
+	// param. Calling the one-argument form on 5.7 is a hard compile error
+	// (C2660), so pick the form the engine in hand actually declares.
+	static bool ApplyMaterialUsage(UMaterial* Material, EMaterialUsage Usage)
+	{
+#if UE_MCP_HAS_5_8_API
+		return Material->SetMaterialUsage(Usage);
+#else
+		bool bNeedsRecompile = false;
+		return Material->SetMaterialUsage(bNeedsRecompile, Usage);
+#endif
+	}
 }
 
 // #617 read/write a MaterialExpressionCustom's HLSL Code, named inputs, and
@@ -2500,7 +2515,7 @@ TSharedPtr<FJsonValue> FMaterialHandlers::SetMaterialUsage(const TSharedPtr<FJso
 		}
 		// The bNeedsRecompile out param is gone in the virtual implementation;
 		// the shim that kept it always ignored the value anyway.
-		Material->SetMaterialUsage(Usage);
+		ApplyMaterialUsage(Material, Usage);
 		Applied.Add(U);
 	}
 
@@ -2598,7 +2613,7 @@ TSharedPtr<FJsonValue> FMaterialHandlers::CreateMaterialSimple(const TSharedPtr<
 				EMaterialUsage U;
 				if (ParseMaterialUsage(S, U))
 				{
-					Material->SetMaterialUsage(U);
+					ApplyMaterialUsage(Material, U);
 				}
 			}
 		}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Public/HandlerUtils.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Public/HandlerUtils.h
@@ -13,11 +13,23 @@
 #include "EngineUtils.h"
 #include "GameFramework/Actor.h"
 
+// Engine API tiers. One macro per supported minor version, so a gate reads the
+// same everywhere and nobody writes a second scheme. The supported range is
+// UE 5.4 through 5.8; 5.4 is the floor, which is why UE_MCP_HAS_5_4_API is
+// true for every engine the plugin builds against and exists only so a gate
+// can name the floor explicitly instead of leaving it implied.
+#define UE_MCP_HAS_5_4_API ((ENGINE_MAJOR_VERSION > 5) || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4))
+
 // True on UE 5.5+ (and any future 6.x). Used to gate APIs introduced in 5.5
 // that don't exist in 5.4: StateTreeEditingSubsystem, FExpressionInputIterator,
 // AActor::Get/SetNetUpdateFrequency, UWidgetBlueprint::WidgetVariableNameToGuidMap,
 // UPCGEditorGraphNodeBase, UIKRetargeterController::AssignIKRigToAllOps, etc.
 #define UE_MCP_HAS_5_5_API ((ENGINE_MAJOR_VERSION > 5) || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5))
+
+// True on UE 5.6+ (and any future 6.x). The tier between 5.5 and 5.7, kept so
+// an API that arrived in 5.6 is gated by name rather than by an open-coded
+// ENGINE_MINOR_VERSION test.
+#define UE_MCP_HAS_5_6_API ((ENGINE_MAJOR_VERSION > 5) || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6))
 
 // True on UE 5.7+. Gates EFindObjectFlags (the bool bExactClass overloads are
 // deprecated there) and UPoseSearchDatabase's non-templated
@@ -27,7 +39,10 @@
 // True on UE 5.8+. Gates EGetObjectsFlags and
 // FStringTable::ImportStringsFromCSVFile; the bool / ImportStrings forms they
 // replace are deprecated in 5.8 and warn on every user build, but do not exist
-// before it.
+// before it. Also gates the one-argument UMaterial::SetMaterialUsage (5.7 has
+// only the bNeedsRecompile form) and FCoreDelegates::ApplicationHeartbeat
+// (added in 5.8; the status module carries its own copy of this macro because
+// it must not depend on this one).
 #define UE_MCP_HAS_5_8_API ((ENGINE_MAJOR_VERSION > 5) || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8))
 
 // ── Quick result builders ────────────────────────────────────────────────────

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_BridgeStatus/Private/MCPEngineStatus.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_BridgeStatus/Private/MCPEngineStatus.cpp
@@ -16,6 +16,16 @@
 #include "Modules/ModuleManager.h"
 #include "Serialization/JsonSerializer.h"
 #include "Serialization/JsonWriter.h"
+#include "Runtime/Launch/Resources/Version.h"
+
+// Same definition as the canonical one in UE_MCP_Bridge/Public/HandlerUtils.h.
+// It is repeated rather than shared because this module loads at
+// PostConfigInit and must not depend on the bridge module, and because the
+// bridge module lists this one as a private dependency, so its public headers
+// cannot reach in the other direction either. Keep the two in step.
+#ifndef UE_MCP_HAS_5_8_API
+#define UE_MCP_HAS_5_8_API ((ENGINE_MAJOR_VERSION > 5) || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8))
+#endif
 
 DEFINE_LOG_CATEGORY(LogMCPBridgeStatus);
 
@@ -50,7 +60,7 @@ void FMCPEngineStatus::Install()
 	// Two Core-only capture hooks, which is all that exists this early:
 	//
 	//  - the core ticker covers ordinary frames;
-	//  - the application heartbeat is broadcast by
+	//  - on UE 5.8+ the application heartbeat is broadcast by
 	//    FFeedbackContext::ProgressReported on every slow-task progress frame,
 	//    so an operation that advances its progress bar without ever returning
 	//    to the tick loop still refreshes the percentage. Startup is almost
@@ -71,10 +81,31 @@ void FMCPEngineStatus::Install()
 			return true;
 		}), 0.0f);
 
+#if UE_MCP_HAS_5_8_API
 	HeartbeatHandle = FCoreDelegates::ApplicationHeartbeat.AddLambda([this]()
 	{
 		CaptureNow();
 	});
+#else
+	// Before 5.8 there is no application heartbeat at all:
+	// FFeedbackContext::ProgressReported is an empty virtual and Core carries
+	// no other per-progress broadcast. Slow-task progress is still captured,
+	// one link further down the same chain: the editor's progress path ticks
+	// Slate on every report (FFeedbackContextEditor::ProgressReported calls
+	// TickSlate, which calls FSlateApplication::Tick), and the bridge module
+	// hooks FSlateApplication::OnPreTick when it loads at PostEngineInit.
+	//
+	// What is genuinely lost on those versions is progress refresh during the
+	// splash-only phase, before Slate can display windows: there the editor
+	// updates the splash text and returns without ticking Slate. Slow-task
+	// scopes opening and closing, and modules finishing loading, still refresh
+	// the snapshot throughout, so the phase and stall figures stay honest.
+	// Say this out loud once, because a missing hook and a working hook that
+	// never fires look identical in the log otherwise.
+	UE_LOG(LogMCPBridgeStatus, Log,
+		TEXT("[UE-MCP] UE %d.%d has no FCoreDelegates::ApplicationHeartbeat (5.8+ only). Slow-task progress is captured from the Slate pre-tick once the bridge module loads; it does not refresh during the splash phase."),
+		ENGINE_MAJOR_VERSION, ENGINE_MINOR_VERSION);
+#endif
 
 	// Neither of the above fires during PreInit: there is no tick loop yet, and
 	// the heartbeat rides on slow-task progress reporting that startup does not
@@ -125,11 +156,13 @@ void FMCPEngineStatus::Shutdown()
 		TickerHandle.Reset();
 	}
 
+#if UE_MCP_HAS_5_8_API
 	if (HeartbeatHandle.IsValid())
 	{
 		FCoreDelegates::ApplicationHeartbeat.Remove(HeartbeatHandle);
 		HeartbeatHandle.Reset();
 	}
+#endif
 
 	if (ModulesChangedHandle.IsValid())
 	{

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_BridgeStatus/Public/MCPEngineStatus.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_BridgeStatus/Public/MCPEngineStatus.h
@@ -32,9 +32,11 @@ DECLARE_LOG_CATEGORY_EXTERN(LogMCPBridgeStatus, Log, All);
  *
  * This lives in its own module so it can load at PostConfigInit, long before
  * the bridge module (PostEngineInit). Its two Core-only hooks - the core
- * ticker and FCoreDelegates::ApplicationHeartbeat, which every slow-task
- * progress frame broadcasts - cover the entire startup window that used to be
- * invisible: asset registry scan, startup shader compilation, map load.
+ * ticker and, on UE 5.8+, FCoreDelegates::ApplicationHeartbeat, which every
+ * slow-task progress frame broadcasts - cover the entire startup window that
+ * used to be invisible: asset registry scan, startup shader compilation, map
+ * load. Earlier engine versions have no heartbeat delegate; see Install() for
+ * what covers those frames there and what it costs.
  *
  * Sources that need Slate or Engine are injected by the bridge module when it
  * loads (SetModalProvider / SetCompileProvider / CaptureNow from Slate ticks),
@@ -134,6 +136,7 @@ private:
 	/** Bind the slow-task events on whichever feedback context GWarn is now. */
 	void RebindFeedbackContextIfNeeded();
 
+	/** Bound on UE 5.8+ only, where the heartbeat delegate exists. */
 	FDelegateHandle HeartbeatHandle;
 	FDelegateHandle ModulesChangedHandle;
 	FDelegateHandle SlowTaskStartHandle;

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_BridgeStatus/UE_MCP_BridgeStatus.Build.cs
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_BridgeStatus/UE_MCP_BridgeStatus.Build.cs
@@ -8,8 +8,8 @@ using UnrealBuildTool;
  * invisible to ue-mcp because nothing of ours was loaded yet.
  *
  * Dependencies are deliberately minimal: Core carries the slow-task scope
- * stack, the application heartbeat and the threading needed to publish the
- * snapshot. Slate and Engine are NOT dependencies - they are not reliably
+ * stack, the application heartbeat (UE 5.8+) and the threading needed to
+ * publish the snapshot. Slate and Engine are NOT dependencies - they are not reliably
  * up this early, so the bridge module injects those richer sources
  * (modal-dialog description, shader/asset compile counts) when it loads.
  */


### PR DESCRIPTION
Closes #865.

The plugin does not build on UE 5.7. Two 5.8-only APIs are used unguarded, both confirmed against the 5.7 and 5.8 engine headers on disk rather than inferred.

### What is gated

- **`FCoreDelegates::ApplicationHeartbeat`** (`MCPEngineStatus.cpp`). Declared only in 5.8 (`Misc/CoreDelegates.h:454`); absent from 5.7 Core entirely. The bind and unbind are now behind the version macro. On older engines the same frames are still captured one link further down the chain: `FFeedbackContextEditor::ProgressReported` calls `TickSlate`, which calls `FSlateApplication::Tick`, and the bridge module hooks `FSlateApplication::OnPreTick` at PostEngineInit. The uncovered window is the splash-only phase, where the editor updates splash text without ticking Slate. The module logs that once at install rather than looking like a hook that silently never fires.
- **`UMaterial::SetMaterialUsage` arity** (`MaterialHandlers.cpp`, two call sites). 5.7 declares only `SetMaterialUsage(bool& bNeedsRecompile, const EMaterialUsage, UMaterialInterface* = nullptr)`; 5.8 makes it the one-argument virtual and keeps the old form as a deprecated forwarding shim. Both call sites now go through one helper that picks the form the engine in hand declares, so 5.8 keeps the non-deprecated path and 5.7 gets the out param nothing reads.
- **Missing tiers `UE_MCP_HAS_5_4_API` and `UE_MCP_HAS_5_6_API`** added to `HandlerUtils.h`, so the 5.4 floor and the 5.6 boundary are nameable instead of open-coded.

The status module carries its own copy of `UE_MCP_HAS_5_8_API` with a comment pointing at the canonical definition. It loads at PostConfigInit and must not depend on the bridge module, and the bridge module holds it as a private dependency, so a shared header cannot be reached from either direction without changing the dependency shape.

### Sweep

Mechanical comparison of the 645 engine headers the plugin includes that resolve in both installs. Every include the plugin uses exists in 5.7. Diffing each pair and filtering the changed declarations down to symbols the plugin actually calls turned up no further function that is declared in 5.8 and missing from the 5.7 copy of the same header.

### Unverified, not chased

- Data-member and enum-value differences below the declaration level were too noisy to separate from renamed or moved members inside changed structs in the time available. Nothing in that set was confirmed as a break.
- UE 5.4 and 5.6 are not installed on this machine, so the sweep proves nothing about those two versions. The README range still claims 5.4 through 5.8.
- Transitively included engine headers (anything the plugin uses without including directly) were out of the compared set.

No version bump, no tags, no release. C++ changed, so a build is needed.