### PR TITLE
Add native skeletal asset structural diffs

### DIFF
--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DiffHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DiffHandlers.cpp
@@ -96,9 +96,9 @@ namespace
 
 	struct FVirtualBoneDiffRecord
 	{
-		FString Name;
-		FString Source;
-		FString Target;
+		FName Name;
+		FName Source;
+		FName Target;
 
 		bool operator==(const FVirtualBoneDiffRecord& Other) const
 		{
@@ -108,9 +108,9 @@ namespace
 
 	bool VirtualBoneRecordLess(const FVirtualBoneDiffRecord& A, const FVirtualBoneDiffRecord& B)
 	{
-		if (A.Name != B.Name) return A.Name < B.Name;
-		if (A.Source != B.Source) return A.Source < B.Source;
-		return A.Target < B.Target;
+		if (A.Name != B.Name) return A.Name.ToString() < B.Name.ToString();
+		if (A.Source != B.Source) return A.Source.ToString() < B.Source.ToString();
+		return A.Target.ToString() < B.Target.ToString();
 	}
 
 	TArray<FVirtualBoneDiffRecord> CollectVirtualBones(const USkeleton* Skeleton)
@@ -120,9 +120,9 @@ namespace
 		for (const FVirtualBone& Bone : Skeleton->GetVirtualBones())
 		{
 			Out.Add({
-				Bone.VirtualBoneName.ToString(),
-				Bone.SourceBoneName.ToString(),
-				Bone.TargetBoneName.ToString()
+				Bone.VirtualBoneName,
+				Bone.SourceBoneName,
+				Bone.TargetBoneName
 			});
 		}
 		Out.Sort(VirtualBoneRecordLess);
@@ -136,20 +136,20 @@ namespace
 		for (const FVirtualBoneDiffRecord& Bone : In)
 		{
 			TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
-			Obj->SetStringField(TEXT("name"), Bone.Name);
-			Obj->SetStringField(TEXT("sourceBone"), Bone.Source);
-			Obj->SetStringField(TEXT("targetBone"), Bone.Target);
+			Obj->SetStringField(TEXT("name"), Bone.Name.ToString());
+			Obj->SetStringField(TEXT("sourceBone"), Bone.Source.ToString());
+			Obj->SetStringField(TEXT("targetBone"), Bone.Target.ToString());
 			Out.Add(MakeShared<FJsonValueObject>(Obj));
 		}
 		return Out;
 	}
 
-	FString RawParentName(const TArray<FMeshBoneInfo>& Bones, int32 BoneIndex)
+	FName RawParentName(const TArray<FMeshBoneInfo>& Bones, int32 BoneIndex)
 	{
 		const int32 ParentIndex = Bones[BoneIndex].ParentIndex;
-		if (ParentIndex == INDEX_NONE) return NAME_None.ToString();
-		if (Bones.IsValidIndex(ParentIndex)) return Bones[ParentIndex].Name.ToString();
-		return FString::Printf(TEXT("<invalid:%d>"), ParentIndex);
+		if (ParentIndex == INDEX_NONE) return NAME_None;
+		if (Bones.IsValidIndex(ParentIndex)) return Bones[ParentIndex].Name;
+		return FName(*FString::Printf(TEXT("<invalid:%d>"), ParentIndex));
 	}
 }
 
@@ -399,46 +399,49 @@ TSharedPtr<FJsonValue> FDiffHandlers::DiffSkeleton(const TSharedPtr<FJsonObject>
 	const TArray<FMeshBoneInfo>& RawA = A->GetReferenceSkeleton().GetRawRefBoneInfo();
 	const TArray<FMeshBoneInfo>& RawB = B->GetReferenceSkeleton().GetRawRefBoneInfo();
 
-	TMap<FString, FString> ParentByBoneA;
-	TMap<FString, FString> ParentByBoneB;
+	TMap<FName, FName> ParentByBoneA;
+	TMap<FName, FName> ParentByBoneB;
 	for (int32 Index = 0; Index < RawA.Num(); ++Index)
 	{
-		ParentByBoneA.Add(RawA[Index].Name.ToString(), RawParentName(RawA, Index));
+		ParentByBoneA.Add(RawA[Index].Name, RawParentName(RawA, Index));
 	}
 	for (int32 Index = 0; Index < RawB.Num(); ++Index)
 	{
-		ParentByBoneB.Add(RawB[Index].Name.ToString(), RawParentName(RawB, Index));
+		ParentByBoneB.Add(RawB[Index].Name, RawParentName(RawB, Index));
 	}
 
 	TArray<FString> RawBonesAdded;
 	TArray<FString> RawBonesRemoved;
-	TArray<FString> SharedRawBones;
-	for (const TPair<FString, FString>& Bone : ParentByBoneB)
+	TArray<FName> SharedRawBones;
+	for (const TPair<FName, FName>& Bone : ParentByBoneB)
 	{
-		if (!ParentByBoneA.Contains(Bone.Key)) RawBonesAdded.Add(Bone.Key);
+		if (!ParentByBoneA.Contains(Bone.Key)) RawBonesAdded.Add(Bone.Key.ToString());
 	}
-	for (const TPair<FString, FString>& Bone : ParentByBoneA)
+	for (const TPair<FName, FName>& Bone : ParentByBoneA)
 	{
 		if (ParentByBoneB.Contains(Bone.Key)) SharedRawBones.Add(Bone.Key);
-		else RawBonesRemoved.Add(Bone.Key);
+		else RawBonesRemoved.Add(Bone.Key.ToString());
 	}
 	RawBonesAdded.Sort();
 	RawBonesRemoved.Sort();
-	SharedRawBones.Sort();
+	SharedRawBones.Sort([](const FName& Left, const FName& Right)
+	{
+		return Left.ToString() < Right.ToString();
+	});
 
 	TArray<TSharedPtr<FJsonValue>> Reparented;
 	bool bSharedParentsMatch = true;
-	for (const FString& BoneName : SharedRawBones)
+	for (const FName& BoneName : SharedRawBones)
 	{
-		const FString& ParentA = ParentByBoneA.FindChecked(BoneName);
-		const FString& ParentB = ParentByBoneB.FindChecked(BoneName);
+		const FName ParentA = ParentByBoneA.FindChecked(BoneName);
+		const FName ParentB = ParentByBoneB.FindChecked(BoneName);
 		if (ParentA != ParentB)
 		{
 			bSharedParentsMatch = false;
 			TSharedPtr<FJsonObject> Delta = MakeShared<FJsonObject>();
-			Delta->SetStringField(TEXT("bone"), BoneName);
-			Delta->SetStringField(TEXT("fromParent"), ParentA);
-			Delta->SetStringField(TEXT("toParent"), ParentB);
+			Delta->SetStringField(TEXT("bone"), BoneName.ToString());
+			Delta->SetStringField(TEXT("fromParent"), ParentA.ToString());
+			Delta->SetStringField(TEXT("toParent"), ParentB.ToString());
 			Reparented.Add(MakeShared<FJsonValueObject>(Delta));
 		}
 	}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DiffHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DiffHandlers.cpp
@@ -7,6 +7,8 @@
 #include "EdGraph/EdGraphPin.h"
 #include "Engine/SimpleConstructionScript.h"
 #include "Engine/SCS_Node.h"
+#include "Animation/Skeleton.h"
+#include "ReferenceSkeleton.h"
 
 // ── Structural extraction helpers ────────────────────────────────────────────
 namespace
@@ -90,6 +92,64 @@ namespace
 		Out.Reserve(In.Num());
 		for (const FString& S : In) Out.Add(MakeShared<FJsonValueString>(S));
 		return Out;
+	}
+
+	struct FVirtualBoneDiffRecord
+	{
+		FString Name;
+		FString Source;
+		FString Target;
+
+		bool operator==(const FVirtualBoneDiffRecord& Other) const
+		{
+			return Name == Other.Name && Source == Other.Source && Target == Other.Target;
+		}
+	};
+
+	bool VirtualBoneRecordLess(const FVirtualBoneDiffRecord& A, const FVirtualBoneDiffRecord& B)
+	{
+		if (A.Name != B.Name) return A.Name < B.Name;
+		if (A.Source != B.Source) return A.Source < B.Source;
+		return A.Target < B.Target;
+	}
+
+	TArray<FVirtualBoneDiffRecord> CollectVirtualBones(const USkeleton* Skeleton)
+	{
+		TArray<FVirtualBoneDiffRecord> Out;
+		Out.Reserve(Skeleton->GetVirtualBones().Num());
+		for (const FVirtualBone& Bone : Skeleton->GetVirtualBones())
+		{
+			Out.Add({
+				Bone.VirtualBoneName.ToString(),
+				Bone.SourceBoneName.ToString(),
+				Bone.TargetBoneName.ToString()
+			});
+		}
+		Out.Sort(VirtualBoneRecordLess);
+		return Out;
+	}
+
+	TArray<TSharedPtr<FJsonValue>> VirtualBonesToJson(const TArray<FVirtualBoneDiffRecord>& In)
+	{
+		TArray<TSharedPtr<FJsonValue>> Out;
+		Out.Reserve(In.Num());
+		for (const FVirtualBoneDiffRecord& Bone : In)
+		{
+			TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
+			Obj->SetStringField(TEXT("name"), Bone.Name);
+			Obj->SetStringField(TEXT("sourceBone"), Bone.Source);
+			Obj->SetStringField(TEXT("targetBone"), Bone.Target);
+			Out.Add(MakeShared<FJsonValueObject>(Obj));
+		}
+		return Out;
+	}
+
+	FString RawParentName(const TArray<FMeshBoneInfo>& Bones, int32 BoneIndex)
+	{
+		const int32 ParentIndex = Bones[BoneIndex].ParentIndex;
+		if (ParentIndex == INDEX_NONE) return NAME_None.ToString();
+		if (Bones.IsValidIndex(ParentIndex)) return Bones[ParentIndex].Name.ToString();
+		return FString::Printf(TEXT("<invalid:%d>"), ParentIndex);
 	}
 }
 
