### PR TITLE
Fix the 15 unit failures: machine-dependent tests and a shebang

### DIFF
--- a/scripts/audit-unity-collisions.mjs
+++ b/scripts/audit-unity-collisions.mjs
@@ -1,5 +1,9 @@
-#!/usr/bin/env node
 // Duplicate file-local definition audit.
+//
+// No shebang: this file is run by `node` from npm scripts and re-imported by
+// vitest, whose loader chokes on the shebang line as "Invalid or unexpected
+// token" and takes the whole test file down with it. Invoke as
+// `node scripts/audit-unity-collisions.mjs` (already the `audit:unity` shape).
 //
 // UBT compiles a module as a unity build: several .cpp files are concatenated
 // into one translation unit. An anonymous namespace is per translation unit, so

--- a/tests/unit/feedback-submit-routing.test.ts
+++ b/tests/unit/feedback-submit-routing.test.ts
@@ -88,6 +88,20 @@ async function route(ctx: ToolContext, params: Record<string, unknown>): Promise
 
 const CACHED_USER = { token: "ghu_abc", login: "tester", authorized_at: "2026-05-20T00:00:00Z" };
 
+// Redirect ~/.ue-mcp/state.json to a per-run temp file. resolveFeedbackMode
+// falls back to the user-scoped preference when no env override is set, so
+// without this these tests read the developer's real feedback mode and a
+// machine set to auto-approve skips the approval gate they assert on.
+let stateRoot: string;
+beforeEach(() => {
+  stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-routing-state-"));
+  process.env.UE_MCP_USER_STATE = path.join(stateRoot, "state.json");
+});
+afterEach(() => {
+  delete process.env.UE_MCP_USER_STATE;
+  fs.rmSync(stateRoot, { recursive: true, force: true });
+});
+
 describe("feedback(submit) plugin routing", () => {
   beforeEach(() => {
     delete process.env.UE_MCP_FEEDBACK_ROUTING;

--- a/tests/unit/feedback-submit.test.ts
+++ b/tests/unit/feedback-submit.test.ts
@@ -52,6 +52,22 @@ const CACHED_USER = {
   authorized_at: "2026-05-20T00:00:00Z",
 };
 
+// Redirect ~/.ue-mcp/state.json to a per-run temp file. resolveFeedbackMode
+// falls back to the user-scoped preference when no env override is set, so
+// without this the whole file reads the developer's real feedback mode: a
+// machine with `npx ue-mcp feedback mode auto-approve` set skips the
+// elicitation gate these tests exist to cover. CI passes either way because
+// its home directory is empty, which is what let it go unnoticed.
+let stateRoot: string;
+beforeEach(() => {
+  stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-feedback-state-"));
+  process.env.UE_MCP_USER_STATE = path.join(stateRoot, "state.json");
+});
+afterEach(() => {
+  delete process.env.UE_MCP_USER_STATE;
+  fs.rmSync(stateRoot, { recursive: true, force: true });
+});
+
 describe("feedback(submit) elicitation gate", () => {
   beforeEach(() => {
     // Routing (plugin-registry lookup) is exercised in feedback-routing.test.ts

--- a/tests/unit/workaround-partition.test.ts
+++ b/tests/unit/workaround-partition.test.ts
@@ -47,6 +47,11 @@ beforeEach(() => {
   root = fs.mkdtempSync(path.join(os.tmpdir(), "ue-mcp-workaround-"));
   resetAllWorkarounds();
   process.env.UE_MCP_FEEDBACK_ROUTING = "off";
+  // Redirect ~/.ue-mcp/state.json into the same temp root. resolveFeedbackMode
+  // falls back to the user-scoped preference when no env override is set, so
+  // without this the submit path reads the developer's real feedback mode and
+  // a machine set to auto-approve bypasses the elicitation this asserts on.
+  process.env.UE_MCP_USER_STATE = path.join(root, "state.json");
   mockSubmitFeedback.mockReset();
   mockReadUserAuth.mockReset();
   mockReadUserAuth.mockResolvedValue({
@@ -60,6 +65,7 @@ afterEach(() => {
   fs.rmSync(root, { recursive: true, force: true });
   resetAllWorkarounds();
   delete process.env.UE_MCP_FEEDBACK_ROUTING;
+  delete process.env.UE_MCP_USER_STATE;
 });
 
 describe("workaround tracker partitioning", () => {


### PR DESCRIPTION
The unit suite failed 15 tests on a developer machine and passed on CI. Both causes are the suite depending on the machine rather than on the code.

## The shebang (1 file, 7 tests)

`scripts/audit-unity-collisions.mjs` started with `#!/usr/bin/env node`. vitest's loader reads that as "Invalid or unexpected token" and fails the whole test file at the import, so the audit CLAUDE.md points at as the guard against unity-build duplicate definitions had no working test behind it.

`scripts/release-headline.mjs` already documents this exact trap in its own header and carries the same note. The script is only ever invoked as `node scripts/...` from `audit:unity`, so the shebang bought nothing.

## The user state file (3 files, 14 tests)

`resolveFeedbackMode` falls back to the user-scoped preference when no env override is set:

```ts
const pref = getFeedbackMode(ctx.project?.projectDir ?? null);
if (pref) return pref;
return "interactive";
```

`getFeedbackMode` reads `~/.ue-mcp/state.json` via `statePath()`, which honours `UE_MCP_USER_STATE`. The three feedback suites never set it.

On a machine that has run `npx ue-mcp feedback mode auto-approve`, `mode` resolved to `auto-approve`, the submit path took the auto-approve branch, and 14 tests failed on the exact behaviour they exist to cover. The elicitation gate was never being exercised there at all.

CI has an empty home directory, so it always resolved `interactive` and always passed. The tests were asserting against whoever ran them.

They now redirect `UE_MCP_USER_STATE` to a per-run temp file, matching what `hook-installer.test.ts`, `project.test.ts` and `session-config.test.ts` already do.

## Result

```
Test Files  82 passed (82)
     Tests  828 passed (828)
```

Verified the developer's real `~/.ue-mcp/state.json` is unmodified by the run.