### PR TITLE
Point anonymous feedback at feedback.ue-mcp.com

### DIFF
--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -144,7 +144,17 @@ The `author` parameter is an enum with two values:
 
 If `author="user"` and no OAuth token is cached, the call returns an `auth_required` directive. Run `npx ue-mcp auth` to authorize, or call with `author="bot"` to post anonymously.
 
-Anonymous reports are signed by a hosted service rather than by this package, so nothing in the install carries a GitHub credential. The report is POSTed to `https://plugins.ue-mcp.com/api/feedback`, and the contract that endpoint implements is: hold the App key server-side, check the destination against ue-mcp core and the trackers of published plugins, rate-limit per caller, then open the issue as `ue-mcp-feedback[bot]`. Point `UE_MCP_FEEDBACK_ENDPOINT` at another origin to use your own.
+Anonymous reports are signed by a hosted service rather than by this package, so nothing in the install carries a GitHub credential. The report is POSTed to `https://feedback.ue-mcp.com`, and the contract that endpoint implements is: hold the App key server-side, check the destination against ue-mcp core and the trackers of published plugins, rate-limit per caller, then open the issue as `ue-mcp-feedback[bot]`.
+
+Two environment variables redirect it, and a fallback covers the rest:
+
+| Variable | Effect |
+| --- | --- |
+| `UE_MCP_FEEDBACK` | Origin of the signing service. Default `https://feedback.ue-mcp.com`, posted to at the root. |
+| `UE_MCP_FEEDBACK_ENDPOINT` | The full URL, when the path differs too. Exact: no other origin is tried. |
+| `UE_MCP_REGISTRY` | Set on its own, that origin's `/api/feedback` is tried first, since a self-hosted deployment is what its operator meant. |
+
+Without either feedback variable the client tries `https://feedback.ue-mcp.com` and then `https://plugins.ue-mcp.com/api/feedback`, which is where the service used to live. The second is only reached when the first does not answer at all (DNS, TLS, timeout, or a gateway page instead of the endpoint). An answer of any kind, including "not configured" or "rate limited", is taken as final, so a report is never filed twice.
 
 If that service is unreachable or turned off, nothing is lost: the call returns the approved body as a prefilled "new issue" URL you can open in one click, and `author="user"` keeps working independently.
 
@@ -238,7 +248,7 @@ The hook handler self-gates: if `feedback` is in `ue-mcp.yml`'s `ue-mcp.disable[
 - **The agent is the adversary for the consent step.** The MCP elicitation prompt is rendered by your client, and the response comes back to the server over the protocol - the agent has no IPC to forge an approval.
 - **The redaction passes are non-bypassable.** They run before the body reaches the elicitation prompt or `submitFeedback`, and the agent never sees the pre-scrubbed bytes.
 - **Routing cannot aim a report at an arbitrary repo.** The `repo` parameter is accepted only for ue-mcp core or a repo a registered plugin owns, and the `Tracker` field on the approval prompt only accepts the two values it offered. There is no path from "an agent wrote a string" to "an issue on any GitHub project".
-- **The package ships no credentials.** `author="user"` posts with a token you authorized yourself through GitHub's device flow, stored under `~/.ue-mcp/`. `author="bot"` posts through a hosted signing service (`POST https://plugins.ue-mcp.com/api/feedback`) whose contract is to hold the `ue-mcp-feedback` App key server-side, apply per-caller rate limits, re-run the redaction pass, and only open issues on ue-mcp core or the tracker of a published plugin. Until a signing key is installed on that deployment the anonymous path hands back a prefilled issue URL instead of posting. Either way there is no key inside the package to extract.
+- **The package ships no credentials.** `author="user"` posts with a token you authorized yourself through GitHub's device flow, stored under `~/.ue-mcp/`. `author="bot"` posts through a hosted signing service (`POST https://feedback.ue-mcp.com`) whose contract is to hold the `ue-mcp-feedback` App key server-side, apply per-caller rate limits, re-run the redaction pass, and only open issues on ue-mcp core or the tracker of a published plugin. Until a signing key is installed on that deployment the anonymous path hands back a prefilled issue URL instead of posting. Either way there is no key inside the package to extract.
 - **Disable the category if you don't want it available.** Add `"feedback"` to `ue-mcp.yml`'s `ue-mcp.disable[]` and the tool is not registered with the MCP server. The category checkbox lives in the **Agent behavior** section of `npx ue-mcp init` (default unchecked on fresh installs).
 
 ## For maintainers