@@ -309,6 +369,142 @@ TSharedPtr<FJsonValue> FDiffHandlers::DiffBlueprint(const TSharedPtr<FJsonObject
 	return MCPResult(Result);
 }
 
+TSharedPtr<FJsonValue> FDiffHandlers::DiffSkeleton(const TSharedPtr<FJsonObject>& Params)
+{
+	FString PathA;
+	if (TSharedPtr<FJsonValue> Err = RequireStringAlt(Params, TEXT("assetPath"), TEXT("path"), PathA)) return Err;
+	FString PathB;
+	if (TSharedPtr<FJsonValue> Err = RequireString(Params, TEXT("otherPath"), PathB)) return Err;
+
+	UObject* AssetA = LoadAssetByPath<UObject>(PathA);
+	if (!AssetA) return MCPError(FString::Printf(TEXT("Asset not found: %s"), *PathA));
+	if (AssetA->GetClass() != USkeleton::StaticClass())
+	{
+		return MCPError(FString::Printf(
+			TEXT("Asset at '%s' must be exactly a Skeleton; found '%s'"),
+			*PathA, *AssetA->GetClass()->GetName()));
+	}
+
+	UObject* AssetB = LoadAssetByPath<UObject>(PathB);
+	if (!AssetB) return MCPError(FString::Printf(TEXT("Asset not found: %s"), *PathB));
+	if (AssetB->GetClass() != USkeleton::StaticClass())
+	{
+		return MCPError(FString::Printf(
+			TEXT("Asset at '%s' must be exactly a Skeleton; found '%s'"),
+			*PathB, *AssetB->GetClass()->GetName()));
+	}
+
+	const USkeleton* A = CastChecked<USkeleton>(AssetA);
+	const USkeleton* B = CastChecked<USkeleton>(AssetB);
+	const TArray<FMeshBoneInfo>& RawA = A->GetReferenceSkeleton().GetRawRefBoneInfo();
+	const TArray<FMeshBoneInfo>& RawB = B->GetReferenceSkeleton().GetRawRefBoneInfo();
+
+	TMap<FString, FString> ParentByBoneA;
+	TMap<FString, FString> ParentByBoneB;
+	for (int32 Index = 0; Index < RawA.Num(); ++Index)
+	{
+		ParentByBoneA.Add(RawA[Index].Name.ToString(), RawParentName(RawA, Index));
+	}
+	for (int32 Index = 0; Index < RawB.Num(); ++Index)
+	{
+		ParentByBoneB.Add(RawB[Index].Name.ToString(), RawParentName(RawB, Index));
+	}
+
+	TArray<FString> RawBonesAdded;
+	TArray<FString> RawBonesRemoved;
+	TArray<FString> SharedRawBones;
+	for (const TPair<FString, FString>& Bone : ParentByBoneB)
+	{
+		if (!ParentByBoneA.Contains(Bone.Key)) RawBonesAdded.Add(Bone.Key);
+	}
+	for (const TPair<FString, FString>& Bone : ParentByBoneA)
+	{
+		if (ParentByBoneB.Contains(Bone.Key)) SharedRawBones.Add(Bone.Key);
+		else RawBonesRemoved.Add(Bone.Key);
+	}
+	RawBonesAdded.Sort();
+	RawBonesRemoved.Sort();
+	SharedRawBones.Sort();
+
+	TArray<TSharedPtr<FJsonValue>> Reparented;
+	bool bSharedParentsMatch = true;
+	for (const FString& BoneName : SharedRawBones)
+	{
+		const FString& ParentA = ParentByBoneA.FindChecked(BoneName);
+		const FString& ParentB = ParentByBoneB.FindChecked(BoneName);
+		if (ParentA != ParentB)
+		{
+			bSharedParentsMatch = false;
+			TSharedPtr<FJsonObject> Delta = MakeShared<FJsonObject>();
+			Delta->SetStringField(TEXT("bone"), BoneName);
+			Delta->SetStringField(TEXT("fromParent"), ParentA);
+			Delta->SetStringField(TEXT("toParent"), ParentB);
+			Reparented.Add(MakeShared<FJsonValueObject>(Delta));
+		}
+	}
+
+	const TArray<FVirtualBoneDiffRecord> VirtualA = CollectVirtualBones(A);
+	const TArray<FVirtualBoneDiffRecord> VirtualB = CollectVirtualBones(B);
+	TArray<FVirtualBoneDiffRecord> VirtualBonesAdded;
+	TArray<FVirtualBoneDiffRecord> VirtualBonesRemoved;
+	for (const FVirtualBoneDiffRecord& Bone : VirtualB)
+	{
+		if (!VirtualA.Contains(Bone)) VirtualBonesAdded.Add(Bone);
+	}
+	for (const FVirtualBoneDiffRecord& Bone : VirtualA)
+	{
+		if (!VirtualB.Contains(Bone)) VirtualBonesRemoved.Add(Bone);
+	}
+	VirtualBonesAdded.Sort(VirtualBoneRecordLess);
+	VirtualBonesRemoved.Sort(VirtualBoneRecordLess);
+
+	const bool bSameRawRoot = RawA.Num() > 0
+		&& RawB.Num() > 0
+		&& RawA[0].ParentIndex == INDEX_NONE
+		&& RawB[0].ParentIndex == INDEX_NONE
+		&& RawA[0].Name == RawB[0].Name;
+	const bool bHierarchyCompatible = bSameRawRoot && bSharedParentsMatch;
+	const bool bEditorCompatible = A->IsCompatibleForEditor(B);
+	const int32 ChangeCount = RawBonesAdded.Num()
+		+ RawBonesRemoved.Num()
+		+ Reparented.Num()
+		+ VirtualBonesAdded.Num()
+		+ VirtualBonesRemoved.Num();
+
+	TSharedPtr<FJsonObject> Result = MCPSuccess();
+	Result->SetStringField(TEXT("assetType"), TEXT("Skeleton"));
+	Result->SetStringField(TEXT("from"), PathA);
+	Result->SetStringField(TEXT("to"), PathB);
+	Result->SetNumberField(TEXT("boneCountFrom"), A->GetReferenceSkeleton().GetNum());
+	Result->SetNumberField(TEXT("boneCountTo"), B->GetReferenceSkeleton().GetNum());
+	Result->SetNumberField(TEXT("rawBoneCountFrom"), RawA.Num());
+	Result->SetNumberField(TEXT("rawBoneCountTo"), RawB.Num());
+	Result->SetNumberField(TEXT("virtualBoneCountFrom"), VirtualA.Num());
+	Result->SetNumberField(TEXT("virtualBoneCountTo"), VirtualB.Num());
+	Result->SetNumberField(TEXT("sharedRawBoneCount"), SharedRawBones.Num());
+	Result->SetArrayField(TEXT("rawBonesAdded"), StringsToJson(RawBonesAdded));
+	Result->SetArrayField(TEXT("rawBonesRemoved"), StringsToJson(RawBonesRemoved));
+	Result->SetArrayField(TEXT("reparented"), Reparented);
+	Result->SetArrayField(TEXT("virtualBonesAdded"), VirtualBonesToJson(VirtualBonesAdded));
+	Result->SetArrayField(TEXT("virtualBonesRemoved"), VirtualBonesToJson(VirtualBonesRemoved));
+	Result->SetBoolField(TEXT("editorCompatible"), bEditorCompatible);
+	Result->SetBoolField(TEXT("hierarchyCompatible"), bHierarchyCompatible);
+	Result->SetNumberField(TEXT("changeCount"), ChangeCount);
+	Result->SetBoolField(TEXT("structurallyIdentical"), ChangeCount == 0);
+	Result->SetBoolField(TEXT("identical"), ChangeCount == 0);
+	Result->SetStringField(TEXT("summary"), ChangeCount == 0
+		? FString::Printf(
+			TEXT("Skeleton structures are identical: %d final, %d raw, %d declared virtual"),
+			A->GetReferenceSkeleton().GetNum(), RawA.Num(), VirtualA.Num())
+		: FString::Printf(
+			TEXT("Skeleton delta: %d change(s), final %d -> %d, raw %d -> %d, declared virtual %d -> %d"),
+			ChangeCount,
+			A->GetReferenceSkeleton().GetNum(), B->GetReferenceSkeleton().GetNum(),
+			RawA.Num(), RawB.Num(), VirtualA.Num(), VirtualB.Num()));
+
+	return MCPResult(Result);
+}
+
 TSharedPtr<FJsonValue> FDiffHandlers::DiffAsset(const TSharedPtr<FJsonObject>& Params)
 {
 	FString PathA;
@@ -320,8 +516,12 @@ TSharedPtr<FJsonValue> FDiffHandlers::DiffAsset(const TSharedPtr<FJsonObject>& P
 		{
 			return DiffBlueprint(Params);
 		}
+		if (Asset->GetClass() == USkeleton::StaticClass())
+		{
+			return DiffSkeleton(Params);
+		}
 		return MCPError(FString::Printf(
-			TEXT("Diffing '%s' assets is not supported yet. Blueprint diffing is available now; StateTree and other graph assets are staged follow-ups."),
+			TEXT("Diffing '%s' assets is not supported yet. Blueprint and Skeleton diffing are available now; StateTree and other graph assets are staged follow-ups."),
 			*Asset->GetClass()->GetName()));
 	}
 	return MCPError(FString::Printf(TEXT("Asset not found: %s"), *PathA));

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DiffHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DiffHandlers.cpp
@@ -8,6 +8,7 @@
 #include "Engine/SimpleConstructionScript.h"
 #include "Engine/SCS_Node.h"
 #include "Animation/Skeleton.h"
+#include "Engine/SkeletalMesh.h"
 #include "ReferenceSkeleton.h"
 
 // ── Structural extraction helpers ────────────────────────────────────────────
@@ -116,6 +117,10 @@ namespace
 	TArray<FVirtualBoneDiffRecord> CollectVirtualBones(const USkeleton* Skeleton)
 	{
 		TArray<FVirtualBoneDiffRecord> Out;
+		if (!Skeleton)
+		{
+			return Out;
+		}
 		Out.Reserve(Skeleton->GetVirtualBones().Num());
 		for (const FVirtualBone& Bone : Skeleton->GetVirtualBones())
 		{
@@ -378,36 +383,52 @@ TSharedPtr<FJsonValue> FDiffHandlers::DiffSkeleton(const TSharedPtr<FJsonObject>
 
 	UObject* AssetA = LoadAssetByPath<UObject>(PathA);
 	if (!AssetA) return MCPError(FString::Printf(TEXT("Asset not found: %s"), *PathA));
-	if (AssetA->GetClass() != USkeleton::StaticClass())
+	const bool bSkeletonAssets = AssetA->GetClass() == USkeleton::StaticClass();
+	const bool bSkeletalMeshAssets = AssetA->GetClass() == USkeletalMesh::StaticClass();
+	if (!bSkeletonAssets && !bSkeletalMeshAssets)
 	{
 		return MCPError(FString::Printf(
-			TEXT("Asset at '%s' must be exactly a Skeleton; found '%s'"),
+			TEXT("Asset at '%s' must be exactly a Skeleton or SkeletalMesh; found '%s'"),
 			*PathA, *AssetA->GetClass()->GetName()));
 	}
 
 	UObject* AssetB = LoadAssetByPath<UObject>(PathB);
 	if (!AssetB) return MCPError(FString::Printf(TEXT("Asset not found: %s"), *PathB));
-	if (AssetB->GetClass() != USkeleton::StaticClass())
+	if (AssetB->GetClass() != AssetA->GetClass())
 	{
 		return MCPError(FString::Printf(
-			TEXT("Asset at '%s' must be exactly a Skeleton; found '%s'"),
-			*PathB, *AssetB->GetClass()->GetName()));
+			TEXT("Asset at '%s' must be exactly a %s to match the first asset; found '%s'"),
+			*PathB, *AssetA->GetClass()->GetName(), *AssetB->GetClass()->GetName()));
 	}
 
-	const USkeleton* A = CastChecked<USkeleton>(AssetA);
-	const USkeleton* B = CastChecked<USkeleton>(AssetB);
-	const TArray<FMeshBoneInfo>& RawA = A->GetReferenceSkeleton().GetRawRefBoneInfo();
-	const TArray<FMeshBoneInfo>& RawB = B->GetReferenceSkeleton().GetRawRefBoneInfo();
+	const USkeleton* SkeletonAssetA = bSkeletonAssets ? CastChecked<USkeleton>(AssetA) : nullptr;
+	const USkeleton* SkeletonAssetB = bSkeletonAssets ? CastChecked<USkeleton>(AssetB) : nullptr;
+	const USkeletalMesh* SkeletalMeshA = bSkeletalMeshAssets ? CastChecked<USkeletalMesh>(AssetA) : nullptr;
+	const USkeletalMesh* SkeletalMeshB = bSkeletalMeshAssets ? CastChecked<USkeletalMesh>(AssetB) : nullptr;
+	const FReferenceSkeleton& ReferenceA = bSkeletonAssets
+		? SkeletonAssetA->GetReferenceSkeleton()
+		: SkeletalMeshA->GetRefSkeleton();
+	const FReferenceSkeleton& ReferenceB = bSkeletonAssets
+		? SkeletonAssetB->GetReferenceSkeleton()
+		: SkeletalMeshB->GetRefSkeleton();
+	const USkeleton* PolicySkeletonA = bSkeletonAssets ? SkeletonAssetA : SkeletalMeshA->GetSkeleton();
+	const USkeleton* PolicySkeletonB = bSkeletonAssets ? SkeletonAssetB : SkeletalMeshB->GetSkeleton();
+	const TArray<FMeshBoneInfo>& RawA = ReferenceA.GetRawRefBoneInfo();
+	const TArray<FMeshBoneInfo>& RawB = ReferenceB.GetRawRefBoneInfo();
 
 	TMap<FName, FName> ParentByBoneA;
 	TMap<FName, FName> ParentByBoneB;
+	TMap<FName, int32> IndexByBoneA;
+	TMap<FName, int32> IndexByBoneB;
 	for (int32 Index = 0; Index < RawA.Num(); ++Index)
 	{
 		ParentByBoneA.Add(RawA[Index].Name, RawParentName(RawA, Index));
+		IndexByBoneA.Add(RawA[Index].Name, Index);
 	}
 	for (int32 Index = 0; Index < RawB.Num(); ++Index)
 	{
 		ParentByBoneB.Add(RawB[Index].Name, RawParentName(RawB, Index));
+		IndexByBoneB.Add(RawB[Index].Name, Index);
 	}
 
 	TArray<FString> RawBonesAdded;
@@ -430,6 +451,7 @@ TSharedPtr<FJsonValue> FDiffHandlers::DiffSkeleton(const TSharedPtr<FJsonObject>
 	});
 
 	TArray<TSharedPtr<FJsonValue>> Reparented;
+	TArray<TSharedPtr<FJsonValue>> RawBoneIndexChanges;
 	bool bSharedParentsMatch = true;
 	for (const FName& BoneName : SharedRawBones)
 	{
@@ -444,10 +466,21 @@ TSharedPtr<FJsonValue> FDiffHandlers::DiffSkeleton(const TSharedPtr<FJsonObject>
 			Delta->SetStringField(TEXT("toParent"), ParentB.ToString());
 			Reparented.Add(MakeShared<FJsonValueObject>(Delta));
 		}
+
+		const int32 IndexA = IndexByBoneA.FindChecked(BoneName);
+		const int32 IndexB = IndexByBoneB.FindChecked(BoneName);
+		if (IndexA != IndexB)
+		{
+			TSharedPtr<FJsonObject> Delta = MakeShared<FJsonObject>();
+			Delta->SetStringField(TEXT("bone"), BoneName.ToString());
+			Delta->SetNumberField(TEXT("fromIndex"), IndexA);
+			Delta->SetNumberField(TEXT("toIndex"), IndexB);
+			RawBoneIndexChanges.Add(MakeShared<FJsonValueObject>(Delta));
+		}
 	}
 
-	const TArray<FVirtualBoneDiffRecord> VirtualA = CollectVirtualBones(A);
-	const TArray<FVirtualBoneDiffRecord> VirtualB = CollectVirtualBones(B);
+	const TArray<FVirtualBoneDiffRecord> VirtualA = CollectVirtualBones(PolicySkeletonA);
+	const TArray<FVirtualBoneDiffRecord> VirtualB = CollectVirtualBones(PolicySkeletonB);
 	TArray<FVirtualBoneDiffRecord> VirtualBonesAdded;
 	TArray<FVirtualBoneDiffRecord> VirtualBonesRemoved;
 	for (const FVirtualBoneDiffRecord& Bone : VirtualB)
@@ -467,42 +500,56 @@ TSharedPtr<FJsonValue> FDiffHandlers::DiffSkeleton(const TSharedPtr<FJsonObject>
 		&& RawB[0].ParentIndex == INDEX_NONE
 		&& RawA[0].Name == RawB[0].Name;
 	const bool bHierarchyCompatible = bSameRawRoot && bSharedParentsMatch;
-	const bool bEditorCompatible = A->IsCompatibleForEditor(B);
+	const bool bEditorCompatible = PolicySkeletonA
+		&& PolicySkeletonB
+		&& (PolicySkeletonA == PolicySkeletonB
+			|| PolicySkeletonA->IsCompatibleForEditor(PolicySkeletonB)
+			|| PolicySkeletonB->IsCompatibleForEditor(PolicySkeletonA));
 	const int32 ChangeCount = RawBonesAdded.Num()
 		+ RawBonesRemoved.Num()
 		+ Reparented.Num()
+		+ RawBoneIndexChanges.Num()
 		+ VirtualBonesAdded.Num()
 		+ VirtualBonesRemoved.Num();
 
 	TSharedPtr<FJsonObject> Result = MCPSuccess();
-	Result->SetStringField(TEXT("assetType"), TEXT("Skeleton"));
+	const FString AssetType = bSkeletonAssets ? TEXT("Skeleton") : TEXT("SkeletalMesh");
+	Result->SetStringField(TEXT("assetType"), AssetType);
 	Result->SetStringField(TEXT("from"), PathA);
 	Result->SetStringField(TEXT("to"), PathB);
-	Result->SetNumberField(TEXT("boneCountFrom"), A->GetReferenceSkeleton().GetNum());
-	Result->SetNumberField(TEXT("boneCountTo"), B->GetReferenceSkeleton().GetNum());
+	Result->SetNumberField(TEXT("boneCountFrom"), ReferenceA.GetNum());
+	Result->SetNumberField(TEXT("boneCountTo"), ReferenceB.GetNum());
 	Result->SetNumberField(TEXT("rawBoneCountFrom"), RawA.Num());
 	Result->SetNumberField(TEXT("rawBoneCountTo"), RawB.Num());
 	Result->SetNumberField(TEXT("virtualBoneCountFrom"), VirtualA.Num());
 	Result->SetNumberField(TEXT("virtualBoneCountTo"), VirtualB.Num());
+	Result->SetStringField(TEXT("virtualBoneSourceFrom"), GetPathNameSafe(PolicySkeletonA));
+	Result->SetStringField(TEXT("virtualBoneSourceTo"), GetPathNameSafe(PolicySkeletonB));
 	Result->SetNumberField(TEXT("sharedRawBoneCount"), SharedRawBones.Num());
 	Result->SetArrayField(TEXT("rawBonesAdded"), StringsToJson(RawBonesAdded));
 	Result->SetArrayField(TEXT("rawBonesRemoved"), StringsToJson(RawBonesRemoved));
 	Result->SetArrayField(TEXT("reparented"), Reparented);
+	Result->SetArrayField(TEXT("rawBoneIndexChanges"), RawBoneIndexChanges);
 	Result->SetArrayField(TEXT("virtualBonesAdded"), VirtualBonesToJson(VirtualBonesAdded));
 	Result->SetArrayField(TEXT("virtualBonesRemoved"), VirtualBonesToJson(VirtualBonesRemoved));
 	Result->SetBoolField(TEXT("editorCompatible"), bEditorCompatible);
 	Result->SetBoolField(TEXT("hierarchyCompatible"), bHierarchyCompatible);
+	Result->SetBoolField(TEXT("referencePoseCompared"), false);
+	Result->SetBoolField(TEXT("exportNamesCompared"), false);
+	Result->SetStringField(
+		TEXT("structureScope"),
+		TEXT("raw bone names, parent names, raw indices, and declared virtual bones; excludes reference-pose transforms and export names"));
 	Result->SetNumberField(TEXT("changeCount"), ChangeCount);
 	Result->SetBoolField(TEXT("structurallyIdentical"), ChangeCount == 0);
 	Result->SetBoolField(TEXT("identical"), ChangeCount == 0);
 	Result->SetStringField(TEXT("summary"), ChangeCount == 0
 		? FString::Printf(
-			TEXT("Skeleton structures are identical: %d final, %d raw, %d declared virtual"),
-			A->GetReferenceSkeleton().GetNum(), RawA.Num(), VirtualA.Num())
+			TEXT("%s structures are identical: %d final, %d raw, %d declared virtual"),
+			*AssetType, ReferenceA.GetNum(), RawA.Num(), VirtualA.Num())
 		: FString::Printf(
-			TEXT("Skeleton delta: %d change(s), final %d -> %d, raw %d -> %d, declared virtual %d -> %d"),
-			ChangeCount,
-			A->GetReferenceSkeleton().GetNum(), B->GetReferenceSkeleton().GetNum(),
+			TEXT("%s delta: %d change(s), final %d -> %d, raw %d -> %d, declared virtual %d -> %d"),
+			*AssetType, ChangeCount,
+			ReferenceA.GetNum(), ReferenceB.GetNum(),
 			RawA.Num(), RawB.Num(), VirtualA.Num(), VirtualB.Num()));
 
 	return MCPResult(Result);
@@ -519,12 +566,13 @@ TSharedPtr<FJsonValue> FDiffHandlers::DiffAsset(const TSharedPtr<FJsonObject>& P
 		{
 			return DiffBlueprint(Params);
 		}
-		if (Asset->GetClass() == USkeleton::StaticClass())
+		if (Asset->GetClass() == USkeleton::StaticClass()
+			|| Asset->GetClass() == USkeletalMesh::StaticClass())
 		{
 			return DiffSkeleton(Params);
 		}
 		return MCPError(FString::Printf(
-			TEXT("Diffing '%s' assets is not supported yet. Blueprint and Skeleton diffing are available now; StateTree and other graph assets are staged follow-ups."),
+			TEXT("Diffing '%s' assets is not supported yet. Blueprint, Skeleton, and SkeletalMesh diffing are available now; StateTree and other graph assets are staged follow-ups."),
 			*Asset->GetClass()->GetName()));
 	}
 	return MCPError(FString::Printf(TEXT("Asset not found: %s"), *PathA));

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DiffHandlers.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DiffHandlers.h
@@ -30,11 +30,15 @@ private:
 	// otherPath (compare/B). Reports changes as A -> B.
 	static TSharedPtr<FJsonValue> DiffBlueprint(const TSharedPtr<FJsonObject>& Params);
 
-	// Diff two exact USkeleton assets without emitting transforms or full bone
-	// dumps. Raw hierarchy and virtual-bone deltas are reported separately.
+	// Diff two exact USkeleton or USkeletalMesh assets without emitting full
+	// bone dumps. Compares raw bone names, parent names, raw indices, and
+	// declared virtual-bone records. Reference-pose transforms, export names,
+	// sockets, retarget sources, and other metadata are outside this structural
+	// diff. Both inputs must have the same exact asset class.
 	static TSharedPtr<FJsonValue> DiffSkeleton(const TSharedPtr<FJsonObject>& Params);
 
-	// Type-routing entry point. Blueprints and Skeletons delegate to their
-	// respective semantic diff handlers; unsupported classes fail clearly.
+	// Type-routing entry point. Blueprints, Skeletons, and SkeletalMeshes
+	// delegate to their respective semantic diff handlers; unsupported classes
+	// fail clearly.
 	static TSharedPtr<FJsonValue> DiffAsset(const TSharedPtr<FJsonObject>& Params);
 };

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DiffHandlers.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DiffHandlers.h
@@ -30,7 +30,11 @@ private:
 	// otherPath (compare/B). Reports changes as A -> B.
 	static TSharedPtr<FJsonValue> DiffBlueprint(const TSharedPtr<FJsonObject>& Params);
 
