### PR TITLE
Move the guard pipeline into flowkit

### DIFF
--- a/docs/plugins-guards.md
+++ b/docs/plugins-guards.md
@@ -17,6 +17,8 @@ Prefer `beforeWrite`/`afterWrite` for anything write-oriented so reads are never
 
 The guard task is invoked with `{ method, params, paths }` (`paths` = the existing on-disk files the call will touch, empty for non-writes) plus `result` for `after` phases.
 
+The phase name has to be one of the four. A task named `guard.policy.beforeWrites` fails the server at boot with the list of valid phases, rather than registering a guard that never runs. A guard that silently does nothing is the worst outcome for the thing standing between an agent and a mutation, so the typo is worth a loud failure.
+
 ## A deny guard (access policy)
 
 Blocks writes outside a sandbox path. A `before`/`beforeWrite` guard denies by returning `success: false` (or throwing); the underlying call never runs and the agent gets a `WRITE_BLOCKED` error carrying your message.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "ue-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ue-mcp",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
-        "@db-lyon/flowkit": "~0.5.3",
+        "@db-lyon/flowkit": "^0.14.0",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "js-yaml": "^4.1.0",
         "ws": "^8.18.0",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@db-lyon/flowkit": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@db-lyon/flowkit/-/flowkit-0.5.3.tgz",
-      "integrity": "sha512-8gDrjfDDB7OuXAPYbEGSEm5T82/PY3po6DM1k+gF1FtoOHiRJW0CB8wT9qhDfyhxSmOW7er0bmULfPtXnKtz9w==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@db-lyon/flowkit/-/flowkit-0.14.0.tgz",
+      "integrity": "sha512-2e/jyCPG2Vvm4RvZjmU2Rvp4xBR77+CE/S3VbEk7/koVi3Q8HOhpMwcclDZA9su1XqI0dFYDpRg31+tPIqR+Yg==",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@db-lyon/flowkit": "~0.5.3",
+    "@db-lyon/flowkit": "^0.14.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "js-yaml": "^4.1.0",
     "ws": "^8.18.0",

--- a/src/flow/guard.ts
+++ b/src/flow/guard.ts
@@ -1,19 +1,25 @@
 /**
- * A general guard pipeline around the editor bridge, in the shape of NestJS
- * guards/interceptors but agnostic to what any guard does.
+ * The bridge's binding of flowkit's guard pipeline.
  *
- * Every mutating and non-mutating action crosses `IBridge.call`. A `GuardedBridge`
- * runs a registry of `BridgeGuard`s on that seam: each guard may inspect the call,
- * run a `before` hook that can veto it (throw) or act on it (e.g. check a file
- * out), and an optional `after` hook that can observe or replace the result
- * (audit, transform). The chain itself knows nothing about source control,
- * policy, rate limiting, or any concrete concern - those are guards.
+ * Every mutating and non-mutating action crosses `IBridge.call`. That seam is
+ * guarded: each guard may inspect the call, run a `before` hook that can veto
+ * it (throw) or act on it (e.g. check a file out), and an `after` hook that can
+ * observe or replace the result. The chain itself knows nothing about source
+ * control, policy, rate limiting, or any concrete concern - those are guards.
  *
- * `CallContext` is the per-call execution context handed to guards. It carries
- * the raw method/params and a lazy enrichment layer (`write()` / `writeFiles()`)
- * that write-oriented guards may consult, computed on demand and cached so a
- * guard that ignores writes pays nothing.
+ * The pipeline, its ordering, and the `guard.<name>.<phase>` task convention
+ * live in `@db-lyon/flowkit/guard`, because none of that is about Unreal. What
+ * stays here is what is: the shape of a bridge call, and the write
+ * classification in `write-methods.ts` that decides which content paths a call
+ * is about to modify.
  */
+import {
+  GuardRegistry as FlowkitGuardRegistry,
+  guardContextBase,
+  lazy,
+  type Guard,
+  type GuardContext,
+} from "@db-lyon/flowkit/guard";
 import type { IBridge } from "../bridge.js";
 import type { EditorSession } from "../session.js";
 import { classifyWrite, type WriteClassification } from "./write-methods.js";