--- a/src/github-app.ts
+++ b/src/github-app.ts
@@ -1,18 +1,46 @@
 import { resolveUserAuth, clearUserAuth, type PendingDeviceFlow } from "./auth.js";
-import { CORE_REPO, registryBase, repoSlug, sameRepo, type GitHubRepo } from "./registry-catalog.js";
+import {
+  CORE_REPO,
+  feedbackBase,
+  registryBase,
+  repoSlug,
+  sameRepo,
+  type GitHubRepo,
+} from "./registry-catalog.js";
 
 /**
- * Hosted signing endpoint for the anonymous bot path.
+ * Hosted signing endpoints for the anonymous bot path, in the order they are
+ * tried.
  *
  * This package holds no GitHub App credential. Anonymous reports are POSTed as
  * plain JSON to the endpoint, which holds the App key in server-side secrets,
- * mints a short-lived installation token, and opens the issue. Overridable so a
- * self-hosted registry (or a local one during development) can serve it.
+ * mints a short-lived installation token, and opens the issue.
+ *
+ * Feedback has its own public name, `feedback.ue-mcp.com`, so it is no longer
+ * addressed through the plugin registry's hostname. The registry path stays as
+ * a fallback for two reasons: a deployment older than that name, or self-hosted,
+ * still answers there, and while DNS for the new name propagates the anonymous
+ * path keeps working instead of going dark.
+ *
+ * Overrides:
+ *   UE_MCP_FEEDBACK_ENDPOINT  full URL. Exact, and the only candidate: an
+ *                             operator who named a URL means that URL, and
+ *                             silently posting somewhere else would be worse
+ *                             than failing.
+ *   UE_MCP_FEEDBACK           origin only, root path.
+ *   UE_MCP_REGISTRY           when set without UE_MCP_FEEDBACK, that self-hosted
+ *                             origin is tried first, since its operator meant
+ *                             their deployment, not the public one.
  */