-	// Type-routing entry point. Blueprints delegate to DiffBlueprint; other
-	// asset classes return a clear "not yet supported" until their phase lands.
+	// Diff two exact USkeleton assets without emitting transforms or full bone
+	// dumps. Raw hierarchy and virtual-bone deltas are reported separately.
+	static TSharedPtr<FJsonValue> DiffSkeleton(const TSharedPtr<FJsonObject>& Params);
+
+	// Type-routing entry point. Blueprints and Skeletons delegate to their
+	// respective semantic diff handlers; unsupported classes fail clearly.
 	static TSharedPtr<FJsonValue> DiffAsset(const TSharedPtr<FJsonObject>& Params);
 };

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/SkeletonDiffTests.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/SkeletonDiffTests.cpp
@@ -1,0 +1,473 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Animation/Skeleton.h"
+#include "HandlerRegistry.h"
+#include "Handlers/DiffHandlers.h"
+#include "Misc/AutomationTest.h"
+#include "ReferenceSkeleton.h"
+#include "UObject/ObjectSaveContext.h"
+#include "UObject/Package.h"
+
+#include <initializer_list>
+
+namespace
+{
+struct FTestBone
+{
+	const TCHAR* Name;
+	int32 ParentIndex;
+};
+
+class FTransientSkeletonPackage
+{
+public:
+	explicit FTransientSkeletonPackage(const TCHAR* TestName)
+	{
+		const FString PackageName = FString::Printf(
+			TEXT("/Temp/UEMCP_%s_%s"),
+			TestName,
+			*FGuid::NewGuid().ToString(EGuidFormats::Digits));
+		Package = CreatePackage(*PackageName);
+		Package->SetPackageFlags(PKG_Transient);
+		Package->SetDirtyFlag(false);
+	}
+
+	~FTransientSkeletonPackage()
+	{
+		if (Package)
+		{
+			Package->SetDirtyFlag(false);
+			Package->MarkAsGarbage();
+		}
+	}
+
+	USkeleton* AddSkeleton(const TCHAR* Name, std::initializer_list<FTestBone> Bones)
+	{
+		USkeleton* Skeleton = NewObject<USkeleton>(Package, FName(Name), RF_Transient);
+		{
+			FReferenceSkeletonModifier Modifier(Skeleton);
+			for (const FTestBone& Bone : Bones)
+			{
+				Modifier.Add(
+					FMeshBoneInfo(FName(Bone.Name), Bone.Name, Bone.ParentIndex),
+					FTransform::Identity);
+			}
+		}
+		return Skeleton;
+	}
+
+	UObject* AddWrongTypeObject(const TCHAR* Name)
+	{
+		return NewObject<UObject>(Package, FName(Name), RF_Transient);
+	}
+
+	void ResetDirty() const
+	{
+		Package->SetDirtyFlag(false);
+	}
+
+	UPackage* GetPackage() const
+	{
+		return Package;
+	}
+
+private:
+	UPackage* Package = nullptr;
+};
+
+class FPackageSaveObserver
+{
+public:
+	explicit FPackageSaveObserver(UPackage* InPackage)
+		: ObservedPackage(InPackage)
+	{
+		Handle = UPackage::PreSavePackageWithContextEvent.AddLambda(
+			[this](UPackage* Package, FObjectPreSaveContext)
+			{
+				if (Package == ObservedPackage)
+				{
+					++SaveAttempts;
+				}
+			});
+	}
+
+	~FPackageSaveObserver()
+	{
+		UPackage::PreSavePackageWithContextEvent.Remove(Handle);
+	}
+
+	int32 GetSaveAttempts() const
+	{
+		return SaveAttempts;
+	}
+
+private:
+	UPackage* ObservedPackage = nullptr;
+	FDelegateHandle Handle;
+	int32 SaveAttempts = 0;
+};
+
+TSharedPtr<FJsonObject> MakeDiffRequest(const FString& FromPath, const FString& ToPath)
+{
+	TSharedPtr<FJsonObject> Request = MakeShared<FJsonObject>();
+	Request->SetStringField(TEXT("assetPath"), FromPath);
+	if (!ToPath.IsEmpty())
+	{
+		Request->SetStringField(TEXT("otherPath"), ToPath);
+	}
+	return Request;
+}
+
+TSharedPtr<FJsonObject> ExecuteDiff(
+	FMCPHandlerRegistry& Registry,
+	const FString& FromPath,
+	const FString& ToPath)
+{
+	const TSharedPtr<FJsonValue> Response = Registry.ExecuteHandler(
+		TEXT("diff_asset"),
+		MakeDiffRequest(FromPath, ToPath));
+	return Response.IsValid() && Response->Type == EJson::Object
+		? Response->AsObject()
+		: nullptr;
+}
+
+TSharedPtr<FJsonObject> ExecuteDiff(
+	FMCPHandlerRegistry& Registry,
+	const UObject* From,
+	const UObject* To)
+{
+	return ExecuteDiff(
+		Registry,
+		From->GetPathName(),
+		To ? To->GetPathName() : FString());
+}
+
+TArray<FString> GetStringArray(const TSharedPtr<FJsonObject>& Object, const TCHAR* Field)
+{
+	TArray<FString> Result;
+	const TArray<TSharedPtr<FJsonValue>>* Values = nullptr;
+	if (Object.IsValid() && Object->TryGetArrayField(Field, Values) && Values)
+	{
+		for (const TSharedPtr<FJsonValue>& Value : *Values)
+		{
+			FString StringValue;
+			if (Value.IsValid() && Value->TryGetString(StringValue))
+			{
+				Result.Add(MoveTemp(StringValue));
+			}
+		}
+	}
+	return Result;
+}
+
+const TArray<TSharedPtr<FJsonValue>>* GetArray(
+	const TSharedPtr<FJsonObject>& Object,
+	const TCHAR* Field)
+{
+	const TArray<TSharedPtr<FJsonValue>>* Values = nullptr;
+	return Object.IsValid() && Object->TryGetArrayField(Field, Values) ? Values : nullptr;
+}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FSkeletonDiffRegistrationAndValidationTest,
+	"UE.MCP.Diff.Skeleton.RegistrationAndValidation",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkeletonDiffRegistrationAndValidationTest::RunTest(const FString& Parameters)
+{
+	FMCPHandlerRegistry Registry;
+	FDiffHandlers::RegisterHandlers(Registry);
+	TestTrue(TEXT("diff_asset is registered"), Registry.HasHandler(TEXT("diff_asset")));
+
+	FTransientSkeletonPackage Fixture(TEXT("SkeletonDiffValidation"));
+	USkeleton* Skeleton = Fixture.AddSkeleton(TEXT("Skeleton"), {
+		{ TEXT("root"), INDEX_NONE },
+	});
+	UObject* WrongType = Fixture.AddWrongTypeObject(TEXT("WrongType"));
+	Fixture.ResetDirty();
+	FPackageSaveObserver SaveObserver(Fixture.GetPackage());
+
+	const TSharedPtr<FJsonObject> MissingOther = ExecuteDiff(Registry, Skeleton, nullptr);
+	TestTrue(TEXT("missing otherPath returns an object"), MissingOther.IsValid());
+	if (MissingOther.IsValid())
+	{
+		TestFalse(TEXT("missing otherPath fails"), MissingOther->GetBoolField(TEXT("success")));
+		TestTrue(
+			TEXT("missing otherPath names the missing parameter"),
+			MissingOther->GetStringField(TEXT("error")).Contains(TEXT("otherPath")));
+	}
+
+	const TSharedPtr<FJsonObject> WrongTypeResult = ExecuteDiff(Registry, Skeleton, WrongType);
+	TestTrue(TEXT("wrong-type otherPath returns an object"), WrongTypeResult.IsValid());
+	if (WrongTypeResult.IsValid())
+	{
+		TestFalse(TEXT("wrong-type otherPath fails"), WrongTypeResult->GetBoolField(TEXT("success")));
+		const FString Error = WrongTypeResult->GetStringField(TEXT("error"));
+		TestTrue(TEXT("wrong type requires an exact Skeleton"), Error.Contains(TEXT("must be exactly a Skeleton")));
+		TestTrue(TEXT("wrong type identifies the resolved class"), Error.Contains(TEXT("Object")));
+	}
+
+	const FString MissingFromPath = Fixture.GetPackage()->GetName() + TEXT(".MissingFrom");
+	const TSharedPtr<FJsonObject> MissingFrom = ExecuteDiff(
+		Registry,
+		MissingFromPath,
+		Skeleton->GetPathName());
+	TestTrue(TEXT("unloadable assetPath returns an object"), MissingFrom.IsValid());
+	if (MissingFrom.IsValid())
+	{
+		TestFalse(TEXT("unloadable assetPath fails"), MissingFrom->GetBoolField(TEXT("success")));
+		const FString Error = MissingFrom->GetStringField(TEXT("error"));
+		TestTrue(TEXT("unloadable assetPath has a clear not-found error"), Error.Contains(TEXT("Asset not found")));
+		TestTrue(TEXT("unloadable assetPath error identifies the path"), Error.Contains(MissingFromPath));
+	}
+
+	const FString MissingToPath = Fixture.GetPackage()->GetName() + TEXT(".MissingTo");
+	const TSharedPtr<FJsonObject> MissingTo = ExecuteDiff(
+		Registry,
+		Skeleton->GetPathName(),
+		MissingToPath);
+	TestTrue(TEXT("unloadable otherPath returns an object"), MissingTo.IsValid());
+	if (MissingTo.IsValid())
+	{
+		TestFalse(TEXT("unloadable otherPath fails"), MissingTo->GetBoolField(TEXT("success")));
+		const FString Error = MissingTo->GetStringField(TEXT("error"));
+		TestTrue(TEXT("unloadable otherPath has a clear not-found error"), Error.Contains(TEXT("Asset not found")));
+		TestTrue(TEXT("unloadable otherPath error identifies the path"), Error.Contains(MissingToPath));
+	}
+	TestFalse(TEXT("validation does not dirty the fixture package"), Fixture.GetPackage()->IsDirty());
+	TestEqual(TEXT("validation never attempts to save the fixture package"), SaveObserver.GetSaveAttempts(), 0);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FSkeletonDiffIdenticalAndSideEffectsTest,
+	"UE.MCP.Diff.Skeleton.IdenticalAndSideEffects",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkeletonDiffIdenticalAndSideEffectsTest::RunTest(const FString& Parameters)
+{
+	FMCPHandlerRegistry Registry;
+	FDiffHandlers::RegisterHandlers(Registry);
+	FTransientSkeletonPackage Fixture(TEXT("SkeletonDiffIdentical"));
+	USkeleton* Skeleton = Fixture.AddSkeleton(TEXT("Skeleton"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("pelvis"), 0 },
+	});
+	Fixture.ResetDirty();
+	FPackageSaveObserver SaveObserver(Fixture.GetPackage());
+
+	const TSharedPtr<FJsonObject> Result = ExecuteDiff(Registry, Skeleton, Skeleton);
+	TestTrue(TEXT("same-object diff returns an object"), Result.IsValid());
+	if (Result.IsValid())
+	{
+		TestTrue(TEXT("same-object diff succeeds"), Result->GetBoolField(TEXT("success")));
+		TestEqual(TEXT("asset type is Skeleton"), Result->GetStringField(TEXT("assetType")), FString(TEXT("Skeleton")));
+		TestTrue(TEXT("same-object diff is identical"), Result->GetBoolField(TEXT("identical")));
+		TestTrue(TEXT("same-object diff is structurally identical"), Result->GetBoolField(TEXT("structurallyIdentical")));
+		TestEqual(TEXT("identical diff has zero changes"), static_cast<int32>(Result->GetNumberField(TEXT("changeCount"))), 0);
+		TestEqual(TEXT("raw count is reported"), static_cast<int32>(Result->GetNumberField(TEXT("rawBoneCountFrom"))), 2);
+		TestEqual(TEXT("final count is reported"), static_cast<int32>(Result->GetNumberField(TEXT("boneCountFrom"))), 2);
+		TestTrue(TEXT("same object is editor-compatible"), Result->GetBoolField(TEXT("editorCompatible")));
+		TestTrue(TEXT("identical hierarchy is compatible"), Result->GetBoolField(TEXT("hierarchyCompatible")));
+		TestEqual(TEXT("identical diff has no added raw bones"), GetStringArray(Result, TEXT("rawBonesAdded")).Num(), 0);
+	}
+	TestFalse(TEXT("read-only diff does not dirty its package"), Fixture.GetPackage()->IsDirty());
+	TestEqual(TEXT("read-only diff never attempts to save its package"), SaveObserver.GetSaveAttempts(), 0);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FSkeletonDiffDirectionalRawBoneTest,
+	"UE.MCP.Diff.Skeleton.DirectionalRawBonesAndOrdering",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkeletonDiffDirectionalRawBoneTest::RunTest(const FString& Parameters)
+{
+	FMCPHandlerRegistry Registry;
+	FDiffHandlers::RegisterHandlers(Registry);
+	FTransientSkeletonPackage Fixture(TEXT("SkeletonDiffRaw"));
+	USkeleton* From = Fixture.AddSkeleton(TEXT("From"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("RemovedZulu"), 0 },
+		{ TEXT("RemovedAlpha"), 0 },
+	});
+	USkeleton* To = Fixture.AddSkeleton(TEXT("To"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("AddedZulu"), 0 },
+		{ TEXT("AddedAlpha"), 0 },
+	});
+	Fixture.ResetDirty();
+
+	const TSharedPtr<FJsonObject> Forward = ExecuteDiff(Registry, From, To);
+	TestTrue(TEXT("forward raw-bone diff succeeds"), Forward.IsValid() && Forward->GetBoolField(TEXT("success")));
+	if (Forward.IsValid())
+	{
+		const TArray<FString> Added = GetStringArray(Forward, TEXT("rawBonesAdded"));
+		const TArray<FString> Removed = GetStringArray(Forward, TEXT("rawBonesRemoved"));
+		TestEqual(TEXT("two raw bones are added"), Added.Num(), 2);
+		TestEqual(TEXT("two raw bones are removed"), Removed.Num(), 2);
+		if (Added.Num() == 2)
+		{
+			TestEqual(TEXT("added bones are sorted first"), Added[0], FString(TEXT("AddedAlpha")));
+			TestEqual(TEXT("added bones are sorted second"), Added[1], FString(TEXT("AddedZulu")));
+		}
+		if (Removed.Num() == 2)
+		{
+			TestEqual(TEXT("removed bones are sorted first"), Removed[0], FString(TEXT("RemovedAlpha")));
+			TestEqual(TEXT("removed bones are sorted second"), Removed[1], FString(TEXT("RemovedZulu")));
+		}
+		TestTrue(TEXT("additive/removal-only hierarchy stays compatible"), Forward->GetBoolField(TEXT("hierarchyCompatible")));
+	}
+
+	const TSharedPtr<FJsonObject> Reverse = ExecuteDiff(Registry, To, From);
+	TestTrue(TEXT("reverse raw-bone diff succeeds"), Reverse.IsValid() && Reverse->GetBoolField(TEXT("success")));
+	if (Reverse.IsValid())
+	{
+		TestTrue(
+			TEXT("reverse added set is the forward removed set"),
+			GetStringArray(Reverse, TEXT("rawBonesAdded")) == GetStringArray(Forward, TEXT("rawBonesRemoved")));
+		TestTrue(
+			TEXT("reverse removed set is the forward added set"),
+			GetStringArray(Reverse, TEXT("rawBonesRemoved")) == GetStringArray(Forward, TEXT("rawBonesAdded")));
+	}
+	TestFalse(TEXT("directional diff does not dirty its package"), Fixture.GetPackage()->IsDirty());
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FSkeletonDiffReparentTest,
+	"UE.MCP.Diff.Skeleton.ReparentedHierarchy",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkeletonDiffReparentTest::RunTest(const FString& Parameters)
+{
+	FMCPHandlerRegistry Registry;
+	FDiffHandlers::RegisterHandlers(Registry);
+	FTransientSkeletonPackage Fixture(TEXT("SkeletonDiffReparent"));
+	USkeleton* From = Fixture.AddSkeleton(TEXT("From"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("ParentA"), 0 },
+		{ TEXT("ParentB"), 0 },
+		{ TEXT("CommonBone"), 1 },
+	});
+	USkeleton* To = Fixture.AddSkeleton(TEXT("To"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("ParentB"), 0 },
+		{ TEXT("ParentA"), 0 },
+		{ TEXT("CommonBone"), 1 },
+	});
+	Fixture.ResetDirty();
+
+	const TSharedPtr<FJsonObject> Result = ExecuteDiff(Registry, From, To);
+	TestTrue(TEXT("reparent diff succeeds"), Result.IsValid() && Result->GetBoolField(TEXT("success")));
+	if (Result.IsValid())
+	{
+		TestFalse(TEXT("reparented hierarchy is incompatible"), Result->GetBoolField(TEXT("hierarchyCompatible")));
+		TestEqual(TEXT("numeric sibling reordering does not look like add/remove"), GetStringArray(Result, TEXT("rawBonesAdded")).Num(), 0);
+		const TArray<TSharedPtr<FJsonValue>>* Reparented = GetArray(Result, TEXT("reparented"));
+		TestTrue(TEXT("reparented array is present"), Reparented != nullptr);
+		if (Reparented && Reparented->Num() == 1)
+		{
+			const TSharedPtr<FJsonObject> Delta = (*Reparented)[0]->AsObject();
+			TestEqual(TEXT("reparented bone is named"), Delta->GetStringField(TEXT("bone")), FString(TEXT("CommonBone")));
+			TestEqual(TEXT("old parent is name-derived"), Delta->GetStringField(TEXT("fromParent")), FString(TEXT("ParentA")));
+			TestEqual(TEXT("new parent is name-derived"), Delta->GetStringField(TEXT("toParent")), FString(TEXT("ParentB")));
+		}
+		else
+		{
+			AddError(TEXT("Expected exactly one reparented bone"));
+		}
+	}
+	TestFalse(TEXT("reparent diff does not dirty its package"), Fixture.GetPackage()->IsDirty());
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FSkeletonDiffVirtualBoneTest,
+	"UE.MCP.Diff.Skeleton.VirtualBones",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkeletonDiffVirtualBoneTest::RunTest(const FString& Parameters)
+{
+	FMCPHandlerRegistry Registry;
+	FDiffHandlers::RegisterHandlers(Registry);
+	FTransientSkeletonPackage Fixture(TEXT("SkeletonDiffVirtual"));
+	USkeleton* From = Fixture.AddSkeleton(TEXT("From"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("Source"), 0 },
+		{ TEXT("TargetA"), 0 },
+		{ TEXT("TargetB"), 0 },
+	});
+	USkeleton* To = Fixture.AddSkeleton(TEXT("To"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("Source"), 0 },
+		{ TEXT("TargetA"), 0 },
+		{ TEXT("TargetB"), 0 },
+	});
+	TestTrue(TEXT("from virtual bone is created"), From->AddNewNamedVirtualBone(TEXT("Source"), TEXT("TargetA"), TEXT("VB shared")));
+	TestTrue(TEXT("to virtual bone is created"), To->AddNewNamedVirtualBone(TEXT("Source"), TEXT("TargetB"), TEXT("VB shared")));
+	Fixture.ResetDirty();
+
+	const TSharedPtr<FJsonObject> Result = ExecuteDiff(Registry, From, To);
+	TestTrue(TEXT("virtual-bone diff succeeds"), Result.IsValid() && Result->GetBoolField(TEXT("success")));
+	if (Result.IsValid())
+	{
+		TestTrue(TEXT("virtual endpoint change is non-identical"), !Result->GetBoolField(TEXT("identical")));
+		TestTrue(TEXT("virtual-only delta preserves raw hierarchy compatibility"), Result->GetBoolField(TEXT("hierarchyCompatible")));
+		TestEqual(TEXT("declared virtual count from is reported"), static_cast<int32>(Result->GetNumberField(TEXT("virtualBoneCountFrom"))), 1);
+		TestEqual(TEXT("final reference count includes valid virtual from"), static_cast<int32>(Result->GetNumberField(TEXT("boneCountFrom"))), 5);
+
+		const TArray<TSharedPtr<FJsonValue>>* Added = GetArray(Result, TEXT("virtualBonesAdded"));
+		const TArray<TSharedPtr<FJsonValue>>* Removed = GetArray(Result, TEXT("virtualBonesRemoved"));
+		TestTrue(TEXT("changed virtual definition adds one record"), Added && Added->Num() == 1);
+		TestTrue(TEXT("changed virtual definition removes one record"), Removed && Removed->Num() == 1);
+		if (Added && Added->Num() == 1)
+		{
+			const TSharedPtr<FJsonObject> Bone = (*Added)[0]->AsObject();
+			TestEqual(TEXT("added virtual name"), Bone->GetStringField(TEXT("name")), FString(TEXT("VB shared")));
+			TestEqual(TEXT("added virtual source"), Bone->GetStringField(TEXT("sourceBone")), FString(TEXT("Source")));
+			TestEqual(TEXT("added virtual target"), Bone->GetStringField(TEXT("targetBone")), FString(TEXT("TargetB")));
+		}
+		if (Removed && Removed->Num() == 1)
+		{
+			const TSharedPtr<FJsonObject> Bone = (*Removed)[0]->AsObject();
+			TestEqual(TEXT("removed virtual target"), Bone->GetStringField(TEXT("targetBone")), FString(TEXT("TargetA")));
+		}
+	}
+	TestFalse(TEXT("virtual diff does not dirty its package"), Fixture.GetPackage()->IsDirty());
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FSkeletonDiffEditorCompatibilityTest,
+	"UE.MCP.Diff.Skeleton.EditorCompatibility",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkeletonDiffEditorCompatibilityTest::RunTest(const FString& Parameters)
+{
+	FMCPHandlerRegistry Registry;
+	FDiffHandlers::RegisterHandlers(Registry);
+	FTransientSkeletonPackage Fixture(TEXT("SkeletonDiffCompatibility"));
+	USkeleton* From = Fixture.AddSkeleton(TEXT("From"), {
+		{ TEXT("root"), INDEX_NONE },
+	});
+	USkeleton* To = Fixture.AddSkeleton(TEXT("To"), {
+		{ TEXT("root"), INDEX_NONE },
+	});
+	From->AddCompatibleSkeleton(To);
+	Fixture.ResetDirty();
+
+	const TSharedPtr<FJsonObject> Result = ExecuteDiff(Registry, From, To);
+	TestTrue(TEXT("editor-compatibility diff succeeds"), Result.IsValid() && Result->GetBoolField(TEXT("success")));
+	if (Result.IsValid())
+	{
+		TestTrue(TEXT("editorCompatible field is present"), Result->HasTypedField<EJson::Boolean>(TEXT("editorCompatible")));
+		TestTrue(TEXT("explicitly registered skeleton is editor-compatible"), Result->GetBoolField(TEXT("editorCompatible")));
+		TestTrue(TEXT("hierarchy compatibility remains separately present"), Result->HasTypedField<EJson::Boolean>(TEXT("hierarchyCompatible")));
+	}
+	TestFalse(TEXT("compatibility query does not dirty its package"), Fixture.GetPackage()->IsDirty());
+	return true;
+}
+
+#endif

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/SkeletonDiffTests.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/SkeletonDiffTests.cpp
@@ -278,6 +278,48 @@ bool FSkeletonDiffIdenticalAndSideEffectsTest::RunTest(const FString& Parameters
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FSkeletonDiffFNameIdentityTest,
+	"UE.MCP.Diff.Skeleton.FNameIdentity",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkeletonDiffFNameIdentityTest::RunTest(const FString& Parameters)
+{
+	FMCPHandlerRegistry Registry;
+	FDiffHandlers::RegisterHandlers(Registry);
+	FTransientSkeletonPackage Fixture(TEXT("SkeletonDiffFNameIdentity"));
+	USkeleton* From = Fixture.AddSkeleton(TEXT("From"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("pelvis"), 0 },
+		{ TEXT("hand"), 1 },
+	});
+	USkeleton* To = Fixture.AddSkeleton(TEXT("To"), {
+		{ TEXT("ROOT"), INDEX_NONE },
+		{ TEXT("PELVIS"), 0 },
+		{ TEXT("HAND"), 1 },
+	});
+	TestTrue(TEXT("from virtual bone is created"), From->AddNewNamedVirtualBone(TEXT("pelvis"), TEXT("hand"), TEXT("VB Aim")));
+	TestTrue(TEXT("to virtual bone is created"), To->AddNewNamedVirtualBone(TEXT("PELVIS"), TEXT("HAND"), TEXT("vb aim")));
+	Fixture.ResetDirty();
+
+	const TSharedPtr<FJsonObject> Result = ExecuteDiff(Registry, From, To);
+	TestTrue(TEXT("case-only diff succeeds"), Result.IsValid() && Result->GetBoolField(TEXT("success")));
+	if (Result.IsValid())
+	{
+		TestTrue(TEXT("FName-equivalent skeletons are structurally identical"), Result->GetBoolField(TEXT("structurallyIdentical")));
+		TestTrue(TEXT("FName-equivalent hierarchy is compatible"), Result->GetBoolField(TEXT("hierarchyCompatible")));
+		TestEqual(TEXT("case-only names add no changes"), static_cast<int32>(Result->GetNumberField(TEXT("changeCount"))), 0);
+		TestEqual(TEXT("case-only raw names are not added"), GetStringArray(Result, TEXT("rawBonesAdded")).Num(), 0);
+		TestEqual(TEXT("case-only raw names are not removed"), GetStringArray(Result, TEXT("rawBonesRemoved")).Num(), 0);
+		const TArray<TSharedPtr<FJsonValue>>* AddedVirtual = GetArray(Result, TEXT("virtualBonesAdded"));
+		const TArray<TSharedPtr<FJsonValue>>* RemovedVirtual = GetArray(Result, TEXT("virtualBonesRemoved"));
+		TestTrue(TEXT("case-only virtual names are not added"), AddedVirtual && AddedVirtual->Num() == 0);
+		TestTrue(TEXT("case-only virtual names are not removed"), RemovedVirtual && RemovedVirtual->Num() == 0);
+	}
+	TestFalse(TEXT("case-only diff does not dirty its package"), Fixture.GetPackage()->IsDirty());
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FSkeletonDiffDirectionalRawBoneTest,
 	"UE.MCP.Diff.Skeleton.DirectionalRawBonesAndOrdering",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/SkeletonDiffTests.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/SkeletonDiffTests.cpp
@@ -662,7 +662,10 @@ bool FSkeletonDiffEditorCompatibilityTest::RunTest(const FString& Parameters)
 	USkeleton* To = Fixture.AddSkeleton(TEXT("To"), {
 		{ TEXT("root"), INDEX_NONE },
 	});
-	From->AddCompatibleSkeleton(To);
+	To->AddCompatibleSkeleton(From);
+	TestFalse(
+		TEXT("forward policy query is false before the reverse-compatible diff"),
+		From->IsCompatibleForEditor(To));
 	Fixture.ResetDirty();
 
 	const TSharedPtr<FJsonObject> Result = ExecuteDiff(Registry, From, To);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/SkeletonDiffTests.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/SkeletonDiffTests.cpp
@@ -1,6 +1,8 @@
 #if WITH_DEV_AUTOMATION_TESTS
 
 #include "Animation/Skeleton.h"
+#include "Engine/SkeletalMesh.h"
+#include "HandlerUtils.h"
 #include "HandlerRegistry.h"
 #include "Handlers/DiffHandlers.h"
 #include "Misc/AutomationTest.h"
@@ -54,6 +56,27 @@ public:
 			}
 		}
 		return Skeleton;
