### PR TITLE
Compose cumulative release notes for stable versions with prereleases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,10 @@ A version with a prerelease suffix (`1.2.0-beta`, `1.2.0-beta.2`, `1.3.0-rc.1`) 
 
 The tag name still has to match the version exactly: `gh release create v1.2.0-beta --draft --notes-file ...`.
 
+#### Cutting the stable release the betas led up to
+
+Prerelease notes stay incremental: the `1.2.0-beta.3` page says what changed since `beta.2`. Stable notes are cumulative, because the betas never took the "Latest" badge and everything they shipped is invisible from the `1.2.0` page otherwise. `npm run release:notes -- --version 1.2.0 --notes-file <what landed since the last beta> --out /tmp/v1.2.0.md` builds that union: it reads every published prerelease of the same `X.Y.Z` in semver order, merges their bodies section by section, folds bullets that repeat or cite the same issue number, and unions the headlines back off the `landing/headline` commit statuses. It prints what it merged, what it deduped and any headline item it had to drop for the six-item cap, then runs its own output through `scripts/release-headline.mjs` so the file cannot fail the publish gate later. Reread the summary paragraph before you create the draft, since it may have come from a beta. A stable release with no prereleases passes its notes file straight through.
+
 ## Issue handling
 
 - **Never close an issue without shipping code that resolves it.** Not "out of scope for this patch", not "prerequisite shipped", not "follow-up". Issues close only when the fix ships.
@@ -156,6 +160,7 @@ npm run build           # Build the UE C++ plugin only
 npx tsc --noEmit        # Type-check TS
 npm run test:smoke      # Live smoke tests (tests/ue_mcp only)
 npm run golden:record   # Re-record tests/golden/editor-down.json (review the diff)