-function signingEndpoint(): string {
+function signingEndpoints(): string[] {
   const override = process.env.UE_MCP_FEEDBACK_ENDPOINT?.trim();
-  if (override) return override.replace(/\/+$/, "");
-  return `${registryBase()}/api/feedback`;
+  if (override) return [override.replace(/\/+$/, "")];
+
+  const hosted = `${feedbackBase()}/`;
+  const viaRegistry = `${registryBase()}/api/feedback`;
+  const selfHostedRegistry = Boolean(process.env.UE_MCP_REGISTRY?.trim());
+  const ordered = selfHostedRegistry ? [viaRegistry, hosted] : [hosted, viaRegistry];
+  return ordered.filter((url, i) => ordered.indexOf(url) === i);
 }
 
 /** The signing endpoint should answer in well under this; a slow one is a dead one. */
@@ -86,6 +114,20 @@ interface SigningResponse {
 }
 
 /**
+ * One attempt against one endpoint.
+ *
+ * `endpointMissing` separates "there is no signing service at this URL" from
+ * "the signing service answered". Only the first is worth retrying elsewhere:
+ * a service that replied not-configured, rate-limited, or refused-destination
+ * has given a real answer, and asking a different host the same question would
+ * either duplicate the report or contradict the operator's intent.
+ */
+interface SigningAttempt {
+  result: SubmitResult;
+  endpointMissing: boolean;
+}
+
+/**
  * Anonymous bot path.
  *
  * No credential is involved on this side: the body goes to the hosted signing
@@ -93,13 +135,13 @@ interface SigningResponse {
  * is an outcome the caller can act on (file as the user, or open the prefilled
  * URL), so the only thing thrown here is a genuinely unexpected response shape.
  */
-async function submitAsBot(
+async function attemptSigning(
+  endpoint: string,
   title: string,
   body: string,
   labels: string[],
   repo: GitHubRepo,
-): Promise<SubmitResult> {
-  const endpoint = signingEndpoint();
+): Promise<SigningAttempt> {
   let res: Response;
   try {
     res = await fetch(endpoint, {
@@ -113,10 +155,14 @@ async function submitAsBot(
       signal: AbortSignal.timeout(SIGNING_TIMEOUT_MS),
     });
   } catch (e) {
+    // DNS, TLS, timeout: nothing answered, so another origin is worth a try.
     return {
-      kind: "bot_unavailable",
-      code: "unreachable",
-      message: `Could not reach the feedback signing service at ${endpoint} (${e instanceof Error ? e.message : String(e)}).`,
+      endpointMissing: true,
+      result: {
+        kind: "bot_unavailable",
+        code: "unreachable",
+        message: `Could not reach the feedback signing service at ${endpoint} (${e instanceof Error ? e.message : String(e)}).`,
+      },
     };
   }
 
@@ -129,12 +175,15 @@ async function submitAsBot(
 
   if (res.ok && payload.url && typeof payload.number === "number") {
     return {
-      kind: "submitted",
-      url: payload.url,
-      number: payload.number,
-      authoredBy: payload.authoredBy ?? "ue-mcp-feedback[bot]",
-      authoredAs: "bot",
-      repo: payload.repo ?? repoSlug(repo),
+      endpointMissing: false,
+      result: {
+        kind: "submitted",
+        url: payload.url,
+        number: payload.number,
+        authoredBy: payload.authoredBy ?? "ue-mcp-feedback[bot]",
+        authoredAs: "bot",
+        repo: payload.repo ?? repoSlug(repo),
+      },
     };
   }
 
@@ -142,44 +191,99 @@ async function submitAsBot(
   // callers' existing recovery (prefilled URL, or re-file on core) applies.
   if (payload.code === "repo_unavailable" || payload.code === "repo_not_allowed") {
     return {
-      kind: "repo_unavailable",
-      repo: repoSlug(repo),
-      status: payload.status ?? res.status,
-      message: (payload.error ?? "The tracker refused the issue.").slice(0, 300),
+      endpointMissing: false,
+      result: {
+        kind: "repo_unavailable",
+        repo: repoSlug(repo),
+        status: payload.status ?? res.status,
+        message: (payload.error ?? "The tracker refused the issue.").slice(0, 300),
+      },
     };
   }
 
-  if (res.status === 503 || payload.code === "signing_not_configured") {
+  if (payload.code === "signing_not_configured") {
     return {
-      kind: "bot_unavailable",
-      code: "not_configured",
-      message: payload.error ?? "Anonymous feedback signing is not enabled on this deployment.",
-    };
-  }
-
-  // A bare 404 is the endpoint not existing at this origin, not a tracker
-  // saying no. Report it as the anonymous path being off.
-  if (res.status === 404 && !payload.code) {
-    return {
-      kind: "bot_unavailable",
-      code: "not_configured",
-      message: `No feedback signing service at ${endpoint}.`,
+      endpointMissing: false,
+      result: {
+        kind: "bot_unavailable",
+        code: "not_configured",
+        message: payload.error ?? "Anonymous feedback signing is not enabled on this deployment.",
+      },
     };
   }
 
   if (res.status === 429 || payload.code === "rate_limited") {
     return {
-      kind: "bot_unavailable",
-      code: "rate_limited",
-      message: payload.error ?? "Too many anonymous submissions from here recently.",
-      retryAfter: payload.retry_after ?? (Number(res.headers.get("retry-after")) || undefined),
+      endpointMissing: false,
+      result: {
+        kind: "bot_unavailable",
+        code: "rate_limited",
+        message: payload.error ?? "Too many anonymous submissions from here recently.",
+        retryAfter: payload.retry_after ?? (Number(res.headers.get("retry-after")) || undefined),
+      },
+    };
+  }
+
+  /**
+   * Nothing recognisable came back. A 404 or 405 is the endpoint not existing
+   * at this origin, and a 5xx with no code of ours is a proxy or a cold
+   * deployment answering instead of the handler. Neither is a tracker saying
+   * no, so report the anonymous path as off and let the caller try the next
+   * origin.
+   */
+  if (!payload.code && (res.status === 404 || res.status === 405 || res.status >= 500)) {
+    return {
+      endpointMissing: true,
+      result: {
+        kind: "bot_unavailable",
+        code: "not_configured",
+        message: `No feedback signing service at ${endpoint}.`,
+      },
     };
   }
 
   return {
+    endpointMissing: false,
+    result: {
+      kind: "bot_unavailable",
+      code: "rejected",
+      message: `${payload.error ?? "The feedback signing service rejected the submission."} (HTTP ${res.status})`,
+    },
+  };
+}
+
+/**
+ * Try each known signing origin until one of them actually answers.
+ *
+ * The report itself is never at risk here: every branch below is an outcome the
+ * caller can act on, so an offline service ends with a prefilled issue URL in
+ * the user's hands rather than an exception.
+ */
+async function submitAsBot(
+  title: string,
+  body: string,
+  labels: string[],
+  repo: GitHubRepo,
+): Promise<SubmitResult> {
+  const endpoints = signingEndpoints();
+  const missed: SubmitResult[] = [];
+
+  for (const endpoint of endpoints) {
+    const attempt = await attemptSigning(endpoint, title, body, labels, repo);
+    if (!attempt.endpointMissing) return attempt.result;
+    missed.push(attempt.result);
+  }
+
+  // One candidate: keep the original, more specific outcome.
+  if (missed.length === 1) return missed[0];
+
+  // Every origin came up empty. Name them all, because the usual cause is a
+  // host that has not resolved yet and the user can see that from the message.
+  const allUnreachable = missed.every((r) => r.kind === "bot_unavailable" && r.code === "unreachable");
+  return {
     kind: "bot_unavailable",
-    code: "rejected",
-    message: `${payload.error ?? "The feedback signing service rejected the submission."} (HTTP ${res.status})`,
+    code: allUnreachable ? "unreachable" : "not_configured",
+    message: `No feedback signing service answered at ${endpoints.join(" or ")}.`,
   };
 }
 

--- a/src/registry-catalog.ts
+++ b/src/registry-catalog.ts
@@ -48,6 +48,21 @@ export function registryBase(): string {
   return (process.env.UE_MCP_REGISTRY ?? "https://plugins.ue-mcp.com").replace(/\/+$/, "");
 }
 
+/**
+ * Origin of the anonymous feedback signing service.
+ *
+ * Separate from the registry on purpose. Feedback about ue-mcp core has nothing
+ * to do with the plugin catalog, and addressing it through the catalog's
+ * hostname tied two unrelated surfaces together. Both names happen to be served
+ * by the same deployment today, which is an operational detail, not a contract.
+ *
+ * `UE_MCP_FEEDBACK` overrides the origin; `UE_MCP_FEEDBACK_ENDPOINT` (read in
+ * src/github-app.ts) overrides the full URL when the path differs too.
+ */
+export function feedbackBase(): string {
+  return (process.env.UE_MCP_FEEDBACK ?? "https://feedback.ue-mcp.com").replace(/\/+$/, "");
+}
+
 /** `https://github.com/db-lyon/pie-studio(.git)` -> `{owner, repo}`. */
 export function parseGitHubRepo(url: string | null | undefined): GitHubRepo | null {
   if (!url) return null;

--- a/tests/unit/feedback-signing.test.ts
+++ b/tests/unit/feedback-signing.test.ts
@@ -14,8 +14,14 @@ const { submitFeedback } = await import("../../src/github-app.js");
 const REPO = { owner: "db-lyon", repo: "ue-mcp" };
 const ENDPOINT = "https://signing.example.test/api/feedback";
 
+/** The two origins tried by default, in order. */
+const FEEDBACK_HOST = "https://feedback.ue-mcp.com/";
+const REGISTRY_PATH = "https://plugins.ue-mcp.com/api/feedback";
+
 const originalFetch = globalThis.fetch;
 const originalEndpointEnv = process.env.UE_MCP_FEEDBACK_ENDPOINT;
+const originalFeedbackEnv = process.env.UE_MCP_FEEDBACK;
+const originalRegistryEnv = process.env.UE_MCP_REGISTRY;
 
 function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -29,6 +35,8 @@ describe("anonymous feedback goes through the hosted signing service", () => {
 
   beforeEach(() => {
     process.env.UE_MCP_FEEDBACK_ENDPOINT = ENDPOINT;
+    delete process.env.UE_MCP_FEEDBACK;
+    delete process.env.UE_MCP_REGISTRY;
     fetchMock.mockReset();
     globalThis.fetch = fetchMock as unknown as typeof fetch;
   });
@@ -37,6 +45,10 @@ describe("anonymous feedback goes through the hosted signing service", () => {
     globalThis.fetch = originalFetch;
     if (originalEndpointEnv === undefined) delete process.env.UE_MCP_FEEDBACK_ENDPOINT;
     else process.env.UE_MCP_FEEDBACK_ENDPOINT = originalEndpointEnv;
+    if (originalFeedbackEnv === undefined) delete process.env.UE_MCP_FEEDBACK;
+    else process.env.UE_MCP_FEEDBACK = originalFeedbackEnv;
+    if (originalRegistryEnv === undefined) delete process.env.UE_MCP_REGISTRY;
+    else process.env.UE_MCP_REGISTRY = originalRegistryEnv;
   });
 
   it("posts the report to the endpoint and sends no credential", async () => {
@@ -142,16 +154,125 @@ describe("anonymous feedback goes through the hosted signing service", () => {
     expect(result.status).toBe(403);
   });
 
-  it("defaults to the registry origin when no endpoint override is set", async () => {
-    delete process.env.UE_MCP_FEEDBACK_ENDPOINT;
-    fetchMock.mockResolvedValue(
-      jsonResponse(201, { ok: true, url: "https://example.test/issues/1", number: 1 }),
-    );
+  it("stops at the named endpoint when one was named, rather than trying another host", async () => {
+    fetchMock.mockResolvedValue(new Response("<html>not found</html>", { status: 404 }));
 
     await submitFeedback("A title", "A body", [], { useBot: true, repo: REPO });
 
-    const [url] = fetchMock.mock.calls[0] as [string];
-    expect(url).toBe("https://plugins.ue-mcp.com/api/feedback");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0] as [string])[0]).toBe(ENDPOINT);
+  });
+});
+
+/**
+ * Feedback has its own public name. The registry path is kept behind it so a
+ * deployment that predates the name, or a self-hosted one, still works, and so
+ * a client does not go dark while DNS for the new host propagates.
+ */
+describe("which signing origin gets asked", () => {
+  const fetchMock = vi.fn();
+
+  const created = () =>
+    jsonResponse(201, { ok: true, url: "https://example.test/issues/1", number: 1 });
+
+  beforeEach(() => {
+    delete process.env.UE_MCP_FEEDBACK_ENDPOINT;
+    delete process.env.UE_MCP_FEEDBACK;
+    delete process.env.UE_MCP_REGISTRY;
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEndpointEnv === undefined) delete process.env.UE_MCP_FEEDBACK_ENDPOINT;
+    else process.env.UE_MCP_FEEDBACK_ENDPOINT = originalEndpointEnv;
+    if (originalFeedbackEnv === undefined) delete process.env.UE_MCP_FEEDBACK;
+    else process.env.UE_MCP_FEEDBACK = originalFeedbackEnv;
+    if (originalRegistryEnv === undefined) delete process.env.UE_MCP_REGISTRY;
+    else process.env.UE_MCP_REGISTRY = originalRegistryEnv;
+  });
+
+  const urlsCalled = () => fetchMock.mock.calls.map((c) => (c as [string])[0]);
+
+  it("posts to the feedback host by default", async () => {
+    fetchMock.mockResolvedValue(created());
+
+    await submitFeedback("A title", "A body", [], { useBot: true, repo: REPO });
+
+    expect(urlsCalled()).toEqual([FEEDBACK_HOST]);
+  });
+
+  it("falls back to the registry path when the feedback host does not resolve", async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error("getaddrinfo ENOTFOUND feedback.ue-mcp.com"))
+      .mockResolvedValueOnce(created());
+
+    const result = await submitFeedback("A title", "A body", [], { useBot: true, repo: REPO });
+
+    expect(urlsCalled()).toEqual([FEEDBACK_HOST, REGISTRY_PATH]);
+    expect(result.kind).toBe("submitted");
+  });
+
+  it("falls back when the feedback host answers with something other than the endpoint", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response("<html>bad gateway</html>", { status: 502 }))
+      .mockResolvedValueOnce(created());
+
+    const result = await submitFeedback("A title", "A body", [], { useBot: true, repo: REPO });
+
+    expect(urlsCalled()).toEqual([FEEDBACK_HOST, REGISTRY_PATH]);
+    expect(result.kind).toBe("submitted");
+  });
+
+  it("accepts a real answer from the first host instead of asking the second", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(503, { error: "not configured here", code: "signing_not_configured" }),
+    );
+
+    const result = await submitFeedback("A title", "A body", [], { useBot: true, repo: REPO });
+
+    expect(urlsCalled()).toEqual([FEEDBACK_HOST]);
+    expect(result.kind).toBe("bot_unavailable");
+  });
+
+  it("does not double-post when the first host rate limits the caller", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(429, { code: "rate_limited", retry_after: 600 }));
+
+    await submitFeedback("A title", "A body", [], { useBot: true, repo: REPO });
+
+    expect(urlsCalled()).toEqual([FEEDBACK_HOST]);
+  });
+
+  it("names both origins, and still degrades gracefully, when neither answers", async () => {
+    fetchMock.mockRejectedValue(new Error("getaddrinfo ENOTFOUND"));
+
+    const result = await submitFeedback("A title", "A body", [], { useBot: true, repo: REPO });
+
+    expect(urlsCalled()).toEqual([FEEDBACK_HOST, REGISTRY_PATH]);
+    expect(result.kind).toBe("bot_unavailable");
+    if (result.kind !== "bot_unavailable") throw new Error("unreachable");
+    expect(result.code).toBe("unreachable");
+    expect(result.message).toContain(FEEDBACK_HOST);
+    expect(result.message).toContain(REGISTRY_PATH);
+  });
+
+  it("honours UE_MCP_FEEDBACK as the origin", async () => {
+    process.env.UE_MCP_FEEDBACK = "https://feedback.local.test/";
+    fetchMock.mockResolvedValue(created());
+
+    await submitFeedback("A title", "A body", [], { useBot: true, repo: REPO });
+
+    expect(urlsCalled()[0]).toBe("https://feedback.local.test/");
+  });
+
+  it("asks a self-hosted registry first when only UE_MCP_REGISTRY is set", async () => {
+    process.env.UE_MCP_REGISTRY = "https://registry.internal.test";
+    fetchMock.mockResolvedValue(created());
+
+    await submitFeedback("A title", "A body", [], { useBot: true, repo: REPO });
+
+    expect(urlsCalled()).toEqual(["https://registry.internal.test/api/feedback"]);
   });
 });
 