+	}
+
+	USkeletalMesh* AddSkeletalMesh(
+		const TCHAR* Name,
+		std::initializer_list<FTestBone> Bones,
+		USkeleton* AssociatedSkeleton)
+	{
+		USkeletalMesh* Mesh = NewObject<USkeletalMesh>(Package, FName(Name), RF_Transient);
+		FReferenceSkeleton ReferenceSkeleton;
+		{
+			FReferenceSkeletonModifier Modifier(ReferenceSkeleton, AssociatedSkeleton);
+			for (const FTestBone& Bone : Bones)
+			{
+				Modifier.Add(
+					FMeshBoneInfo(FName(Bone.Name), Bone.Name, Bone.ParentIndex),
+					FTransform::Identity);
+			}
+		}
+		Mesh->SetRefSkeleton(ReferenceSkeleton);
+		Mesh->SetSkeleton(AssociatedSkeleton);
+		return Mesh;
 	}
 
 	UObject* AddWrongTypeObject(const TCHAR* Name)
@@ -166,6 +189,22 @@ const TArray<TSharedPtr<FJsonValue>>* GetArray(
 {
 	const TArray<TSharedPtr<FJsonValue>>* Values = nullptr;
 	return Object.IsValid() && Object->TryGetArrayField(Field, Values) ? Values : nullptr;
+}
+
+bool AddNamedVirtualBoneForTest(
+	USkeleton* Skeleton,
+	const FName SourceBone,
+	const FName TargetBone,
+	const FName DesiredName,
+	FName& OutActualName)
+{
+#if UE_MCP_HAS_5_5_API
+	OutActualName = DesiredName;
+	return Skeleton->AddNewNamedVirtualBone(SourceBone, TargetBone, DesiredName);
+#else
+	OutActualName = NAME_None;
+	return Skeleton->AddNewVirtualBone(SourceBone, TargetBone, OutActualName);
+#endif
 }
 }
 
