### PR TITLE
Fix the three failures the live tier found against a real editor

### DIFF
--- a/docs/flows.md
+++ b/docs/flows.md
@@ -30,6 +30,8 @@ flow(action="run", flowName="build_and_check")
 
 That's it. The config is **hot-reloaded on every call** - edit the YAML and run again without restarting the MCP server.
 
+The response carries a `summary` line per step plus a `steps` array holding what each step answered, so an action called inside a flow returns the same data it returns when called directly.
+
 ## Concepts
 
 ### Tasks
@@ -339,7 +341,7 @@ Filter to a specific run with `?runId=<id>`. The runId is returned in the `flow(
 | `step_failed` | When a step errors (in addition to `step_completed`) | `runId`, `flowName`, `step`, `error: { message, name }`, `timestamp` |
 | `run_completed` | After the whole flow finishes (including hook phases + rollback) | `runId`, `flowName`, `success`, `duration`, `stepCount`, `failedStep?`, `timestamp` |
 
-`step_completed` deliberately omits `result.data` because shell outputs and CSV rows can be large. The full data is in the `flow.run` response or in handler returns. If you need live stdout from a long-running shell step, the `shell` task streams chunks through the task logger - that's a separate channel from the SSE event bus.
+`step_completed` deliberately omits `result.data` because shell outputs and CSV rows can be large. The full data is in the `steps` array of the `flow.run` response. If you need live stdout from a long-running shell step, the `shell` task streams chunks through the task logger - that's a separate channel from the SSE event bus.
 
 Keepalive comment lines (`: keepalive <ts>`) fire every 30s during quiet periods so proxies and load balancers don't drop the connection.
 

--- a/src/deployer.ts
+++ b/src/deployer.ts
@@ -64,9 +64,17 @@ export function deploySummary(r: DeployResult): string {
  * Unlike `deploy()`, this NEVER overwrites bridge source under
  * `Plugins/UE_MCP_Bridge/Source/` - so local forks/edits and
  * project-tracked bridge revisions are preserved. It only:
+ *   - detects whether the bridge plugin is installed in the project
  *   - ensures PythonScriptPlugin is listed in the .uproject
  *   - ensures UE_MCP_Bridge is listed in the .uproject
  *   - reports plugin presence + version for a warning-level check
+ *
+ * Detection comes first, and a project without the plugin installed is
+ * left byte-identical. Enabling a plugin that is not on disk turns the
+ * project's next launch in Unreal into a missing-plugin prompt, and
+ * PythonScriptPlugin is only enabled here because the bridge's
+ * `execute_python` handler needs it, so it has no reason to be written
+ * into a project the bridge is absent from.
  *
  * If the plugin is missing or a version mismatch is detected, callers
  * should surface that to the user and ask them to run `ue-mcp init`
@@ -84,9 +92,6 @@ export function attach(context: ProjectContext): AttachResult {
 
   try {
     const uprojectPath = context.projectPath!;
-    result.pythonPluginEnabled = ensurePythonPlugin(uprojectPath);
-    result.cppPluginEnabled = ensureCppPluginEnabled(uprojectPath);
-
     const projectDir = path.dirname(uprojectPath);
     const installedUplugin = path.join(
       projectDir,
@@ -94,6 +99,7 @@ export function attach(context: ProjectContext): AttachResult {
       "UE_MCP_Bridge",
       "UE_MCP_Bridge.uplugin",
     );
+
     result.cppPluginPresent = fs.existsSync(installedUplugin);
     result.installedVersion = readUpluginVersion(installedUplugin);
     result.packagedVersion = readUpluginVersion(packagedUpluginPath());
@@ -101,6 +107,11 @@ export function attach(context: ProjectContext): AttachResult {
     if (result.installedVersion && result.packagedVersion) {
       result.versionMatch = result.installedVersion === result.packagedVersion;
     }
+
+    if (!result.cppPluginPresent) return result;
+
+    result.pythonPluginEnabled = ensurePythonPlugin(uprojectPath);
+    result.cppPluginEnabled = ensureCppPluginEnabled(uprojectPath);
   } catch (e) {
     result.error = e instanceof Error ? e.message : String(e);
   }

--- a/src/flow/events.ts
+++ b/src/flow/events.ts
@@ -31,8 +31,9 @@ export type FlowEvent =
       flowName: string;
       step: PlanStep;
       // Trimmed: drops result.data (which can be large - shell outputs,
-      // CSV rows, etc.). Subscribers that need the full data should pull
-      // from the final run_completed event or the flow.run response.
+      // CSV rows, etc.). Subscribers that need the full data read it from
+      // the `steps` array of the flow.run response, which carries each
+      // step's data untouched.
       result: {
         success: boolean;
         skipped: boolean;

--- a/src/flow/flow-tool.ts
+++ b/src/flow/flow-tool.ts
@@ -338,6 +338,25 @@ function formatFlowResult(result: FlowRunResult): Record<string, unknown> {
     duration: result.duration,
     stepCount: result.steps.length,
     failedStep: result.steps.find((s) => s.result?.success === false)?.name,
+    // What each step answered. The per-step events carry no data by design
+    // (an SSE subscriber does not want a shell log or an asset listing pushed
+    // at it), which left the run response as the only place the data could
+    // arrive, and it was dropping it too: a flow that read anything returned a
+    // summary line and nothing else, so the same action was strictly less
+    // useful inside a flow than called directly.
+    steps: result.steps.map((s) => ({
+      stepNumber: s.stepNumber,
+      name: s.name,
+      type: s.type,
+      skipped: s.skipped,
+      success: s.result?.success ?? false,
+      duration: s.duration,
+      attempts: s.attempts,
+      error: s.result?.error
+        ? { message: s.result.error.message, name: s.result.error.name }
+        : undefined,
+      data: s.result?.data,
+    })),
     rollback: result.rollback,
     hookErrors: result.hookErrors,
   };

--- a/src/project.ts
+++ b/src/project.ts
@@ -77,13 +77,27 @@ export interface UeMcpConfig {
 }
 
 /**
+ * True when a path names a `.uproject` file, whatever case the extension is
+ * written in.
+ *
+ * The extension is the only thing telling a project file from the directory
+ * holding one, and every other project-keyed part of the server folds case
+ * (the session key, the derived bridge port, the lockfile path). Reading it
+ * case-sensitively here made `C:\PROJ\GAME.UPROJECT` resolve as a directory,
+ * which fails as "project directory not found" on a path that exists.
+ */
+export function isUProjectPath(candidate: string): boolean {
+  return path.extname(candidate).toLowerCase() === ".uproject";
+}
+
+/**
  * Resolve a user-supplied path (a .uproject, or a directory holding one) to an
  * absolute .uproject path. Pure: it touches no state, so a caller that has to
  * move several things at once can validate the target first and leave
  * everything where it was when the path is bad.
  */
 export function resolveUProjectPath(inputPath: string): string {
-  if (inputPath.endsWith(".uproject")) {
+  if (isUProjectPath(inputPath)) {
     const resolved = path.resolve(inputPath);
     if (!fs.existsSync(resolved)) {
       throw new McpError(ErrorCode.NOT_FOUND, `No .uproject file at ${resolved}`);
@@ -97,7 +111,7 @@ export function resolveUProjectPath(inputPath: string): string {
   } catch {
     throw new McpError(ErrorCode.NOT_FOUND, `Project directory not found: ${inputPath}`);
   }
-  const files = entries.filter((f) => f.endsWith(".uproject"));
+  const files = entries.filter(isUProjectPath);
   if (files.length === 0) {
     throw new McpError(ErrorCode.NOT_FOUND, `No .uproject file found in ${inputPath}`);
   }
@@ -132,7 +146,10 @@ export class ProjectContext {
 
   setProject(inputPath: string): void {
     this.projectPath = resolveUProjectPath(inputPath);
-    this.projectName = path.basename(this.projectPath, ".uproject");
+    // Strip whatever case the extension actually carries: basename() compares
+    // the suffix byte for byte, so a hardcoded ".uproject" leaves the whole
+    // "Game.UPROJECT" standing as the project name.
+    this.projectName = path.basename(this.projectPath, path.extname(this.projectPath));
     this.contentDir = path.join(path.dirname(this.projectPath), "Content");
     // The cache is keyed to nothing but the process, so a switch would keep
     // resolving /MyPlugin/ paths against the project we just left.

--- a/tests/live/matrix.ts
+++ b/tests/live/matrix.ts
@@ -385,7 +385,14 @@ export const SINGLE_EDITOR_CHANGES: MatrixCase[] = [
   {
     id: "flow-context-complete",
     text: "Flows receive the full context: elicit, getFlows, getPlugins.",
-    coverage: [{ kind: "live", file: LIVE_SINGLE, title: "hands a flow the whole context, including flows and plugins" }],
+    coverage: [
+      { kind: "live", file: LIVE_SINGLE, title: "hands a flow the whole context, including flows and plugins" },
+      {
+        kind: "engine-free",
+        file: "tests/unit/flow-run-result.test.ts",
+        title: "hands the step the accessors the context had, not a rebuilt subset",
+      },
+    ],
   },
   {
     id: "default-config-categories",

--- a/tests/live/matrix.ts
+++ b/tests/live/matrix.ts
@@ -241,7 +241,14 @@ export const SINGLE_EDITOR_CHANGES: MatrixCase[] = [
   {
     id: "attach-no-dangling-entry",
     text: "attach() no longer writes a dangling .uproject entry for an absent bridge.",
-    coverage: [{ kind: "live", file: LIVE_SINGLE, title: "writes no dangling plugin entry into a project that has no bridge" }],
+    coverage: [
+      { kind: "live", file: LIVE_SINGLE, title: "writes no dangling plugin entry into a project that has no bridge" },
+      {
+        kind: "engine-free",
+        file: "tests/unit/deployer-attach.test.ts",
+        title: "writes nothing into a project that has no bridge installed",
+      },
+    ],
   },
   {
     id: "staleness-against-package",

--- a/tests/live/matrix.ts
+++ b/tests/live/matrix.ts
@@ -114,6 +114,16 @@ export const MATRIX_CASES: MatrixCase[] = [
         title: "records sessions that collapse onto one port, because they cannot be told apart",
       },
       {
+        kind: "engine-free",
+        file: "tests/unit/session.test.ts",
+        title: "folds the case of the path and of the extension, where the filesystem does",
+      },
+      {
+        kind: "engine-free",
+        file: "tests/unit/session.test.ts",
+        title: "keeps projects that differ by more than spelling apart",
+      },
+      {
         kind: "cpp",
         reason:
           "two editors of one project binding two ports is a socket-exclusivity result (plan 0.2), and " +

--- a/tests/unit/deployer-attach.test.ts
+++ b/tests/unit/deployer-attach.test.ts
@@ -1,0 +1,107 @@
+/**
+ * attach() on server startup, engine-free (#817).
+ *
+ * attach is the one thing the server does to a project before anybody asks it
+ * to do anything, so what it writes matters more than what it reports. A
+ * project that does not have the bridge installed has to come back out of it
+ * byte for byte: enabling a plugin that is not on disk turns that project's
+ * next launch in Unreal into a missing-plugin prompt, on a project the user
+ * only pointed at.
+ *
+ * The live tier asserts the same property against the real test project
+ * (tests/live/single-editor.test.ts); this is the half that needs no editor.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { attach } from "../../src/deployer.js";
+import { ProjectContext } from "../../src/project.js";
+
+let root: string;
+
+function makeProject(name: string): string {
+  const dir = path.join(root, name);
+  fs.mkdirSync(dir, { recursive: true });
+  const uproject = path.join(dir, `${name}.uproject`);
+  fs.writeFileSync(
+    uproject,
+    JSON.stringify({ FileVersion: 3, EngineAssociation: "5.6" }, null, 2),
+    "utf-8",
+  );
+  return uproject;
+}
+
+/** Put a plugin descriptor where attach looks for the installed bridge. */
+function installBridge(uproject: string, version: string): void {
+  const dir = path.join(path.dirname(uproject), "Plugins", "UE_MCP_Bridge");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "UE_MCP_Bridge.uplugin"),
+    JSON.stringify({ FileVersion: 3, VersionName: version, FriendlyName: "UE MCP Bridge" }, null, 2),
+    "utf-8",
+  );
+}
+
+function contextFor(uproject: string): ProjectContext {
+  const context = new ProjectContext();
+  context.setProject(uproject);
+  return context;
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-attach-"));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("attach", () => {
+  it("writes nothing into a project that has no bridge installed", () => {
+    const uproject = makeProject("NoBridge");
+    const before = fs.readFileSync(uproject, "utf-8");
+
+    const result = attach(contextFor(uproject));
+
+    expect(result.cppPluginPresent).toBe(false);
+    expect(result.cppPluginEnabled).toBe(false);
+    expect(result.pythonPluginEnabled).toBe(false);
+    expect(fs.readFileSync(uproject, "utf-8")).toBe(before);
+    expect(fs.readFileSync(uproject, "utf-8")).not.toContain("UE_MCP_Bridge");
+    // Still reports what it found, which is what the startup warning reads.
+    expect(result.packagedVersion).toBeTruthy();
+    expect(result.installedVersion).toBeNull();
+  });
+
+  it("enables the plugins once the bridge is really there", () => {
+    const uproject = makeProject("WithBridge");
+    installBridge(uproject, "9.9.9");
+
+    const result = attach(contextFor(uproject));
+
+    expect(result.cppPluginPresent).toBe(true);
+    expect(result.cppPluginEnabled).toBe(true);
+    expect(result.pythonPluginEnabled).toBe(true);
+    const written = JSON.parse(fs.readFileSync(uproject, "utf-8")) as {
+      Plugins: Array<{ Name: string; Enabled: boolean }>;
+    };
+    expect(written.Plugins.map((p) => p.Name)).toContain("UE_MCP_Bridge");
+    expect(written.Plugins.map((p) => p.Name)).toContain("PythonScriptPlugin");
+    expect(result.installedVersion).toBe("9.9.9");
+    expect(result.versionMatch).toBe(false);
+  });
+
+  it("leaves an already-configured project byte-identical", () => {
+    const uproject = makeProject("Configured");
+    installBridge(uproject, "9.9.9");
+    attach(contextFor(uproject));
+    const before = fs.readFileSync(uproject, "utf-8");
+
+    const again = attach(contextFor(uproject));
+
+    expect(again.cppPluginEnabled).toBe(false);
+    expect(again.pythonPluginEnabled).toBe(false);
+    expect(fs.readFileSync(uproject, "utf-8")).toBe(before);
+  });
+});

--- a/tests/unit/flow-run-result.test.ts
+++ b/tests/unit/flow-run-result.test.ts
@@ -1,0 +1,121 @@
+/**
+ * What a flow run hands back, engine-free (#817).
+ *
+ * Two properties, and they only mean something together:
+ *
+ *  1. A step sees the whole tool context. `makeRunner` spreads the context it
+ *     was given rather than rebuilding it field by field, which used to drop
+ *     `elicit`, `getFlows`, `getPlugins` and the editor session, so an action
+ *     called inside a flow saw a different server than the same action called
+ *     directly.
+ *  2. The run response carries what each step answered. Without that, the
+ *     first property is unobservable from outside, and a flow that reads
+ *     anything returns a summary line and no data at all.
+ *
+ * The live tier asserts the same pair against a real editor
+ * (tests/live/single-editor.test.ts, "hands a flow the whole context").
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { FlowConfigSchema, type FlowConfig } from "../../src/flow/schema.js";
+import { buildFlowRegistry } from "../../src/flow/registry.js";
+import { createFlowTool } from "../../src/flow/flow-tool.js";
+import { categoryTool, type ToolContext } from "../../src/types.js";
+import { ProjectContext } from "../../src/project.js";
+import type { IBridge } from "../../src/bridge.js";
+
+const bridge: IBridge = {
+  isConnected: false,
+  connect: async () => {},
+  retargetProject: () => ({ projectPath: null, port: 0, portSource: "default" as const, verified: true }),
+  getTarget: () => ({ projectPath: null, port: 0, portSource: "default" as const, verified: true }),
+  call: async () => ({}),
+};
+
+/** Reports the accessors it can see, which is the whole point of the probe. */
+const probeTool = categoryTool(
+  "probe",
+  "Test-only category that reports what the context handed it.",
+  {
+    context: {
+      description: "Report the context accessors this call was given.",
+      handler: async (ctx) => ({
+        flows: ctx.getFlows?.().map((f) => f.name) ?? null,
+        plugins: ctx.getPlugins?.().map((p) => p.name) ?? null,
+        canElicit: typeof ctx.elicit === "function",
+      }),
+    },
+  },
+  undefined,
+  { note: z.string().optional() } as Record<string, z.ZodType>,
+);
+
+const FLOWS = [{ name: "context_probe", description: "asks the context what it is" }];
+
+function contextWithAccessors(): ToolContext {
+  return {
+    bridge,
+    project: new ProjectContext(),
+    getFlows: () => FLOWS,
+    getPlugins: () => [{ name: "ue-mcp-example", active: true }] as never,
+    elicit: async () => ({ action: "decline" as const }),
+  };
+}
+
+function config(): FlowConfig {
+  return FlowConfigSchema.parse({
+    "ue-mcp": { version: 1 },
+    flows: {
+      context_probe: {
+        description: "asks the context what it is",
+        steps: { "1": { task: "probe.context" } },
+      },
+    },
+  });
+}
+
+async function runProbe(ctx: ToolContext): Promise<Record<string, unknown>> {
+  const flowTool = createFlowTool(buildFlowRegistry([probeTool]), () => config());
+  const result = await flowTool.handler(ctx, { action: "run", flowName: "context_probe" });
+  return result as Record<string, unknown>;
+}
+
+interface RunResponse {
+  success: boolean;
+  steps: Array<{
+    name: string;
+    success: boolean;
+    data?: { flows?: string[] | null; plugins?: string[] | null; canElicit?: boolean };
+  }>;
+}
+
+describe("flow run result", () => {
+  it("carries every step's data, so what the step answered is readable", async () => {
+    const body = (await runProbe(contextWithAccessors())) as unknown as RunResponse;
+
+    expect(body.success).toBe(true);
+    expect(body.steps).toHaveLength(1);
+    expect(body.steps[0].success).toBe(true);
+    expect(body.steps[0].data).toBeTruthy();
+  });
+
+  it("hands the step the accessors the context had, not a rebuilt subset", async () => {
+    const body = (await runProbe(contextWithAccessors())) as unknown as RunResponse;
+    const data = body.steps[0].data!;
+
+    expect(data.flows).toEqual(["context_probe"]);
+    expect(data.plugins).toEqual(["ue-mcp-example"]);
+    expect(data.canElicit).toBe(true);
+  });
+
+  it("reports the absence of an accessor as absence, not as an empty answer", async () => {
+    // A context genuinely without them still runs: the flow path adds nothing
+    // and takes nothing away.
+    const bare: ToolContext = { bridge, project: new ProjectContext() };
+    const body = (await runProbe(bare)) as unknown as RunResponse;
+
+    expect(body.success).toBe(true);
+    expect(body.steps[0].data!.flows).toBeNull();
+    expect(body.steps[0].data!.canElicit).toBe(false);
+  });
+});

--- a/tests/unit/session.test.ts
+++ b/tests/unit/session.test.ts
@@ -58,6 +58,46 @@ describe("SessionRegistry", () => {
     expect(registry.size).toBe(1);
   });
 
+  it("folds the case of the path and of the extension, where the filesystem does", () => {
+    // Windows and macOS hand the same file back for either spelling, so two
+    // sessions for it would be two handles competing for one editor. The
+    // extension is part of that: an upper-cased ".UPROJECT" used to be read as
+    // a directory name and failed as "project directory not found".
+    if (process.platform !== "win32" && process.platform !== "darwin") return;
+    const uproject = makeProject("Alpha");
+    const registry = new SessionRegistry();
+
+    const a = registry.register({ projectPath: uproject });
+    expect(registry.register({ projectPath: uproject.toUpperCase() })).toBe(a);
+    expect(registry.register({ projectPath: path.dirname(uproject).toUpperCase() })).toBe(a);
+    expect(registry.size).toBe(1);
+    // The name comes off the file, so the shouted spelling must not rename it.
+    expect(a.project.projectName).toBe("Alpha");
+  });
+
+  it("keeps projects that differ by more than spelling apart", () => {
+    // The other half of folding case: a key that collapsed too far would hand
+    // one editor's session to another project's calls, which is worse than the
+    // duplicate it was avoiding.
+    const alpha = makeProject("Alpha");
+    const alphaTwo = makeProject("Alpha2");
+    // A project living inside another project's directory: same prefix, and
+    // its own root all the same.
+    const nestedDir = path.join(path.dirname(alpha), "Inner");
+    fs.mkdirSync(nestedDir, { recursive: true });
+    const nested = path.join(nestedDir, "Alpha.uproject");
+    fs.writeFileSync(nested, JSON.stringify({ FileVersion: 3, EngineAssociation: "5.6" }), "utf-8");
+    const registry = new SessionRegistry();
+
+    const a = registry.register({ projectPath: alpha });
+    const b = registry.register({ projectPath: alphaTwo });
+    const c = registry.register({ projectPath: nested });
+
+    expect(registry.size).toBe(3);
+    expect(new Set([a.key, b.key, c.key]).size).toBe(3);
+    expect(new Set([a.name, b.name, c.name]).size).toBe(3);
+  });
+
   it("gives every session its own bridge port and its own lockfile", () => {
     const alpha = makeProject("Alpha");
     const beta = makeProject("Beta");


### PR DESCRIPTION
Stacked on #872. Fixes the three failures the live tier found when it was run against a real editor (47 passed, 3 failed, 6 skipped). In all three the product was wrong, not the test.

### `attach()` wrote a plugin entry before checking the plugin was there

`attach()` enabled `PythonScriptPlugin` and `UE_MCP_Bridge` in the `.uproject` and only then looked for the installed descriptor, so pointing the server at a project without the bridge left a reference to a plugin that is not on disk, and that project's next launch in Unreal opens with a missing-plugin prompt. Detection now runs first and the writes happen only when the descriptor is really there. `PythonScriptPlugin` goes with it, since it is enabled here solely for the bridge's `execute_python` handler. Presence and versions are still reported, so the startup warning still says the plugin is missing.

Live: `writes no dangling plugin entry into a project that has no bridge`. Engine-free: `tests/unit/deployer-attach.test.ts`.

### A flow run returned no step data

`makeRunner` already spreads the whole context (that half of the eighteen-row change shipped in #857), but nothing outside the flow could see it: `formatFlowResult` returned a summary, a duration, a step count and the failed step name, and dropped every step's `data`. So `project(get_status)` inside a flow reported flows to nobody, and more generally any action was strictly less useful inside a flow than called directly.

Both `src/flow/events.ts` and `docs/flows.md` already told readers the full data was in the `flow.run` response. It was not. The response now carries a `steps` array with each step's number, name, type, outcome, duration, attempts, error and data. The `summary` string is unchanged.

Live: `hands a flow the whole context, including flows and plugins`. Engine-free: `tests/unit/flow-run-result.test.ts`.

### One project spelled two ways registered as two sessions, or threw

The session key already folds slashes, trailing separators and case. `resolveUProjectPath` did not: it asked whether the path ended in `.uproject` byte for byte, so `C:\Proj\Game.UPROJECT` was treated as a directory and failed as "project directory not found" on a path that exists. Registering that spelling threw instead of returning the session the project already had. The extension is now matched case-insensitively, and the project name is stripped with the case the extension actually carries (`basename()` compares the suffix exactly, so it used to leave `Game.UPROJECT` standing as the name).

The other half is asserted too: projects that differ by more than spelling, including one nested inside another's directory, still key apart.

Live: `registers one session for the project however the path is spelled`. Engine-free: two new cases in `tests/unit/session.test.ts`.

### Verification

`npx tsc --noEmit`, `npx vitest run tests/unit` (including the editor-down golden), `npx vitest run tests/multi-editor` and the 7.3 matrix coverage check are green: 85 files, 847 tests. No C++ changed.

The live tier itself is unverified here: this branch was written without access to a running editor.