### PR DESCRIPTION
Client half of moving the anonymous feedback endpoint off the plugin registry's
hostname. Server half is db-lyon/ue-mcp-marketplace#2.

## What changed

- `feedbackBase()` in `src/registry-catalog.ts`: its own origin, default
  `https://feedback.ue-mcp.com`, overridable with `UE_MCP_FEEDBACK` (matching
  the `UE_MCP_REGISTRY` convention). `signingEndpoint()` used to derive the URL
  from `registryBase()`, which conflated two unrelated surfaces.
- `src/github-app.ts` now walks a candidate list instead of a single URL.

## Order and failure behaviour

| Environment | Tried, in order |
| --- | --- |
| default | `https://feedback.ue-mcp.com/` then `https://plugins.ue-mcp.com/api/feedback` |
| `UE_MCP_FEEDBACK` set | that origin's root, then the registry path |
| `UE_MCP_REGISTRY` set alone | that origin's `/api/feedback` first, then the public feedback host |
| `UE_MCP_FEEDBACK_ENDPOINT` set | that exact URL, and nothing else |

The second candidate is reached only when the first does not answer at all:
transport failure (DNS, TLS, timeout), or a 404/405/5xx carrying none of the
endpoint's own JSON codes, which is a proxy or a cold deploy rather than the
handler. Every real answer is final, including `signing_not_configured`,
`rate_limited`, and `repo_not_allowed`, so a report cannot be filed twice.

That keeps the anonymous path alive while DNS for the new host propagates, and
keeps older and self-hosted deployments working.

Graceful degradation is intact: every branch still returns an outcome the caller
acts on, so an offline signing service ends with a prefilled issue URL rather
than an exception.

## Verification

- `npx tsc --noEmit` clean.
- `npx vitest run tests/unit`: 761 passing, including 8 new cases pinning the
  candidate order, both fallback triggers, and the no-double-post rule.
- `docs/feedback.md` updated: new host, the three variables, and the fallback
  rule stated so a failed submission is not ambiguous.

No version bump, no tag. The endpoint is reachable through the registry path
until the owner adds the DNS record described in the marketplace PR.