@@ -297,8 +336,15 @@ bool FSkeletonDiffFNameIdentityTest::RunTest(const FString& Parameters)
 		{ TEXT("PELVIS"), 0 },
 		{ TEXT("HAND"), 1 },
 	});
-	TestTrue(TEXT("from virtual bone is created"), From->AddNewNamedVirtualBone(TEXT("pelvis"), TEXT("hand"), TEXT("VB Aim")));
-	TestTrue(TEXT("to virtual bone is created"), To->AddNewNamedVirtualBone(TEXT("PELVIS"), TEXT("HAND"), TEXT("vb aim")));
+	FName FromVirtualName;
+	FName ToVirtualName;
+	TestTrue(
+		TEXT("from virtual bone is created"),
+		AddNamedVirtualBoneForTest(From, TEXT("pelvis"), TEXT("hand"), TEXT("VB Aim"), FromVirtualName));
+	TestTrue(
+		TEXT("to virtual bone is created"),
+		AddNamedVirtualBoneForTest(To, TEXT("PELVIS"), TEXT("HAND"), TEXT("vb aim"), ToVirtualName));
+	TestEqual(TEXT("case-only virtual bone names retain FName identity"), FromVirtualName, ToVirtualName);
 	Fixture.ResetDirty();
 
 	const TSharedPtr<FJsonObject> Result = ExecuteDiff(Registry, From, To);