+npm run release:notes   # Compose cumulative stable notes from a version's prereleases
 npm test                # Vitest unit tests
 node scripts/deploy.mjs # Sync plugin/ → tests/ue_mcp/Plugins/
 ```

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "test:unit": "vitest run tests/unit",
     "test:multi-editor": "vitest run tests/multi-editor",
     "golden:record": "node scripts/record-golden.mjs",
+    "release:notes": "node scripts/compose-release-notes.mjs",
     "audit:docs": "node scripts/audit-docs.mjs && node scripts/audit-params.mjs",
     "audit:handlers": "node scripts/audit-handlers.mjs",
     "audit:em-dash": "node scripts/check-em-dashes.mjs",

--- a/scripts/compose-release-notes.mjs
+++ b/scripts/compose-release-notes.mjs
@@ -1,0 +1,682 @@
+/**
+ * Cumulative release notes for a stable version that had prereleases.
+ *
+ * The release flow gives every version its own hand-authored notes file, which
+ * is right for a prerelease: someone reading the 1.2.0-beta.3 page wants what
+ * changed since beta.2, not a growing wall of everything the line has shipped.
+ * It is wrong for the stable release those betas lead up to. Written the same
+ * way, the 1.2.0 page describes the last few days of work and buries the
+ * months the betas carried, and the betas are prereleases so they never take
+ * the "Latest" badge or answer /releases/latest. The work becomes invisible.
+ *
+ * So a stable release's notes are the union of every prerelease of the same
+ * X.Y.Z, plus whatever landed after the last one. This script builds that
+ * union from published releases:
+ *
+ *   node scripts/compose-release-notes.mjs --version 1.2.0 \
+ *     --notes-file since-last-beta.md --out /tmp/v1.2.0.md
+ *
+ * What it merges:
+ *
+ *   - Bodies, section by section, on the `### Heading` level the repo already
+ *     uses (Server, Bug fixes, Internals, Multi-editor, Bridge protocol, and
+ *     anything else that shows up). Heading order is order of first
+ *     appearance; a section that only exists in the newest input lands at the
+ *     end.
+ *   - Bullets, deduplicated. A fix often gets reworded between betas, so
+ *     matching the text alone is not enough: two bullets are also the same
+ *     bullet when they cite the same issue or PR number. The longer variant
+ *     wins, because it is usually the one carrying the detail. Nothing fuzzier
+ *     than that, on purpose. A bullet that merely reads like another one is
+ *     kept, and a human deleting a duplicate is cheap next to this script
+ *     silently eating a shipped change.
+ *   - Headline frontmatter, from the union of the prerelease headlines. The
+ *     published body has its frontmatter stripped by CI, so the headline is
+ *     read back from the `landing/headline` commit status CI posts on the
+ *     tagged commit, which is the validated, ` · `-joined copy.
+ *
+ * Dedupe is global rather than per section, since the beta that called
+ * something a bug fix and the beta that called it a server change are still
+ * describing one change. The first section it appeared in is the one it keeps.
+ *
+ * A stable release with no prereleases is a supported case: there is nothing
+ * to merge, so the local notes file passes straight through and is validated.
+ *
+ * The composed file is run through scripts/release-headline.mjs before this
+ * script exits, so a body it produced cannot fail the publish gate later.
+ *
+ * No shebang: vitest re-imports this file and its loader rejects the shebang
+ * line as "Invalid or unexpected token". Invoke as
+ * `node scripts/compose-release-notes.mjs ...` or `npm run release:notes --`.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { parseVersion } from "./release-version.mjs";
+import {
+  ITEM_RE,
+  MAX_ITEMS,
+  MAX_ITEM_LEN,
+  MAX_JOINED_LEN,
+  MIN_ITEMS,
+  MIN_ITEM_LEN,
+  SEP,
+  ValidationError,
+  processBody,
+  splitFrontmatter,
+  parseHeadlineArray,
+} from "./release-headline.mjs";
+
+/** The commit status CI posts with the validated, joined headline. */
+export const HEADLINE_STATUS_CONTEXT = "landing/headline";
+
+export class ComposeError extends Error {}
+
+/* ------------------------------------------------------------------ *
+ * Version ordering
+ * ------------------------------------------------------------------ */
+
+/** Strips a leading `v` from a tag so it can be parsed as a version. */
+export function versionOfTag(tag) {
+  return String(tag).trim().replace(/^v/, "");
+}
+
+/**
+ * Semver precedence for two prerelease suffixes, per the spec's rule 11.
+ *
+ * Lexical sorting is wrong here and quietly so: `v1.2.0-beta.10` sorts before
+ * `v1.2.0-beta.2` as a string, which would merge the betas out of order and
+ * hand the older wording priority over the newer.
+ *
+ * `null` means "no prerelease suffix", which outranks every suffix.
+ */
+export function comparePrereleaseIds(a, b) {
+  if (a === null && b === null) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  const left = a.split(".");
+  const right = b.split(".");
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const l = left[i];
+    const r = right[i];
+    // A shorter set of identifiers has lower precedence when all the leading
+    // ones are equal, so `beta` sorts before `beta.2`.
+    if (l === undefined) return -1;
+    if (r === undefined) return 1;
+    const lNum = /^\d+$/.test(l);
+    const rNum = /^\d+$/.test(r);
+    if (lNum && rNum) {
+      const d = Number(l) - Number(r);
+      if (d !== 0) return d < 0 ? -1 : 1;
+      continue;
+    }
+    // Numeric identifiers always have lower precedence than alphanumeric ones.
+    if (lNum !== rNum) return lNum ? -1 : 1;
+    if (l !== r) return l < r ? -1 : 1;
+  }
+  return 0;
+}
+
+/** Full semver precedence, used to sort the prerelease tags of one version. */
+export function compareVersions(a, b) {
+  const x = parseVersion(a);
+  const y = parseVersion(b);
+  for (const key of ["major", "minor", "patch"]) {
+    if (x[key] !== y[key]) return x[key] < y[key] ? -1 : 1;
+  }
+  return comparePrereleaseIds(x.prerelease, y.prerelease);
+}
+
+/**
+ * The tags that are prereleases of `version`, oldest first.
+ *
+ * Anything that is not parseable semver, belongs to another X.Y.Z, or is the
+ * stable release itself is dropped rather than thrown on: the tag list comes
+ * from a repo that may carry tags this pipeline never created.
+ */
+export function prereleaseTagsFor(version, tags) {
+  const target = parseVersion(version);
+  const matches = [];
+  for (const tag of tags ?? []) {
+    let parsed;
+    try {
+      parsed = parseVersion(versionOfTag(tag));
+    } catch {
+      continue;
+    }
+    if (parsed.prerelease === null) continue;
+    if (
+      parsed.major !== target.major ||
+      parsed.minor !== target.minor ||
+      parsed.patch !== target.patch
+    ) {
+      continue;
+    }
+    matches.push(tag);
+  }
+  matches.sort((a, b) => compareVersions(versionOfTag(a), versionOfTag(b)));
+  return matches;
+}
+
+/* ------------------------------------------------------------------ *
+ * Body parsing
+ * ------------------------------------------------------------------ */
+
+function toLines(text) {
+  return String(text ?? "").replace(/\r\n/g, "\n").split("\n");
+}
+
+function trimBlank(lines) {
+  const out = [...lines];
+  while (out.length && out[0].trim() === "") out.shift();
+  while (out.length && out[out.length - 1].trim() === "") out.pop();
+  return out;
+}
+
+/**
+ * Splits a release body into the text above the first `### ` heading and the
+ * sections below it. `## vX.Y.Z` and the summary paragraph stay in the
+ * preamble; a `#### ` sub-heading stays inside its section.
+ */
+export function parseSections(body) {
+  const preamble = [];
+  let current = null;
+  const sections = [];
+  for (const line of toLines(body)) {
+    const m = line.match(/^###\s+(.+?)\s*$/);
+    if (m) {
+      current = { heading: m[1], lines: [] };
+      sections.push(current);
+      continue;
+    }
+    (current ? current.lines : preamble).push(line);
+  }
+  return {
+    preamble: trimBlank(preamble).join("\n"),
+    sections: sections.map((s) => ({
+      heading: s.heading,
+      body: trimBlank(s.lines).join("\n"),
+    })),
+  };
+}
+
+/**
+ * Splits section text into any prose above the bullets and the bullets
+ * themselves. A bullet starts with a marker in column 0; indented lines and
+ * nested bullets belong to the bullet above them.
+ */
+export function parseBullets(sectionBody) {
+  const lead = [];
+  const bullets = [];
+  let current = null;
+  for (const line of toLines(sectionBody)) {
+    if (/^[-*]\s+\S/.test(line)) {
+      current = [line];
+      bullets.push(current);
+      continue;
+    }
+    if (current) current.push(line);
+    else lead.push(line);
+  }
+  return {
+    lead: trimBlank(lead).join("\n"),
+    bullets: bullets.map((b) => trimBlank(b).join("\n")),
+  };
+}
+
+/** A bullet's text with its marker removed and whitespace collapsed. */
+export function bulletText(bullet) {
+  return String(bullet).replace(/^[-*]\s+/, "").replace(/\s+/g, " ").trim();
+}
+
+/** The exact-match dedupe key: case and trailing punctuation do not count. */
+export function bulletKey(bullet) {
+  return bulletText(bullet).toLowerCase().replace(/[.\s]+$/, "");
+}
+
+/**
+ * Issue and PR numbers cited by a bullet.
+ *
+ * The `#` has to open a word so a heading marker or a mid-word hash is not
+ * read as a citation, and `#5.7` is left alone because a dot followed by more
+ * digits makes that a version rather than an issue.
+ */
+export function issueRefs(bullet) {
+  const refs = new Set();
+  for (const m of bulletText(bullet).matchAll(/(?:^|[\s([])#(\d+)\b(?!\.\d)/g)) {
+    refs.add(`#${m[1]}`);
+  }
+  return refs;
+}
+
+/* ------------------------------------------------------------------ *
+ * Merging
+ * ------------------------------------------------------------------ */
+
+/**
+ * Merges release bodies in the order given, oldest input first.
+ *
+ * Returns the merged sections and the bullets that were folded away, each
+ * naming the input it came from so the run can report what it did.
+ */
+export function mergeBodies(inputs) {
+  const order = [];
+  const buckets = new Map();
+  const byExactKey = new Map();
+  const byIssueRef = new Map();
+  const duplicates = [];
+
+  for (const input of inputs ?? []) {
+    const { sections } = parseSections(input.body);
+    for (const section of sections) {
+      const key = section.heading.trim().toLowerCase();
+      let bucket = buckets.get(key);
+      if (!bucket) {
+        bucket = { heading: section.heading.trim(), lead: "", bullets: [] };
+        buckets.set(key, bucket);
+        order.push(key);
+      }
+      const { lead, bullets } = parseBullets(section.body);
+      if (!bucket.lead && lead) bucket.lead = lead;
+
+      for (const bullet of bullets) {
+        const exact = bulletKey(bullet);
+        const refs = issueRefs(bullet);
+        let hit = byExactKey.get(exact) ?? null;
+        let reason = hit ? "same text" : null;
+        if (!hit) {
+          for (const ref of refs) {
+            const candidate = byIssueRef.get(ref);
+            if (candidate) {
+              hit = candidate;
+              reason = `same issue ${ref}`;
+              break;
+            }
+          }
+        }
+        if (hit) {
+          // The longer wording usually carries the extra detail a later beta
+          // added, so it is the one that survives. The position does not move.
+          const replaced = bulletText(bullet).length > bulletText(hit.text).length;
+          duplicates.push({
+            source: input.label,
+            reason,
+            kept: replaced ? bulletText(bullet) : bulletText(hit.text),
+            dropped: replaced ? bulletText(hit.text) : bulletText(bullet),
+          });
+          if (replaced) hit.text = bullet;
+          byExactKey.set(exact, hit);
+          for (const ref of refs) if (!byIssueRef.has(ref)) byIssueRef.set(ref, hit);
+          continue;
+        }
+        const entry = { text: bullet };
+        bucket.bullets.push(entry);
+        byExactKey.set(exact, entry);
+        for (const ref of refs) if (!byIssueRef.has(ref)) byIssueRef.set(ref, entry);
+      }
+    }
+  }
+
+  return {
+    sections: order.map((key) => {
+      const bucket = buckets.get(key);
+      return {
+        heading: bucket.heading,
+        lead: bucket.lead,
+        bullets: bucket.bullets.map((e) => e.text),
+      };
+    }),
+    duplicates,
+  };
+}
+
+/**
+ * Unions the headline items in order of first appearance and truncates to what
+ * the publish gate accepts.
+ *
+ * Every drop is reported rather than applied quietly: the union of five betas
+ * routinely exceeds six items, and which five survive is an editorial call a
+ * human may want to overrule.
+ */
+export function mergeHeadlines(lists) {
+  const seen = new Set();
+  const ordered = [];
+  for (const list of lists ?? []) {
+    for (const raw of list ?? []) {
+      const item = String(raw).trim();
+      if (!item) continue;
+      const norm = item.toLowerCase().replace(/\s+/g, " ");
+      if (seen.has(norm)) continue;
+      seen.add(norm);
+      ordered.push(item);
+    }
+  }
+
+  const items = [];
+  const dropped = [];
+  for (const item of ordered) {
+    if (item.length < MIN_ITEM_LEN || item.length > MAX_ITEM_LEN) {
+      dropped.push({
+        item,
+        reason: `${item.length} chars, allowed ${MIN_ITEM_LEN}-${MAX_ITEM_LEN}`,
+      });
+      continue;
+    }
+    if (!ITEM_RE.test(item)) {
+      dropped.push({ item, reason: "forbidden characters" });
+      continue;
+    }
+    if (items.length >= MAX_ITEMS) {
+      dropped.push({ item, reason: `over the ${MAX_ITEMS} item cap` });
+      continue;
+    }
+    if ([...items, item].join(SEP).length > MAX_JOINED_LEN) {
+      dropped.push({ item, reason: `joined headline would pass ${MAX_JOINED_LEN} chars` });
+      continue;
+    }
+    items.push(item);
+  }
+  return { items, dropped };
+}
+
+/** Reads a headline array out of a notes file, tolerating one that has none. */
+export function headlineOf(body) {
+  try {
+    const { yaml } = splitFrontmatter(String(body ?? ""));
+    return parseHeadlineArray(yaml);
+  } catch {
+    return [];
+  }
+}
+
+/** Drops frontmatter if the body still carries it. Published bodies do not. */
+export function stripFrontmatter(body) {
+  try {
+    return splitFrontmatter(String(body ?? "")).rest.replace(/^\s+/, "");
+  } catch {
+    return String(body ?? "");
+  }
+}
+
+/** Points the preamble's `## vX.Y.Z` heading at the version being cut. */
+export function retitle(preamble, version) {
+  const lines = toLines(preamble);
+  const idx = lines.findIndex((l) => /^##\s+v?\d/.test(l));
+  if (idx === -1) return trimBlank([`## v${version}`, "", ...lines]).join("\n");
+  lines[idx] = `## v${version}`;
+  return trimBlank(lines).join("\n");
+}
+
+/** True when a preamble carries something beyond its version heading. */
+export function hasSummary(preamble) {
+  return toLines(preamble)
+    .filter((l) => !/^##\s+v?\d/.test(l))
+    .some((l) => l.trim() !== "");
+}
+
+/** Renders the composed notes file, frontmatter first. */
+export function renderBody({ version, headline, preamble, sections }) {
+  const out = ["---", "headline:"];
+  for (const item of headline) out.push(`  - ${item}`);
+  out.push("---", "");
+  out.push(retitle(preamble, version), "");
+  for (const section of sections) {
+    if (!section.lead && section.bullets.length === 0) continue;
+    out.push(`### ${section.heading}`, "");
+    if (section.lead) out.push(section.lead, "");
+    for (const bullet of section.bullets) out.push(bullet);
+    out.push("");
+  }
+  return `${out.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd()}\n`;
+}
+
+/* ------------------------------------------------------------------ *
+ * Composition
+ * ------------------------------------------------------------------ */
+
+/**
+ * Builds the stable release body.
+ *
+ * `prereleases` is `[{ tag, body, headline }]`, oldest first. `localNotes` is
+ * the raw contents of a notes file covering whatever landed after the last
+ * prerelease, frontmatter and all.
+ *
+ * With no prereleases there is nothing to accumulate, so the local file is the
+ * answer as written and is returned unchanged.
+ */
+export function composeReleaseNotes({ version, prereleases = [], localNotes = null }) {
+  parseVersion(version);
+  if (parseVersion(version).prerelease !== null) {
+    throw new ComposeError(
+      `${version} is itself a prerelease. Prerelease notes stay incremental; compose ` +
+        `only when cutting the stable X.Y.Z they lead up to.`
+    );
+  }
+  if (prereleases.length === 0 && localNotes === null) {
+    throw new ComposeError(
+      `No published prereleases of ${version} and no --notes-file. There is nothing to compose.`
+    );
+  }
+
+  if (prereleases.length === 0) {
+    const body = String(localNotes);
+    validateBody(body);
+    return {
+      body,
+      passthrough: true,
+      merged: [],
+      duplicates: [],
+      headline: { items: headlineOf(body), dropped: [] },
+      preambleFrom: null,
+    };
+  }
+
+  const inputs = prereleases.map((r) => ({ label: r.tag, body: stripFrontmatter(r.body) }));
+  const localBody = localNotes === null ? null : stripFrontmatter(localNotes);
+  if (localBody !== null) inputs.push({ label: "local notes", body: localBody });
+
+  const { sections, duplicates } = mergeBodies(inputs);
+
+  // The summary belongs to the release being cut, so a local file's summary
+  // wins. Falling back to the newest prerelease keeps a body that reads, but
+  // that text was written about a beta and wants a human eye.
+  const localPreamble = localBody === null ? "" : parseSections(localBody).preamble;
+  const newest = prereleases[prereleases.length - 1];
+  const usingLocal = hasSummary(localPreamble);
+  const preamble = usingLocal
+    ? localPreamble
+    : parseSections(stripFrontmatter(newest.body)).preamble;
+  const preambleFrom = usingLocal ? "local notes" : newest.tag;
+
+  const headline = mergeHeadlines([
+    ...prereleases.map((r) => r.headline ?? []),
+    localNotes === null ? [] : headlineOf(localNotes),
+  ]);
+  if (headline.items.length < MIN_ITEMS) {
+    throw new ComposeError(
+      `No usable headline items. The prereleases of ${version} carry no landing/headline ` +
+        `status and the notes file has no headline frontmatter; add one to the notes file.`
+    );
+  }
+
+  const body = renderBody({ version, headline: headline.items, preamble, sections });
+  validateBody(body);
+  return {
+    body,
+    passthrough: false,
+    merged: prereleases.map((r) => r.tag),
+    duplicates,
+    headline,
+    preambleFrom,
+    newestTag: newest.tag,
+  };
+}
+
+/** Runs the composed body through the same parser the publish gate runs. */
+export function validateBody(body) {
+  try {
+    return processBody(body);
+  } catch (e) {
+    if (e instanceof ValidationError) {
+      throw new ComposeError(`Composed body would fail the publish gate: ${e.message}`);
+    }
+    throw e;
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * GitHub reads
+ * ------------------------------------------------------------------ */
+
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+}
+
+/**
+ * Reads a tag's headline back off the `landing/headline` commit status.
+ *
+ * CI strips the frontmatter before it publishes, so the status is the only
+ * machine-readable copy of a released headline. A tag without one contributes
+ * nothing rather than failing the run: the status only exists for versions
+ * published after the gate was added.
+ */
+export function fetchHeadline(repo, tag, run = gh) {
+  let raw;
+  try {
+    raw = run([
+      "api",
+      `repos/${repo}/commits/${tag}/status`,
+      "--jq",
+      `[.statuses[] | select(.context=="${HEADLINE_STATUS_CONTEXT}") | .description] | first // ""`,
+    ]);
+  } catch {
+    return [];
+  }
+  return String(raw)
+    .trim()
+    .split(SEP.trim())
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** Every published prerelease of `version`, oldest first, bodies included. */
+export function fetchPrereleases(repo, version, run = gh) {
+  const listed = JSON.parse(
+    run(["release", "list", "--repo", repo, "--limit", "200", "--json", "tagName,isDraft"])
+  );
+  const tags = prereleaseTagsFor(
+    version,
+    listed.filter((r) => !r.isDraft).map((r) => r.tagName)
+  );
+  return tags.map((tag) => ({
+    tag,
+    body: JSON.parse(run(["release", "view", tag, "--repo", repo, "--json", "body"])).body ?? "",
+    headline: fetchHeadline(repo, tag, run),
+  }));
+}
+
+function currentRepo(run = gh) {
+  return JSON.parse(run(["repo", "view", "--json", "nameWithOwner"])).nameWithOwner;
+}
+
+/* ------------------------------------------------------------------ *
+ * CLI
+ * ------------------------------------------------------------------ */
+
+const USAGE = `Usage: node scripts/compose-release-notes.mjs --version X.Y.Z [options]
+
+  --version X.Y.Z     the stable version being cut (required)
+  --notes-file PATH    notes covering what landed after the last prerelease
+  --out PATH           where to write the composed body (default: temp dir)
+  --repo OWNER/NAME    repository to read releases from (default: the checkout)`;
+
+function main() {
+  const args = process.argv.slice(2);
+  let version = null;
+  let notesFile = null;
+  let out = null;
+  let repo = null;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--version") version = args[++i];
+    else if (args[i] === "--notes-file") notesFile = args[++i];
+    else if (args[i] === "--out") out = args[++i];
+    else if (args[i] === "--repo") repo = args[++i];
+    else if (args[i] === "--help" || args[i] === "-h") {
+      console.log(USAGE);
+      return;
+    } else if (!args[i].startsWith("-") && version === null) version = args[i];
+  }
+  if (!version) {
+    console.error(USAGE);
+    process.exit(2);
+  }
+
+  try {
+    const slug = repo ?? currentRepo();
+    const prereleases = fetchPrereleases(slug, version);
+    const localNotes = notesFile === null ? null : fs.readFileSync(notesFile, "utf8");
+    const result = composeReleaseNotes({ version, prereleases, localNotes });
+
+    const target =
+      out ??
+      path.join(fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-compose-")), `v${version}.md`);
+    fs.mkdirSync(path.dirname(path.resolve(target)), { recursive: true });
+    fs.writeFileSync(target, result.body);
+
+    report(version, notesFile, target, result);
+
+    // Prove the file the releaser is about to hand to `gh release create`
+    // survives the exact script the publish job runs on it.
+    const self = path.dirname(fileURLToPath(import.meta.url));
+    execFileSync(
+      process.execPath,
+      [path.join(self, "release-headline.mjs"), "--body-file", target],
+      { stdio: "inherit" }
+    );
+  } catch (e) {
+    if (e instanceof ComposeError || e instanceof ValidationError) {
+      console.error(`::error::${e.message}`);
+      process.exit(1);
+    }
+    throw e;
+  }
+}
+
+function report(version, notesFile, target, result) {
+  console.log(`Composed release notes for v${version}`);
+  if (result.passthrough) {
+    console.log(`  No published prereleases of ${version}; ${notesFile} passed through as written.`);
+  } else {
+    console.log(`  Merged ${result.merged.length} prerelease(s): ${result.merged.join(", ")}`);
+    if (notesFile) console.log(`  Plus local notes: ${notesFile}`);
+    console.log(`  Deduped ${result.duplicates.length} bullet(s)`);
+    for (const dupe of result.duplicates) {
+      console.log(`    [${dupe.reason}] kept: ${clip(dupe.kept)}`);
+      console.log(`                  folded: ${clip(dupe.dropped)}`);
+    }
+    console.log(`  Headline: ${result.headline.items.join(SEP)}`);
+    for (const drop of result.headline.dropped) {
+      console.log(`  Dropped headline item (${drop.reason}): ${drop.item}`);
+    }
+    if (result.headline.dropped.length) {
+      console.log("  Edit the frontmatter by hand if a dropped item should have won.");
+    }
+    if (result.preambleFrom !== "local notes") {
+      console.log(
+        `  Summary paragraph came from ${result.preambleFrom}; reread it, it was written about a prerelease.`
+      );
+    }
+  }
+  console.log(`NOTES_PATH=${target}`);
+}
+
+function clip(text, limit = 90) {
+  return text.length > limit ? `${text.slice(0, limit)} [trimmed]` : text;
+}
+
+const invokedAsScript =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedAsScript) main();

--- a/tests/unit/compose-release-notes.test.ts
+++ b/tests/unit/compose-release-notes.test.ts
@@ -1,0 +1,439 @@
+import { describe, it, expect } from "vitest";
+import {
+  ComposeError,
+  bulletKey,
+  comparePrereleaseIds,
+  compareVersions,
+  composeReleaseNotes,
+  fetchHeadline,
+  fetchPrereleases,
+  issueRefs,
+  mergeBodies,
+  mergeHeadlines,
+  parseBullets,
+  parseSections,
+  prereleaseTagsFor,
+  retitle,
+} from "../../scripts/compose-release-notes.mjs";
+import { processBody } from "../../scripts/release-headline.mjs";
+
+/** A published prerelease body, frontmatter already stripped by CI. */
+function release(tag: string, body: string, headline: string[] = []) {
+  return { tag, body, headline };
+}
+
+describe("prerelease ordering", () => {
+  it("orders numeric identifiers numerically, not lexically", () => {
+    expect(comparePrereleaseIds("beta.2", "beta.10")).toBe(-1);
+    expect(comparePrereleaseIds("beta.10", "beta.2")).toBe(1);
+  });
+
+  it("ranks a bare identifier below the same identifier with a number", () => {
+    expect(comparePrereleaseIds("beta", "beta.1")).toBe(-1);
+  });
+
+  it("ranks numeric identifiers below alphanumeric ones", () => {
+    expect(comparePrereleaseIds("alpha.1", "alpha.beta")).toBe(-1);
+  });
+
+  it("ranks a prerelease below its own stable release", () => {
+    expect(comparePrereleaseIds("rc.1", null)).toBe(-1);
+    expect(compareVersions("1.2.0-rc.1", "1.2.0")).toBe(-1);
+    expect(compareVersions("1.2.0", "1.2.1-beta")).toBe(-1);
+  });
+
+  it("sorts the prereleases of one version and ignores everything else", () => {
+    const tags = [
+      "v1.2.0-beta.10",
+      "v1.1.44",
+      "v1.2.0",
+      "v1.2.0-beta",
+      "v1.3.0-rc.1",
+      "not-a-tag",
+      "v1.2.0-beta.2",
+      "v1.2.0-rc.1",
+    ];
+    expect(prereleaseTagsFor("1.2.0", tags)).toEqual([
+      "v1.2.0-beta",
+      "v1.2.0-beta.2",
+      "v1.2.0-beta.10",
+      "v1.2.0-rc.1",
+    ]);
+  });
+
+  it("returns nothing when the version never had a prerelease", () => {
+    expect(prereleaseTagsFor("1.1.44", ["v1.1.43", "v1.1.44", "v1.2.0-beta"])).toEqual([]);
+  });
+});
+
+describe("body parsing", () => {
+  const BODY = [
+    "## v1.2.0-beta",
+    "",
+    "One line summary.",
+    "",
+    "### Server",
+    "",
+    "- First thing.",
+    "  Continued on a second line.",
+    "- Second thing.",
+    "",
+    "### Bug fixes",
+    "",
+    "Prose above the bullets.",
+    "",
+    "- A fix (#123).",
+  ].join("\n");
+
+  it("keeps the version heading and summary in the preamble", () => {
+    const parsed = parseSections(BODY);
+    expect(parsed.preamble).toBe("## v1.2.0-beta\n\nOne line summary.");
+    expect(parsed.sections.map((s) => s.heading)).toEqual(["Server", "Bug fixes"]);
+  });
+
+  it("handles CRLF bodies, which is what the GitHub API returns", () => {
+    const parsed = parseSections(BODY.replace(/\n/g, "\r\n"));
+    expect(parsed.sections.map((s) => s.heading)).toEqual(["Server", "Bug fixes"]);
+    expect(parsed.sections[0].body).not.toContain("\r");
+  });
+
+  it("keeps a bullet's continuation lines with the bullet", () => {
+    const { bullets } = parseBullets(parseSections(BODY).sections[0].body);
+    expect(bullets).toEqual([
+      "- First thing.\n  Continued on a second line.",
+      "- Second thing.",
+    ]);
+  });
+
+  it("separates prose above the bullets from the bullets", () => {
+    const { lead, bullets } = parseBullets(parseSections(BODY).sections[1].body);
+    expect(lead).toBe("Prose above the bullets.");
+    expect(bullets).toEqual(["- A fix (#123)."]);
+  });
+
+  it("reads issue citations but not version numbers or headings", () => {
+    expect([...issueRefs("- Fixes #123 and #45.")]).toEqual(["#123", "#45"]);
+    expect([...issueRefs("- Parenthesised (#7).")]).toEqual(["#7"]);
+    expect([...issueRefs("- Works on UE 5.7 with #5.7 style anchors")]).toEqual([]);
+  });
+
+  it("ignores case and trailing punctuation in the exact key", () => {
+    expect(bulletKey("- The Same  Thing.")).toBe(bulletKey("*   the same thing"));
+  });
+});
+
+describe("section merging", () => {
+  it("merges matching sections and keeps first-appearance order", () => {
+    const merged = mergeBodies([
+      { label: "beta", body: "### Server\n\n- Alpha\n\n### Bug fixes\n\n- Bravo" },
+      { label: "beta.2", body: "### Bug fixes\n\n- Charlie\n\n### Server\n\n- Delta" },
+    ]);
+    expect(merged.sections.map((s) => s.heading)).toEqual(["Server", "Bug fixes"]);
+    expect(merged.sections[0].bullets).toEqual(["- Alpha", "- Delta"]);
+    expect(merged.sections[1].bullets).toEqual(["- Bravo", "- Charlie"]);
+  });
+
+  it("appends a section that only the newest input introduced", () => {
+    const merged = mergeBodies([
+      { label: "beta", body: "### Server\n\n- Alpha" },
+      { label: "local", body: "### Security\n\n- Bravo" },
+    ]);
+    expect(merged.sections.map((s) => s.heading)).toEqual(["Server", "Security"]);
+  });
+
+  it("matches a heading regardless of case", () => {
+    const merged = mergeBodies([
+      { label: "beta", body: "### Bug fixes\n\n- Alpha" },
+      { label: "beta.2", body: "### Bug Fixes\n\n- Bravo" },
+    ]);
+    expect(merged.sections).toHaveLength(1);
+    expect(merged.sections[0].heading).toBe("Bug fixes");
+    expect(merged.sections[0].bullets).toEqual(["- Alpha", "- Bravo"]);
+  });
+
+  it("carries prose above the bullets from the first input that had it", () => {
+    const merged = mergeBodies([
+      { label: "beta", body: "### Server\n\nThe original lead.\n\n- Alpha" },
+      { label: "beta.2", body: "### Server\n\nA later lead.\n\n- Bravo" },
+    ]);
+    expect(merged.sections[0].lead).toBe("The original lead.");
+  });
+});
+
+describe("bullet dedupe", () => {
+  it("folds an exact repeat, ignoring case and spacing", () => {
+    const merged = mergeBodies([
+      { label: "beta", body: "### Server\n\n- The same thing shipped." },
+      { label: "beta.2", body: "### Server\n\n- The  Same thing shipped" },
+    ]);
+    expect(merged.sections[0].bullets).toEqual(["- The same thing shipped."]);
+    expect(merged.duplicates).toHaveLength(1);
+    expect(merged.duplicates[0].reason).toBe("same text");
+  });
+
+  it("folds two wordings of the same issue and keeps the longer one", () => {
+    const merged = mergeBodies([
+      { label: "beta", body: "### Bug fixes\n\n- Map writes no longer drop entries (#820)." },
+      {
+        label: "beta.2",
+        body:
+          "### Bug fixes\n\n- Map writes no longer drop entries, and the count is verified " +
+          "against what was asked for (#820).",
+      },
+    ]);
+    expect(merged.sections[0].bullets).toEqual([
+      "- Map writes no longer drop entries, and the count is verified against what was asked for (#820).",
+    ]);
+    expect(merged.duplicates[0].reason).toBe("same issue #820");
+  });
+
+  it("keeps the earlier position when a later wording wins", () => {
+    const merged = mergeBodies([
+      { label: "beta", body: "### Server\n\n- Short (#5).\n- Untouched." },
+      { label: "beta.2", body: "### Server\n\n- A much longer retelling of it (#5)." },
+    ]);
+    expect(merged.sections[0].bullets).toEqual([
+      "- A much longer retelling of it (#5).",
+      "- Untouched.",
+    ]);
+  });
+
+  it("folds a bullet that moved between sections", () => {
+    const merged = mergeBodies([
+      { label: "beta", body: "### Bug fixes\n\n- Reconnect loop (#404)." },
+      { label: "beta.2", body: "### Server\n\n- Reconnect loop reworked (#404)." },
+    ]);
+    expect(merged.sections.map((s) => s.heading)).toEqual(["Bug fixes", "Server"]);
+    expect(merged.sections[0].bullets).toEqual(["- Reconnect loop reworked (#404)."]);
+    expect(merged.sections[1].bullets).toEqual([]);
+  });
+
+  it("keeps two bullets that merely read alike", () => {
+    const merged = mergeBodies([
+      { label: "beta", body: "### Server\n\n- Faster asset search." },
+      { label: "beta.2", body: "### Server\n\n- Faster asset search on large projects." },
+    ]);
+    expect(merged.sections[0].bullets).toHaveLength(2);
+    expect(merged.duplicates).toHaveLength(0);
+  });
+
+  it("keeps two fixes that cite different issues", () => {
+    const merged = mergeBodies([
+      { label: "beta", body: "### Bug fixes\n\n- A fix (#1)." },
+      { label: "beta.2", body: "### Bug fixes\n\n- A fix (#2)." },
+    ]);
+    expect(merged.sections[0].bullets).toHaveLength(2);
+  });
+});
+
+describe("headline union", () => {
+  it("unions in first-appearance order and drops case-insensitive repeats", () => {
+    const merged = mergeHeadlines([
+      ["Multi-editor sessions", "Bridge protocol"],
+      ["bridge protocol", "Widget interaction"],
+    ]);
+    expect(merged.items).toEqual([
+      "Multi-editor sessions",
+      "Bridge protocol",
+      "Widget interaction",
+    ]);
+    expect(merged.dropped).toEqual([]);
+  });
+
+  it("truncates to six items and reports the ones it dropped", () => {
+    const merged = mergeHeadlines([["One A", "Two B", "Three C", "Four D", "Five E", "Six F"], ["Seven G"]]);
+    expect(merged.items).toHaveLength(6);
+    expect(merged.dropped).toEqual([{ item: "Seven G", reason: "over the 6 item cap" }]);
+  });
+
+  it("drops items the publish gate would reject on length or characters", () => {
+    const merged = mergeHeadlines([["OK", "Fine one", "Nope: colon", "x".repeat(31)]]);
+    expect(merged.items).toEqual(["Fine one"]);
+    expect(merged.dropped.map((d) => d.reason)).toEqual([
+      "2 chars, allowed 3-30",
+      "forbidden characters",
+      "31 chars, allowed 3-30",
+    ]);
+  });
+
+  it("stops before the joined string passes the status-description cap", () => {
+    const merged = mergeHeadlines([
+      ["A".repeat(30), "B".repeat(30), "C".repeat(30), "D".repeat(30), "E".repeat(30)],
+    ]);
+    expect(merged.items.join(" · ").length).toBeLessThanOrEqual(140);
+    expect(merged.dropped).toHaveLength(1);
+  });
+});
+
+describe("composeReleaseNotes", () => {
+  const BETA = release(
+    "v1.2.0-beta",
+    [
+      "## v1.2.0-beta",
+      "",
+      "The beta summary.",
+      "",
+      "### Multi-editor",
+      "",
+      "- One server, many editors (#800).",
+      "",
+      "### Bug fixes",
+      "",
+      "- Map writes keep their entries (#820).",
+    ].join("\n"),
+    ["Multi-editor sessions", "Struct-keyed TMap safety"]
+  );
+
+  const BETA2 = release(
+    "v1.2.0-beta.2",
+    [
+      "## v1.2.0-beta.2",
+      "",
+      "The second beta summary.",
+      "",
+      "### Bug fixes",
+      "",
+      "- Map writes keep their entries, and the stored count is verified (#820).",
+      "",
+      "### Internals",
+      "",
+      "- A new test tier.",
+    ].join("\n"),
+    ["Multi-editor sessions", "Two-bridge test tier"]
+  );
+
+  const LOCAL = [
+    "---",
+    "headline:",
+    "  - Landed after the betas",
+    "---",
+    "",
+    "## v1.2.0",
+    "",
+    "The stable summary.",
+    "",
+    "### Server",
+    "",
+    "- One last thing.",
+  ].join("\n");
+
+  it("accumulates every prerelease plus the local notes", () => {
+    const result = composeReleaseNotes({
+      version: "1.2.0",
+      prereleases: [BETA, BETA2],
+      localNotes: LOCAL,
+    });
+    expect(result.passthrough).toBe(false);
+    expect(result.merged).toEqual(["v1.2.0-beta", "v1.2.0-beta.2"]);
+
+    const { headline, strippedBody } = processBody(result.body);
+    expect(headline).toBe(
+      "Multi-editor sessions · Struct-keyed TMap safety · Two-bridge test tier · Landed after the betas"
+    );
+    expect(strippedBody).toContain("## v1.2.0\n");
+    expect(strippedBody).not.toContain("v1.2.0-beta");
+    expect(strippedBody).toContain("The stable summary.");
+
+    const headings = [...strippedBody.matchAll(/^### (.+)$/gm)].map((m) => m[1]);
+    expect(headings).toEqual(["Multi-editor", "Bug fixes", "Internals", "Server"]);
+
+    // The reworded #820 bullet collapsed to the longer variant.
+    expect(strippedBody).toContain("the stored count is verified (#820)");
+    expect(strippedBody.match(/#820/g)).toHaveLength(1);
+    expect(result.duplicates).toHaveLength(1);
+  });
+
+  it("falls back to the newest prerelease summary and says so", () => {
+    const result = composeReleaseNotes({ version: "1.2.0", prereleases: [BETA, BETA2] });
+    expect(result.preambleFrom).toBe("v1.2.0-beta.2");
+    expect(processBody(result.body).strippedBody).toContain("The second beta summary.");
+  });
+
+  it("passes a stable release with no prereleases straight through", () => {
+    const result = composeReleaseNotes({ version: "1.1.44", prereleases: [], localNotes: LOCAL });
+    expect(result.passthrough).toBe(true);
+    expect(result.body).toBe(LOCAL);
+    expect(processBody(result.body).headline).toBe("Landed after the betas");
+  });
+
+  it("refuses a stable release with neither prereleases nor notes", () => {
+    expect(() => composeReleaseNotes({ version: "1.1.44" })).toThrow(ComposeError);
+  });
+
+  it("refuses to compose for a prerelease, whose notes stay incremental", () => {
+    expect(() => composeReleaseNotes({ version: "1.2.0-beta.3", prereleases: [BETA] })).toThrow(
+      /prerelease notes stay incremental/i
+    );
+  });
+
+  it("fails loudly when nothing supplies a headline", () => {
+    const bare = release("v1.2.0-beta", "## v1.2.0-beta\n\nSummary.\n\n### Server\n\n- Alpha");
+    expect(() => composeReleaseNotes({ version: "1.2.0", prereleases: [bare] })).toThrow(
+      /no usable headline/i
+    );
+  });
+
+  it("emits a body the publish gate accepts", () => {
+    const result = composeReleaseNotes({
+      version: "1.2.0",
+      prereleases: [BETA, BETA2],
+      localNotes: LOCAL,
+    });
+    expect(() => processBody(result.body)).not.toThrow();
+    expect(result.body.endsWith("\n")).toBe(true);
+    expect(result.body).not.toMatch(/\n{3,}/);
+  });
+});
+
+describe("retitle", () => {
+  it("points the version heading at the release being cut", () => {
+    expect(retitle("## v1.2.0-beta.2\n\nSummary.", "1.2.0")).toBe("## v1.2.0\n\nSummary.");
+  });
+
+  it("adds a heading to a preamble that has none", () => {
+    expect(retitle("Summary only.", "1.2.0")).toBe("## v1.2.0\n\nSummary only.");
+  });
+});
+
+describe("GitHub reads", () => {
+  /** Stands in for `gh`, keyed on the subcommand shape each call uses. */
+  function fakeGh(statuses: Record<string, string>) {
+    return (args: string[]) => {
+      if (args[0] === "release" && args[1] === "list") {
+        return JSON.stringify([
+          { tagName: "v1.2.0-beta.10", isDraft: false },
+          { tagName: "v1.2.0-beta.2", isDraft: false },
+          { tagName: "v1.2.0-rc.1", isDraft: true },
+          { tagName: "v1.1.44", isDraft: false },
+        ]);
+      }
+      if (args[0] === "release" && args[1] === "view") {
+        return JSON.stringify({ body: `body of ${args[2]}` });
+      }
+      if (args[0] === "api") {
+        const tag = args[1].split("/")[4];
+        if (!(tag in statuses)) throw new Error("no status");
+        return statuses[tag];
+      }
+      throw new Error(`unexpected gh call: ${args.join(" ")}`);
+    };
+  }
+
+  it("reads the headline back off the landing/headline status", () => {
+    const run = fakeGh({ "v1.2.0-beta.2": "First item · Second item\n" });
+    expect(fetchHeadline("db-lyon/ue-mcp", "v1.2.0-beta.2", run)).toEqual([
+      "First item",
+      "Second item",
+    ]);
+  });
+
+  it("treats a tag with no status as contributing no headline", () => {
+    expect(fetchHeadline("db-lyon/ue-mcp", "v1.2.0-beta", fakeGh({}))).toEqual([]);
+  });
+
+  it("returns published prereleases in semver order, skipping drafts", () => {
+    const found = fetchPrereleases("db-lyon/ue-mcp", "1.2.0", fakeGh({}));
+    expect(found.map((r) => r.tag)).toEqual(["v1.2.0-beta.2", "v1.2.0-beta.10"]);
+    expect(found[0].body).toBe("body of v1.2.0-beta.2");
+  });
+});


### PR DESCRIPTION
## Why

Prerelease notes are incremental, which is right: the `1.2.0-beta.3` page should say what changed since `beta.2`. Stable notes written the same way lose everything the betas shipped, because a prerelease never takes the "Latest" badge and never answers `/releases/latest`. Cutting `1.2.0` today would present a few days of work as the whole release.

## What

`scripts/compose-release-notes.mjs`, wired up as `npm run release:notes`.

- Reads every published prerelease of the target `X.Y.Z` through `gh release list` / `gh release view`, ordered by real semver precedence. `v1.2.0-beta.10` is newer than `v1.2.0-beta.2`, which lexical sorting gets backwards.
- Merges the bodies section by section on the `### ` headings already in use (Server, Bug fixes, Internals, Multi-editor, Bridge protocol, and whatever else appears). Heading order is order of first appearance; a section only the newest input has lands at the end.
- Dedupes bullets by exact text and by shared issue or PR number, keeping the longer variant in the earlier position. Dedupe is global rather than per section, since a change that moved from Bug fixes to Server between betas is still one change. Nothing fuzzier is attempted: a bullet that merely reads like another one is kept.
- Unions the headline frontmatter from the `landing/headline` commit statuses, which is the only machine-readable copy once CI has stripped frontmatter from the published body. Truncates to the publish gate's limits and names every dropped item so a human can overrule it.
- Runs its own output through `scripts/release-headline.mjs` before exiting, so a composed body cannot fail the publish gate later.
- A stable release with no prereleases passes its notes file straight through.

Reported on stdout: which releases were merged, every fold with its reason, the headline, any dropped headline item, and a reminder to reread the summary paragraph when it was inherited from a beta.

## Verification

- `tests/unit/compose-release-notes.test.ts`, 38 cases covering ordering, section merging, both dedupe paths, the near-duplicate that must survive, headline union and truncation, and the zero-prerelease passthrough.
- `npx vitest run tests/unit`: 791 passed.
- `npx tsc --noEmit` clean, `npm run audit:em-dash` clean.
- Ran live against `v1.2.0`: merged `v1.2.0-beta`, recovered its five headline items from the commit status, produced a body that passes the gate. No release was created or modified.

No version bump, no tags, no releases, nothing under `plugin/`.