@@ -21,8 +27,8 @@ import { classifyWrite, type WriteClassification } from "./write-methods.js";
 /** Resolve a UE content path to an absolute on-disk file, or null if it does not exist. */
 export type ResolveExistingFile = (contentPath: string) => string | null;
 
-/** Per-call execution context passed to every guard. Analogous to a NestJS ExecutionContext. */
-export interface CallContext {
+/** Per-call execution context passed to every guard. */
+export interface CallContext extends GuardContext {
   readonly method: string;
   readonly params: Record<string, unknown>;
   readonly timeoutMs?: number;
@@ -30,8 +36,6 @@ export interface CallContext {
   readonly bridge: IBridge;
   /** The editor this call is bound to. Absent only for a bridge built outside a session. */
   readonly session?: EditorSession;
-  /** Scratch space shared across guards for the life of one call. */
-  readonly meta: Map<string, unknown>;
   /** Lazy: how this call classifies as a write (which content paths it touches). Cached. */
   write(): WriteClassification;
   /** Lazy: absolute, existing on-disk files this call will modify (subset of write paths). Cached. */
@@ -39,41 +43,22 @@ export interface CallContext {
 }
 
 /**
- * A guard on the bridge pipeline. Any of the hooks is optional. Guards are
- * agnostic: source control, access policy, audit, rate limiting, and approval
- * gating are all just guards.
+ * A guard on the bridge pipeline. Guards are agnostic: source control, access
+ * policy, audit, rate limiting, and approval gating are all just guards.
  */
-export interface BridgeGuard {
-  /** Stable identifier, for logging and ordering ties. */
-  readonly name: string;
-  /** Lower runs first in `before` and last in `after`. Default 0. */
-  readonly order?: number;
-  /** Whether this guard participates for a given call. Default: always. */
-  appliesTo?(ctx: CallContext): boolean | Promise<boolean>;
-  /** Runs before the call. Throw to DENY the call; side effects are allowed. */
-  before?(ctx: CallContext): Promise<void>;
-  /** Runs after a successful call. Return a value to replace the result; return nothing to leave it. */
-  after?(ctx: CallContext, result: unknown): Promise<unknown | void>;
-}
+export type BridgeGuard = Guard<CallContext, unknown>;
 
-/** An ordered set of guards. Built-in guards register directly; plugin guards are discovered. */
-export class GuardRegistry {
-  private guards: BridgeGuard[] = [];
+/** The bridge's guard set. Built-in guards register directly; plugin guards are discovered. */
+export class GuardRegistry extends FlowkitGuardRegistry<CallContext, unknown> {}
 
-  register(guard: BridgeGuard): this {
-    this.guards.push(guard);
-    // Stable order: by `order`, then by name for determinism.
-    this.guards.sort((a, b) => (a.order ?? 0) - (b.order ?? 0) || a.name.localeCompare(b.name));
-    return this;
-  }
-
-  list(): readonly BridgeGuard[] {
-    return this.guards;
-  }
-
-  get size(): number {
-    return this.guards.length;
-  }
+/**
+ * The scope a `guard.<name>.<phase>Write` task binds to: the call resolves to
+ * existing on-disk files it is about to modify. Declared here rather than in
+ * the task layer so the hand-written and task-backed guards agree on what
+ * "write" means.
+ */
+export function writeScope(ctx: CallContext): boolean {
+  return ctx.writeFiles().length > 0;
 }
 
 /** Build the per-call context, wiring the lazy write-enrichment helpers. */
@@ -85,18 +70,22 @@ export function makeCallContext(
   resolveExistingFile: ResolveExistingFile,
   session?: EditorSession,
 ): CallContext {
-  let writeCache: WriteClassification | undefined;
-  let filesCache: string[] | undefined;
+  const ctx = {
+    ...guardContextBase(),
+    method,
+    params,
+    timeoutMs,
+    bridge: rawBridge,
+    session,
+  } as CallContext;
 
-  const write = (): WriteClassification => (writeCache ??= classifyWrite(method, params));
-  const writeFiles = (): string[] => {
-    if (filesCache) return filesCache;
+  const write = lazy(ctx, "write", () => classifyWrite(method, params));
+  const writeFiles = lazy(ctx, "writeFiles", () => {
     const c = write();
-    filesCache = c.writes
+    return c.writes
       ? c.contentPaths.map(resolveExistingFile).filter((f): f is string => f !== null)
       : [];
-    return filesCache;
-  };
+  });
 
-  return { method, params, timeoutMs, bridge: rawBridge, session, meta: new Map(), write, writeFiles };
+  return Object.assign(ctx, { write, writeFiles });
 }

--- a/src/flow/guarded-bridge.ts
+++ b/src/flow/guarded-bridge.ts
@@ -6,16 +6,14 @@
  * hook runs in reverse order and may replace the result. With an empty registry
  * this is a pure pass-through, so it is always safe to install.
  *
- * Only `call` is gated; connection lifecycle delegates straight through.
+ * The pipeline itself is `runGuarded` from flowkit; what this class adds is the
+ * `IBridge` shape. Only `call` is gated; connection lifecycle delegates
+ * straight through.
  */
+import { runGuarded } from "@db-lyon/flowkit/guard";
 import type { BridgeTarget, IBridge } from "../bridge.js";
 import type { EditorSession } from "../session.js";
-import {
-  GuardRegistry,
-  makeCallContext,
-  type BridgeGuard,
-  type ResolveExistingFile,
-} from "./guard.js";
+import { GuardRegistry, makeCallContext, type ResolveExistingFile } from "./guard.js";
 
 export type { ResolveExistingFile } from "./guard.js";
 
@@ -50,34 +48,21 @@ export class GuardedBridge implements IBridge {
     params?: Record<string, unknown>,
     timeoutMs?: number,
   ): Promise<unknown> {
+    // `runGuarded` is already a pass-through on an empty registry, but building
+    // the context is not free and every bridge call lands here. Most servers run
+    // with no guards at all, so skip the allocation outright.
     if (this.registry.size === 0) {
       return this.inner.call(method, params, timeoutMs);
     }
 
-    const ctx = makeCallContext(method, params ?? {}, timeoutMs, this.inner, this.resolveExistingFile, this.session);
-
-    // Resolve applicability once so `before`/`after` see a consistent set.
-    const applicable: BridgeGuard[] = [];
-    for (const g of this.registry.list()) {
-      if (!g.appliesTo || (await g.appliesTo(ctx))) applicable.push(g);
-    }
-
-    // before: in order. A throw denies the call and propagates unchanged.
-    for (const g of applicable) {
-      if (g.before) await g.before(ctx);
-    }
-
-    let result = await this.inner.call(method, params, timeoutMs);
-
-    // after: in reverse order. A returned value replaces the result.
-    for (let i = applicable.length - 1; i >= 0; i--) {
-      const g = applicable[i];
-      if (g.after) {
-        const replaced = await g.after(ctx, result);
-        if (replaced !== undefined) result = replaced;
-      }
-    }
-
-    return result;
+    const ctx = makeCallContext(
+      method,
+      params ?? {},
+      timeoutMs,
+      this.inner,
+      this.resolveExistingFile,
+      this.session,
+    );
+    return runGuarded(ctx, this.registry, () => this.inner.call(method, params, timeoutMs));
   }
 }

--- a/src/flow/task-guards.ts
+++ b/src/flow/task-guards.ts
@@ -10,27 +10,35 @@
  *   - `afterWrite`  run after a write-classified call
  *
  * No new plugin-activation concept is needed: the loader already registers every
- * `manifest.tasks` entry by name, so a `guard.*.*` task is picked up here. Each
- * matched task becomes one `BridgeGuard`. The core knows nothing about what a
- * guard does - source control, access policy, audit, and rate limiting are all
- * just guards.
+ * `manifest.tasks` entry by name, so a `guard.*.*` task is picked up here. The
+ * core knows nothing about what a guard does - source control, access policy,
+ * audit, and rate limiting are all just guards.
  *
- * A guard task is invoked with `{ method, params, paths }` (paths = the existing
- * on-disk files the call will touch, empty for non-writes) plus, for `after`
- * guards, `result`. A `before` guard denies the call by returning `success:false`
- * or throwing.
+ * The naming convention and the discovery walk are flowkit's; this module binds
+ * them to the bridge: the `write` scope comes from `write-methods.ts`, the guard
+ * task is invoked with `{ method, params, paths }` (plus `result` for `after`
+ * guards), and a denial surfaces as an `McpError` the tool layer already knows
+ * how to render.
  */
 import * as fs from "node:fs";
-import type { TaskRegistry } from "@db-lyon/flowkit";
+import { discoverTaskGuards as discoverFlowkitGuards } from "@db-lyon/flowkit/guard";
+import type { Logger, TaskRegistry } from "@db-lyon/flowkit";
 import type { IBridge } from "../bridge.js";
 import type { ProjectContext } from "../project.js";
 import type { ToolContext } from "../types.js";
 import type { FlowContext } from "./context.js";
-import type { BridgeGuard, CallContext, ResolveExistingFile } from "./guard.js";
+import { writeScope, type BridgeGuard, type CallContext, type ResolveExistingFile } from "./guard.js";
 import { McpError, ErrorCode } from "../errors.js";
-import { debug } from "../log.js";
+import { debug, info } from "../log.js";
 
-const GUARD_TASK_RE = /^guard\.(.+)\.(before|beforeWrite|after|afterWrite)$/;
+/** Adapts flowkit's logger to this server's `guard`-component logging. */
+const GUARD_LOGGER: Logger = {
+  debug: (...args) => debug("guard", args.map(String).join(" ")),
+  info: (...args) => info("guard", args.map(String).join(" ")),
+  warn: (...args) => info("guard", args.map(String).join(" ")),
+  error: (...args) => info("guard", args.map(String).join(" ")),
+  child: () => GUARD_LOGGER,
+};
 
 /** Resolve a UE content path to an absolute file, or null if it does not exist. */
 export function makeResolveExistingFile(project: ProjectContext): ResolveExistingFile {
@@ -54,66 +62,44 @@ export function discoverTaskGuards(
   ctx: ToolContext,
   rawBridge: IBridge,
 ): BridgeGuard[] {
-  const guards: BridgeGuard[] = [];
+  return discoverFlowkitGuards<CallContext, unknown>(registry, {
+    scopes: { write: writeScope },
 
-  for (const taskName of registry.listRegistered()) {
-    const m = GUARD_TASK_RE.exec(taskName);
-    if (!m) continue;
-    const [, name, phase] = m;
-    const writeScoped = phase.endsWith("Write");
-    const isBefore = phase.startsWith("before");
-
-    const runTask = async (cc: CallContext, result?: unknown) => {
-      // Bind the guard to the editor whose call it is guarding, not to
-      // whichever bridge happened to be built first. cc.bridge is the RAW
-      // bridge of the session serving this call, so a guard can neither
-      // recurse through the pipeline nor act on another project's editor.
-      const guardCtx: FlowContext = cc.session
+    // Bind the guard to the editor whose call it is guarding, not to whichever
+    // bridge happened to be built first. cc.bridge is the RAW bridge of the
+    // session serving this call, so a guard can neither recurse through the
+    // pipeline nor act on another project's editor.
+    contextFor: (cc): FlowContext =>
+      cc.session
         ? { ...ctx, bridge: cc.bridge, project: cc.session.project, session: cc.session }
-        : { ...ctx, bridge: rawBridge };
-      const options: Record<string, unknown> = {
-        method: cc.method,
-        params: cc.params,
-        paths: cc.writeFiles(),
-      };
-      if (result !== undefined) options.result = result;
-      try {
-        const task = await registry.create(taskName, guardCtx, options);
-        return await task.run();
-      } catch (e) {
-        throw new McpError(
-          ErrorCode.WRITE_BLOCKED,
-          `guard '${name}' errored on ${cc.method}: ${(e as Error).message}`,
-        );
-      }
-    };
+        : { ...ctx, bridge: rawBridge },
 
-    const guard: BridgeGuard = {
-      name: `${name}.${phase}`,
-      appliesTo: writeScoped ? (cc) => cc.writeFiles().length > 0 : undefined,
-    };
+    optionsFor: (cc, result) => ({
+      method: cc.method,
+      params: cc.params,
+      paths: cc.writeFiles(),
+      ...(result !== undefined ? { result } : {}),
+    }),
 
-    if (isBefore) {
-      guard.before = async (cc) => {
-        const r = await runTask(cc);
-        if (!r.success) {
-          const reason = r.error?.message ?? `denied by guard '${name}'`;
-          const scope = cc.writeFiles().length ? ` on ${cc.writeFiles().join(", ")}` : "";
-          throw new McpError(ErrorCode.WRITE_BLOCKED, `blocked (${cc.method})${scope}: ${reason}`);
-        }
-        debug("guard", `guard '${name}' allowed ${cc.method}`);
-      };
-    } else {
-      // `after` guards observe the result for side effects (audit); a failing
-      // after-guard is logged but does not fail the already-completed call.
-      guard.after = async (cc, result) => {
-        const r = await runTask(cc, result);
-        if (!r.success) debug("guard", `after-guard '${name}' reported failure on ${cc.method}: ${r.error?.message}`);
-      };
-    }
+    onDeny: (info) => {
+      const files = info.ctx.writeFiles();
+      const scope = files.length ? ` on ${files.join(", ")}` : "";
+      return new McpError(
+        ErrorCode.WRITE_BLOCKED,
+        `blocked (${info.ctx.method})${scope}: ${info.reason}`,
+      );
+    },
 
-    guards.push(guard);
-  }
+    onError: (info) =>
+      new McpError(
+        ErrorCode.WRITE_BLOCKED,
+        `guard '${info.guard}' errored on ${info.ctx.method}: ${info.reason}`,
+      ),
 
-  return guards;
+    // A failing after-guard is logged but does not fail the already-completed call.
+    onAfterFailure: (info) =>
+      debug("guard", `after-guard '${info.guard}' reported failure on ${info.ctx.method}: ${info.reason}`),
+
+    logger: GUARD_LOGGER,
+  });
 }

--- a/tests/unit/task-guards.test.ts
+++ b/tests/unit/task-guards.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The bridge's binding of flowkit's task-guard discovery: the `write` scope,
+ * the option shape a guard task is handed, the per-session context, and the
+ * mapping from a denial to an McpError the tool layer renders.
+ */
+import { describe, it, expect } from "vitest";
+import { BaseTask, TaskRegistry, type TaskResult, type TaskConstructor } from "@db-lyon/flowkit";
+import { discoverTaskGuards } from "../../src/flow/task-guards.js";
+import { GuardRegistry, makeCallContext, type CallContext } from "../../src/flow/guard.js";
+import { GuardedBridge } from "../../src/flow/guarded-bridge.js";
+import { McpError, ErrorCode } from "../../src/errors.js";
+import type { IBridge } from "../../src/bridge.js";
+import type { ToolContext } from "../../src/types.js";
+
+const target = { projectPath: null, port: 0, portSource: "default" as const, verified: true };
+
+function fakeBridge(result: unknown = { ok: true }) {
+  const calls: string[] = [];
+  const bridge: IBridge & { calls: string[] } = {
+    calls,
+    isConnected: true,
+    connect: async () => {},
+    retargetProject: () => target,
+    getTarget: () => target,
+    call: async (method: string) => {
+      calls.push(method);
+      return result;
+    },
+  };
+  return bridge;
+}
+
+/** Every /Game/* path exists on disk; anything else is a not-yet-created asset. */
+const resolveExisting = (cp: string) =>
+  cp.startsWith("/Game/") ? `C:/proj/Content/${cp.slice(6)}.uasset` : null;
+
+const ctx = { bridge: fakeBridge(), project: {} } as unknown as ToolContext;
+
+/** Records what each guard task was handed, so a test can assert the option shape. */
+const seen: Array<Record<string, unknown>> = [];
+
+function guardTask(outcome: TaskResult): TaskConstructor {
+  class Stub extends BaseTask {
+    get taskName() {
+      return "guard-stub";
+    }
+    async execute(): Promise<TaskResult> {
+      seen.push(this.options as Record<string, unknown>);
+      return outcome;
+    }
+  }
+  return Stub as unknown as TaskConstructor;
+}
+
+const ALLOW: TaskResult = { success: true };
+const DENY: TaskResult = { success: false, error: new Error("checked out by alice") };
+
+function registryWith(entries: Record<string, TaskResult>): TaskRegistry {
+  const reg = new TaskRegistry();
+  for (const [name, outcome] of Object.entries(entries)) reg.register(name, guardTask(outcome));
+  return reg;
+}
+
+function callCtx(method: string, params: Record<string, unknown> = {}): CallContext {
+  return makeCallContext(method, params, undefined, fakeBridge(), resolveExisting);
+}
+
+describe("discoverTaskGuards", () => {
+  it("discovers guard.* tasks and ignores everything else", () => {
+    const reg = registryWith({ "guard.p4.beforeWrite": ALLOW, deploy: ALLOW });
+    const guards = discoverTaskGuards(reg, ctx, fakeBridge());
+    expect(guards.map((g) => g.name)).toEqual(["p4.beforeWrite"]);
+  });
+
+  it("binds the Write suffix to the bridge's own write classification", async () => {
+    const reg = registryWith({ "guard.p4.beforeWrite": ALLOW });
+    const [guard] = discoverTaskGuards(reg, ctx, fakeBridge());
+
+    // A read verb is not a write.
+    expect(await guard.appliesTo!(callCtx("get_asset", { assetPath: "/Game/Foo" }))).toBe(false);
+    // A write to a path that does not exist yet is a create, not a modify.
+    expect(await guard.appliesTo!(callCtx("save_asset", { assetPath: "/Other/New" }))).toBe(false);
+    // A write to an existing asset is what the scope claims.
+    expect(await guard.appliesTo!(callCtx("save_asset", { assetPath: "/Game/Foo" }))).toBe(true);
+  });
+
+  it("hands the guard task the method, params and resolved paths", async () => {
+    seen.length = 0;
+    const reg = registryWith({ "guard.p4.beforeWrite": ALLOW });
+    const [guard] = discoverTaskGuards(reg, ctx, fakeBridge());
+
+    await guard.before!(callCtx("save_asset", { assetPath: "/Game/Foo" }));
+
+    expect(seen).toEqual([
+      {
+        method: "save_asset",
+        params: { assetPath: "/Game/Foo" },
+        paths: ["C:/proj/Content/Foo.uasset"],
+      },
+    ]);
+  });
+
+  it("adds the result for an after guard only", async () => {
+    seen.length = 0;
+    const reg = registryWith({ "guard.audit.after": ALLOW });
+    const [guard] = discoverTaskGuards(reg, ctx, fakeBridge());
+
+    await guard.after!(callCtx("save_asset", { assetPath: "/Game/Foo" }), { saved: true });
+
+    expect(seen[0].result).toEqual({ saved: true });
+  });
+
+  it("rejects with a WRITE_BLOCKED McpError naming the method and the files", async () => {
+    const reg = registryWith({ "guard.p4.beforeWrite": DENY });
+    const [guard] = discoverTaskGuards(reg, ctx, fakeBridge());
+
+    const err = await guard
+      .before!(callCtx("save_asset", { assetPath: "/Game/Foo" }))
+      .then(() => null)
+      .catch((e: unknown) => e as McpError);
+
+    expect(err).toBeInstanceOf(McpError);
+    expect(err!.code).toBe(ErrorCode.WRITE_BLOCKED);
+    expect(err!.message).toBe(
+      "blocked (save_asset) on C:/proj/Content/Foo.uasset: checked out by alice",
+    );
+  });
+
+  it("omits the file list when an unscoped guard denies a read", async () => {
+    const reg = registryWith({ "guard.policy.before": DENY });
+    const [guard] = discoverTaskGuards(reg, ctx, fakeBridge());
+
+    await expect(guard.before!(callCtx("get_asset", { assetPath: "/Game/Foo" }))).rejects.toThrow(
+      "blocked (get_asset): checked out by alice",
+    );
+  });
+
+  it("does not fail a completed call when an after guard reports failure", async () => {
+    const reg = registryWith({ "guard.audit.after": DENY });
+    const [guard] = discoverTaskGuards(reg, ctx, fakeBridge());
+    await expect(guard.after!(callCtx("save_asset"), 1)).resolves.toBeUndefined();
+  });
+
+  it("throws at startup when a task names a scope the bridge does not declare", () => {
+    const reg = registryWith({ "guard.p4.beforeCheckout": ALLOW });
+    expect(() => discoverTaskGuards(reg, ctx, fakeBridge())).toThrow(
+      /scope 'checkout'.*Known scopes: write/s,
+    );
+  });
+});
+
+describe("task guards through GuardedBridge", () => {
+  it("denies the write before it reaches the editor", async () => {
+    const inner = fakeBridge();
+    const guards = new GuardRegistry().registerAll(
+      discoverTaskGuards(registryWith({ "guard.p4.beforeWrite": DENY }), ctx, inner),
+    );
+    const gb = new GuardedBridge(inner, guards, resolveExisting);
+
+    await expect(gb.call("save_asset", { assetPath: "/Game/Foo" })).rejects.toThrow(
+      /checked out by alice/,
+    );
+    expect(inner.calls).toEqual([]);
+  });
+
+  it("lets a read through a write-scoped guard untouched", async () => {
+    seen.length = 0;
+    const inner = fakeBridge();
+    const guards = new GuardRegistry().registerAll(
+      discoverTaskGuards(registryWith({ "guard.p4.beforeWrite": DENY }), ctx, inner),
+    );
+    const gb = new GuardedBridge(inner, guards, resolveExisting);
+
+    await expect(gb.call("get_asset", { assetPath: "/Game/Foo" })).resolves.toEqual({ ok: true });
+    expect(inner.calls).toEqual(["get_asset"]);
+    expect(seen).toHaveLength(0);
+  });
+
+  it("allows the write and then audits the result", async () => {
+    seen.length = 0;
+    const inner = fakeBridge({ saved: true });
+    const guards = new GuardRegistry().registerAll(
+      discoverTaskGuards(
+        registryWith({ "guard.p4.beforeWrite": ALLOW, "guard.audit.after": ALLOW }),
+        ctx,
+        inner,
+      ),
+    );
+    const gb = new GuardedBridge(inner, guards, resolveExisting);
+
+    const out = await gb.call("save_asset", { assetPath: "/Game/Foo" });
+
+    expect(out).toEqual({ saved: true });
+    expect(inner.calls).toEqual(["save_asset"]);
+    // The after guard observes; it never replaces the editor's result.
+    expect(seen[1].result).toEqual({ saved: true });
+  });
+});


### PR DESCRIPTION
`task-guards.ts` already imported `TaskRegistry` from flowkit, so half the guard feature was a flowkit extension living in this repo. Three other projects want the same seam. This moves the kernel out and keeps the Unreal-specific half here.

Requires flowkit 0.14.0 (db-lyon/flowkit#7), published.

## What moved

The guard interface, the registry's ordering, the before/after chain in `GuardedBridge.call`, and the `guard.<name>.<phase>` discovery walk. None of it is about Unreal.

## What stayed

`write-methods.ts`, untouched. The `write` scope it backs, the per-session context a guard task is bound to (`cc.bridge` is the raw bridge of the session serving the call, so a guard can neither recurse through the pipeline nor act on another project's editor), and the `WRITE_BLOCKED` `McpError` a denial surfaces as.

`GuardedBridge` keeps its own empty-registry fast path. `runGuarded` is already a pass-through on an empty registry, but building the call context is not free and every bridge call lands there.

## Plugin contract

Unchanged. Same task names, same four phases, same `{ method, params, paths }` options, same error shape. `tests/unit/guarded-bridge.test.ts` and `tests/unit/write-methods.test.ts` pass with no edits, which is the assertion that matters.

## One behaviour change

A phase the server does not know used to miss the discovery regex and register nothing, so `guard.policy.beforeWrites` was a guard that silently never ran. Phases are now host-declared scopes and an unknown one fails at boot with the valid list. A guard that quietly does nothing is the worst outcome for the thing standing between an agent and a mutation. Documented in `docs/plugins-guards.md`.

## Tests

Adds `tests/unit/task-guards.test.ts`: 11 tests over the binding layer the migration put at risk, covering the write scope, the option shape and the denial path, none of which had a test before.

Unit suite 806 passing. The 15 failures in `feedback-submit`, `feedback-submit-routing`, `workaround-partition` and `audit-unity-collisions` are pre-existing and reproduce identically on unmodified `main`; they are untouched by this change and not addressed here.