@@ -378,6 +424,118 @@ bool FSkeletonDiffDirectionalRawBoneTest::RunTest(const FString& Parameters)
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FSkeletonDiffRawBoneIndexTest,
+	"UE.MCP.Diff.Skeleton.RawBoneIndexChanges",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkeletonDiffRawBoneIndexTest::RunTest(const FString& Parameters)
+{
+	FMCPHandlerRegistry Registry;
+	FDiffHandlers::RegisterHandlers(Registry);
+	FTransientSkeletonPackage Fixture(TEXT("SkeletonDiffRawIndex"));
+	USkeleton* From = Fixture.AddSkeleton(TEXT("From"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("SiblingZulu"), 0 },
+		{ TEXT("SiblingAlpha"), 0 },
+	});
+	USkeleton* To = Fixture.AddSkeleton(TEXT("To"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("SiblingAlpha"), 0 },
+		{ TEXT("SiblingZulu"), 0 },
+	});
+	Fixture.ResetDirty();
+
+	const TSharedPtr<FJsonObject> Result = ExecuteDiff(Registry, From, To);
+	TestTrue(TEXT("raw-index diff succeeds"), Result.IsValid() && Result->GetBoolField(TEXT("success")));
+	if (Result.IsValid())
+	{
+		TestFalse(TEXT("sibling reordering is not structurally identical"), Result->GetBoolField(TEXT("structurallyIdentical")));
+		TestTrue(TEXT("sibling reordering preserves hierarchy compatibility"), Result->GetBoolField(TEXT("hierarchyCompatible")));
+		TestEqual(TEXT("sibling reordering counts two index changes"), static_cast<int32>(Result->GetNumberField(TEXT("changeCount"))), 2);
+		TestEqual(TEXT("sibling reordering adds no raw bones"), GetStringArray(Result, TEXT("rawBonesAdded")).Num(), 0);
+		TestEqual(TEXT("sibling reordering removes no raw bones"), GetStringArray(Result, TEXT("rawBonesRemoved")).Num(), 0);
+		const TArray<TSharedPtr<FJsonValue>>* IndexChanges = GetArray(Result, TEXT("rawBoneIndexChanges"));
+		TestTrue(TEXT("raw index changes are present"), IndexChanges && IndexChanges->Num() == 2);
+		if (IndexChanges && IndexChanges->Num() == 2)
+		{
+			const TSharedPtr<FJsonObject> First = (*IndexChanges)[0]->AsObject();
+			const TSharedPtr<FJsonObject> Second = (*IndexChanges)[1]->AsObject();
+			TestEqual(TEXT("index changes are sorted by bone name"), First->GetStringField(TEXT("bone")), FString(TEXT("SiblingAlpha")));
+			TestEqual(TEXT("first old index is exact"), static_cast<int32>(First->GetNumberField(TEXT("fromIndex"))), 2);
+			TestEqual(TEXT("first new index is exact"), static_cast<int32>(First->GetNumberField(TEXT("toIndex"))), 1);
+			TestEqual(TEXT("second changed bone is exact"), Second->GetStringField(TEXT("bone")), FString(TEXT("SiblingZulu")));
+			TestEqual(TEXT("second old index is exact"), static_cast<int32>(Second->GetNumberField(TEXT("fromIndex"))), 1);
+			TestEqual(TEXT("second new index is exact"), static_cast<int32>(Second->GetNumberField(TEXT("toIndex"))), 2);
+		}
+	}
+	TestFalse(TEXT("raw-index diff does not dirty its package"), Fixture.GetPackage()->IsDirty());
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FSkeletalMeshDiffPublicRouteTest,
+	"UE.MCP.Diff.Skeleton.SkeletalMeshPublicRoute",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSkeletalMeshDiffPublicRouteTest::RunTest(const FString& Parameters)
+{
+	FMCPHandlerRegistry Registry;
+	FDiffHandlers::RegisterHandlers(Registry);
+	FTransientSkeletonPackage Fixture(TEXT("SkeletalMeshDiffRoute"));
+	USkeleton* FromPolicy = Fixture.AddSkeleton(TEXT("FromPolicy"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("pelvis"), 0 },
+	});
+	USkeleton* ToPolicy = Fixture.AddSkeleton(TEXT("ToPolicy"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("pelvis"), 0 },
+		{ TEXT("hand_attach"), 1 },
+	});
+	FName FromVirtualName;
+	FName ToVirtualName;
+	TestTrue(
+		TEXT("from policy virtual bone is created"),
+		AddNamedVirtualBoneForTest(FromPolicy, TEXT("root"), TEXT("pelvis"), TEXT("VB shared"), FromVirtualName));
+	TestTrue(
+		TEXT("to policy virtual bone is created"),
+		AddNamedVirtualBoneForTest(ToPolicy, TEXT("root"), TEXT("pelvis"), TEXT("VB shared"), ToVirtualName));
+	USkeletalMesh* From = Fixture.AddSkeletalMesh(TEXT("SK_From"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("pelvis"), 0 },
+	}, FromPolicy);
+	USkeletalMesh* To = Fixture.AddSkeletalMesh(TEXT("SK_To"), {
+		{ TEXT("root"), INDEX_NONE },
+		{ TEXT("pelvis"), 0 },
+		{ TEXT("hand_attach"), 1 },
+	}, ToPolicy);
+	Fixture.ResetDirty();
+	FPackageSaveObserver SaveObserver(Fixture.GetPackage());
+
+	const TSharedPtr<FJsonObject> Result = ExecuteDiff(Registry, From, To);
+	TestTrue(TEXT("public diff_asset routes SkeletalMesh assets"), Result.IsValid() && Result->GetBoolField(TEXT("success")));
+	if (Result.IsValid())
+	{
+		TestEqual(TEXT("asset type is SkeletalMesh"), Result->GetStringField(TEXT("assetType")), FString(TEXT("SkeletalMesh")));
+		TestEqual(TEXT("mesh raw count from is compact"), static_cast<int32>(Result->GetNumberField(TEXT("rawBoneCountFrom"))), 2);
+		TestEqual(TEXT("mesh raw count to is compact"), static_cast<int32>(Result->GetNumberField(TEXT("rawBoneCountTo"))), 3);
+		const TArray<FString> Added = GetStringArray(Result, TEXT("rawBonesAdded"));
+		TestEqual(TEXT("mesh diff reports one added bone"), Added.Num(), 1);
+		if (Added.Num() == 1)
+		{
+			TestEqual(TEXT("mesh added bone is exact"), Added[0], FString(TEXT("hand_attach")));
+		}
+		TestTrue(TEXT("additive mesh hierarchy remains compatible"), Result->GetBoolField(TEXT("hierarchyCompatible")));
+		TestEqual(TEXT("mesh policy virtual bones are compared"), static_cast<int32>(Result->GetNumberField(TEXT("virtualBoneCountFrom"))), 1);
+		TestEqual(TEXT("from virtual source is the associated Skeleton"), Result->GetStringField(TEXT("virtualBoneSourceFrom")), FromPolicy->GetPathName());
+		TestFalse(TEXT("reference-pose omission is explicit"), Result->GetBoolField(TEXT("referencePoseCompared")));
+		TestFalse(TEXT("export-name omission is explicit"), Result->GetBoolField(TEXT("exportNamesCompared")));
+	}
+	TestFalse(TEXT("SkeletalMesh diff stays read-only"), Fixture.GetPackage()->IsDirty());
+	TestEqual(TEXT("SkeletalMesh diff never saves"), SaveObserver.GetSaveAttempts(), 0);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FSkeletonDiffReparentTest,
 	"UE.MCP.Diff.Skeleton.ReparentedHierarchy",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
