### PR TITLE
Fix bulk-upsert Unity helper collision

### DIFF
--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_BulkUpsert.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_BulkUpsert.cpp
@@ -50,7 +50,7 @@ struct FPreparedUpsertItem
 	TArray<FPreparedProperty> Properties;
 };
 
-bool IsProtectedAssetPath(const FString& Path)
+bool IsProtectedBulkUpsertAssetPath(const FString& Path)
 {
 	FString Normalized = Path;
 	Normalized.TrimStartAndEndInline();
@@ -144,7 +144,7 @@ bool ParseAssetIdentity(
 	}
 
 	const FString LongPackageName = OutItem.PackagePath + TEXT("/") + OutItem.Name;
-	if (IsProtectedAssetPath(LongPackageName))
+	if (IsProtectedBulkUpsertAssetPath(LongPackageName))
 	{
 		OutError = FString::Printf(TEXT("Refusing to mutate protected package '%s'"), *LongPackageName);
 		return false;
@@ -357,7 +357,7 @@ TSharedPtr<FJsonValue> FAssetHandlers::BulkRestoreDataAssets(const TSharedPtr<FJ
 			FString AssetPath;
 			const TSharedPtr<FJsonObject>* Properties = nullptr;
 			if (!(*Item)->TryGetStringField(TEXT("assetPath"), AssetPath)
-				|| IsProtectedAssetPath(AssetPath)
+				|| IsProtectedBulkUpsertAssetPath(AssetPath)
 				|| !(*Item)->TryGetObjectField(TEXT("properties"), Properties)
 				|| !Properties
 				|| !Properties->IsValid())
@@ -414,7 +414,7 @@ TSharedPtr<FJsonValue> FAssetHandlers::BulkRestoreDataAssets(const TSharedPtr<FJ
 			FString AssetPath;
 			if (!(*CreatedAssetPaths)[PathIndex].IsValid()
 				|| !(*CreatedAssetPaths)[PathIndex]->TryGetString(AssetPath)
-				|| IsProtectedAssetPath(AssetPath))
+				|| IsProtectedBulkUpsertAssetPath(AssetPath))
 			{
 				Errors.Add(MakeShared<FJsonValueString>(FString::Printf(TEXT("createdAssetPaths[%d] is invalid"), PathIndex)));
 				continue;


### PR DESCRIPTION
## Summary
- give the bulk-upsert path guard a handler-specific name
- avoid the anonymous-namespace symbol collision with `AssetHandlers.cpp` when both files share a Unity translation unit

## Verification
- UE 5.8 forced-Unity host build: 13/13 actions succeeded; both files compiled in `Module.UE_MCP_Bridge.2.cpp`
- Territory UE 5.8 bridge rebuild: 6/6 serial actions succeeded with `-NoUBA -MaxParallelActions=1`
- live Territory handshake: protocol 2, 801 actions, engine ready
- `npx tsc --noEmit` and `npx tsc`
- 810 unit tests and 32 multi-editor tests
- em-dash audit