@@ -447,8 +605,14 @@ bool FSkeletonDiffVirtualBoneTest::RunTest(const FString& Parameters)
 		{ TEXT("TargetA"), 0 },
 		{ TEXT("TargetB"), 0 },
 	});
-	TestTrue(TEXT("from virtual bone is created"), From->AddNewNamedVirtualBone(TEXT("Source"), TEXT("TargetA"), TEXT("VB shared")));
-	TestTrue(TEXT("to virtual bone is created"), To->AddNewNamedVirtualBone(TEXT("Source"), TEXT("TargetB"), TEXT("VB shared")));
+	FName FromVirtualName;
+	FName ToVirtualName;
+	TestTrue(
+		TEXT("from virtual bone is created"),
+		AddNamedVirtualBoneForTest(From, TEXT("Source"), TEXT("TargetA"), TEXT("VB shared"), FromVirtualName));
+	TestTrue(
+		TEXT("to virtual bone is created"),
+		AddNamedVirtualBoneForTest(To, TEXT("Source"), TEXT("TargetB"), TEXT("VB shared"), ToVirtualName));
 	Fixture.ResetDirty();
 
 	const TSharedPtr<FJsonObject> Result = ExecuteDiff(Registry, From, To);
@@ -467,13 +631,14 @@ bool FSkeletonDiffVirtualBoneTest::RunTest(const FString& Parameters)
 		if (Added && Added->Num() == 1)
 		{
 			const TSharedPtr<FJsonObject> Bone = (*Added)[0]->AsObject();
-			TestEqual(TEXT("added virtual name"), Bone->GetStringField(TEXT("name")), FString(TEXT("VB shared")));
+			TestEqual(TEXT("added virtual name"), Bone->GetStringField(TEXT("name")), ToVirtualName.ToString());
 			TestEqual(TEXT("added virtual source"), Bone->GetStringField(TEXT("sourceBone")), FString(TEXT("Source")));
 			TestEqual(TEXT("added virtual target"), Bone->GetStringField(TEXT("targetBone")), FString(TEXT("TargetB")));
 		}
 		if (Removed && Removed->Num() == 1)
 		{
 			const TSharedPtr<FJsonObject> Bone = (*Removed)[0]->AsObject();
+			TestEqual(TEXT("removed virtual name"), Bone->GetStringField(TEXT("name")), FromVirtualName.ToString());
 			TestEqual(TEXT("removed virtual target"), Bone->GetStringField(TEXT("targetBone")), FString(TEXT("TargetA")));
 		}
 	}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
@@ -140,4 +140,3 @@ public class UE_MCP_Bridge : ModuleRules
 }
 
 // Rescan trigger: round 2 added handler translation units.
-// Rescan trigger: add Private/Tests/SkeletonDiffTests.cpp.

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
@@ -140,3 +140,4 @@ public class UE_MCP_Bridge : ModuleRules
 }
 
 // Rescan trigger: round 2 added handler translation units.
+// Rescan trigger: add Private/Tests/SkeletonDiffTests.cpp.


### PR DESCRIPTION
## What changed

- Extend the native `diff_asset` bridge handler to compare exact `USkeleton` and `USkeletalMesh` assets.
- Return compact, deterministic raw-bone additions/removals, reparenting, raw-index changes, declared virtual-bone deltas, and separate hierarchy/editor compatibility signals.
- Source SkeletalMesh virtual-bone policy from each mesh's associated Skeleton and report that source explicitly.
- Make the structural scope explicit: reference-pose transforms, export names, sockets, retarget sources, and other metadata are not compared.
- Add read-only Unreal automation coverage for validation, identity, ordering, reparenting, virtual bones, UE 5.4-5.8 virtual-bone API compatibility, SkeletalMesh routing, and reverse compatibility policy.

## Why

Issue #879 had to load mannequin SkeletalMesh assets through `execute_python` and manually compare hundreds of bone entries. This adds the compact native bridge operation needed to answer that structural compatibility question without custom Python or full bone dumps.

This PR is intentionally scoped to `plugin/ue_mcp_bridge`. The server-side `asset(diff)` description can be updated separately to advertise the newly supported classes.

Addresses #879.

## Safety

- Read-only handler; tests assert no package dirtying or save attempts.
- Both inputs must resolve to the same exact supported class.
- Missing paths, mixed classes, unsupported types, and malformed requests fail closed.
- Delta collections are deterministically ordered.
- Reference-pose and other out-of-scope metadata omissions are explicit in the result.

## Validation

- `npx.cmd tsc --noEmit`
- `npm.cmd run test:unit` — 83 files / 840 tests passed
- `npm.cmd run audit:unity`
- `git diff --check upstream/main...HEAD`
- Two independent static reviews, including UE 5.4-5.8 API compatibility

The guarded native build was attempted against the bundled `tests/ue_mcp` project with `-NoEngineChanges`. UnrealBuildTool stopped before compilation because the selected source engine's newer `Build.version` would rewrite existing engine binaries/module manifests. The guard was not bypassed.

Full `npm run audit` still reports unrelated baseline drift in `asset.migrate` documentation parameters and existing handler/caller inventory; focused unity and TypeScript/unit checks pass.