### PR TITLE
Add native static mesh usage summary

### DIFF
--- a/plugin/ue_mcp_bridge/NATIVE_STATIC_MESH_USAGE_PROGRESS.md
+++ b/plugin/ue_mcp_bridge/NATIVE_STATIC_MESH_USAGE_PROGRESS.md
@@ -1,0 +1,115 @@
+# Native Static Mesh Usage Progress
+
+Last updated: 2026-08-12
+
+## Status
+
+| Field | Value |
+| --- | --- |
+| Overall | Source implementation committed; native validation pending; draft PR awaiting review |
+| Pull request | [db-lyon/ue-mcp#903](https://github.com/db-lyon/ue-mcp/pull/903) |
+| Branch | `codex/native-static-mesh-usage` |
+| Base | `db-lyon/ue-mcp:main` at `849a194` |
+| Scope | `plugin/ue_mcp_bridge` only |
+| Handler | `summarize_static_mesh_usage` |
+| Mutation policy | Read-only |
+
+## Goal
+
+Provide a native replacement for the repetitive current-level workflow of
+enumerating actors, reading each static mesh component, and aggregating mesh
+properties through many bridge calls or an `execute_python` script. The raw
+bridge handler performs the common inspection in one bounded game-thread request.
+A typed server action is intentionally deferred because this change is limited
+to the UE-MCP plugin folder.
+
+## Completed
+
+- [x] Register `summarize_static_mesh_usage` with the level handler registry.
+- [x] Support exact `editor` and `pie` world selection, including `pieInstance`.
+- [x] Scan loaded actors and all owned `UStaticMeshComponent` subclasses.
+- [x] Count actors, components, and placements separately.
+- [x] Count a plain static mesh component as one placement.
+- [x] Count ISMC and HISM placements with `GetInstanceCount()`.
+- [x] Preserve zero-instance components in component totals without adding placements.
+- [x] Report null-mesh components diagnostically.
+- [x] Sort results by placement count descending, then mesh path ascending.
+- [x] Bound returned mesh rows to 1 through 500.
+- [x] Bound occurrence examples to 0 through 256 across the response.
+- [x] Fail closed above 8,192 unique loaded meshes.
+- [x] Report full-scan totals even when result rows are truncated.
+- [x] Author plugin-local Automation coverage for registration, world validation,
+  aggregation, ordering, plain and ISMC placement semantics, null meshes, and bounds.
+- [x] Complete independent static review against Unreal Engine 5.8 APIs.
+- [x] Open a plugin-only draft pull request.
+
+## Validation
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Local engine-free unit suite | Passed | 83 files, 840 tests |
+| Local TypeScript type check | Passed | `npx tsc --noEmit` |
+| Local unity collision audit | Passed | `npm run audit:unity` |
+| Local em dash audit | Passed | `npm run audit:em-dash` |
+| GitHub engine-free CI | Passed | Workflow run `31600014333`: 83 files and 840 unit tests, plus 4 files and 32 multi-editor tests |
+| UE 5.8 API/static review | Passed | No P0 or P1 findings |
+| Native Unreal compilation | Not yet proven | Guarded local build stopped before compilation because protected engine outputs would have changed |
+| Native Automation execution | Not yet run | Requires a prepared Unreal test engine or upstream CI lane that compiles the plugin |
+
+The GitHub CI runner has no Unreal installation. Its successful build job
+exercises the repository's Node and TypeScript checks; it does not replace
+native Unreal compilation or execution of the new Automation tests. The
+workflow's `publish` and `surface_counts` jobs were skipped, not failed.
+
+## Changed Files
+
+- `Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers.cpp`
+- `Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers.h`
+- `Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Inspection.cpp`
+- `Source/UE_MCP_Bridge/Private/Tests/LevelStaticMeshUsageTests.cpp`
+- `Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs`
+- `NATIVE_STATIC_MESH_USAGE_PROGRESS.md`
+
+## Current Contract
+
+Example parameters:
+
+```json
+{
+  "world": "editor",
+  "maxResults": 100,
+  "includeOccurrences": false,
+  "maxOccurrences": 32
+}
+```
+
+The result is explicitly `loadedOnly`. It summarizes the selected loaded world
+and makes no claim about unloaded World Partition actors. It performs no asset
+loads, saves, or mutations.
+
+## Remaining Work
+
+- [ ] Compile the plugin in a prepared Unreal Engine test lane.
+- [ ] Run `UE.MCP.Level.SummarizeStaticMeshUsage.*` Automation tests.
+- [ ] Address any upstream review comments on PR #903. None exist as of the
+  last-updated date.
+- [ ] Decide separately whether to expose a typed server action outside the
+  plugin folder. That is intentionally not part of this plugin-only change.
+- [ ] Mark the PR ready for review after native validation or maintainer approval
+  of the documented validation boundary.
+
+## Update Rules
+
+Keep this file current whenever implementation, validation, review state, or
+scope changes:
+
+1. Update the date and overall status.
+2. Move finished items into `Completed` or check them in place.
+3. Record exact validation commands and outcomes without overstating coverage.
+4. Add newly discovered blockers or follow-up work under `Remaining Work`.
+5. Keep all project-specific context outside this plugin progress record.
+
+## History
+
+- 2026-08-12: Native handler, focused tests, static review, engine-free validation,
+  and draft PR completed. Native Unreal compilation remains pending.

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers.cpp
@@ -120,6 +120,7 @@ void FLevelHandlers::RegisterHandlers(FMCPHandlerRegistry& Registry)
 	Registry.RegisterHandler(TEXT("set_fog_properties"), &SetFogProperties);
 	Registry.RegisterHandler(TEXT("get_actors_by_class"), &GetActorsByClass);
 	Registry.RegisterHandler(TEXT("get_actors_by_component_class"), &GetActorsByComponentClass);
+	Registry.RegisterHandler(TEXT("summarize_static_mesh_usage"), &SummarizeStaticMeshUsage);
 	Registry.RegisterHandler(TEXT("count_actors_by_class"), &CountActorsByClass);
 	Registry.RegisterHandler(TEXT("get_runtime_virtual_texture_summary"), &GetRVTSummary);
 	Registry.RegisterHandler(TEXT("set_water_body_property"), &SetWaterBodyProperty);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers.h
@@ -52,6 +52,8 @@ private:
 	static TSharedPtr<FJsonValue> GetActorsByClass(const TSharedPtr<FJsonObject>& Params);
 	// #582 find actors that own a component of a given class
 	static TSharedPtr<FJsonValue> GetActorsByComponentClass(const TSharedPtr<FJsonObject>& Params);
+	// Aggregate loaded static-mesh usage in one bounded, read-only world scan.
+	static TSharedPtr<FJsonValue> SummarizeStaticMeshUsage(const TSharedPtr<FJsonObject>& Params);
 	// v0.7.19 issue #146 - actor class histogram (counts by class name)
 	static TSharedPtr<FJsonValue> CountActorsByClass(const TSharedPtr<FJsonObject>& Params);
 	// v0.7.19 issue #150 - RuntimeVirtualTextureVolume / component summary

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Inspection.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Inspection.cpp
@@ -1,0 +1,280 @@
+#include "LevelHandlers.h"
+
+#include "HandlerUtils.h"
+
+#include "Components/InstancedStaticMeshComponent.h"
+#include "Components/StaticMeshComponent.h"
+#include "Engine/StaticMesh.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "GameFramework/Actor.h"
+
+namespace
+{
+	constexpr int32 DefaultStaticMeshResults = 100;
+	constexpr int32 MaxStaticMeshResults = 500;
+	constexpr int32 HardMaxUniqueStaticMeshes = 8192;
+	constexpr int32 DefaultStaticMeshOccurrences = 32;
+	constexpr int32 MaxStaticMeshOccurrences = 256;
+
+	struct FStaticMeshAggregate
+	{
+		FString MeshPath;
+		FString LastActorPath;
+		int64 ActorCount = 0;
+		int64 ComponentCount = 0;
+		int64 PlacementCount = 0;
+	};
+
+	int64 GetPlacementCount(const UStaticMeshComponent* Component)
+	{
+		if (const UInstancedStaticMeshComponent* Instanced = Cast<UInstancedStaticMeshComponent>(Component))
+		{
+			return FMath::Max(0, Instanced->GetInstanceCount());
+		}
+
+		return 1;
+	}
+
+	void GetSortedActors(UWorld* World, TArray<AActor*>& OutActors)
+	{
+		for (TActorIterator<AActor> It(World); It; ++It)
+		{
+			if (IsValid(*It))
+			{
+				OutActors.Add(*It);
+			}
+		}
+
+		OutActors.Sort([](const AActor& Left, const AActor& Right)
+		{
+			return Left.GetPathName() < Right.GetPathName();
+		});
+	}
+
+	void GetSortedStaticMeshComponents(AActor* Actor, TArray<UStaticMeshComponent*>& OutComponents)
+	{
+		Actor->GetComponents<UStaticMeshComponent>(OutComponents);
+		OutComponents.RemoveAll([](const UStaticMeshComponent* Component)
+		{
+			return !IsValid(Component);
+		});
+		OutComponents.Sort([](const UStaticMeshComponent& Left, const UStaticMeshComponent& Right)
+		{
+			return Left.GetPathName() < Right.GetPathName();
+		});
+	}
+}
+
+TSharedPtr<FJsonValue> FLevelHandlers::SummarizeStaticMeshUsage(const TSharedPtr<FJsonObject>& Params)
+{
+	check(IsInGameThread());
+
+	const FString RequestedWorld = OptionalString(Params, TEXT("world"), TEXT("editor"));
+	const bool bEditorWorld = RequestedWorld.Equals(TEXT("editor"), ESearchCase::IgnoreCase);
+	const bool bPieWorld = RequestedWorld.Equals(TEXT("pie"), ESearchCase::IgnoreCase);
+	if (!bEditorWorld && !bPieWorld)
+	{
+		return MCPError(TEXT("Invalid 'world': expected 'editor' or 'pie'"));
+	}
+
+	const FString WorldScope = bEditorWorld ? TEXT("editor") : TEXT("pie");
+	UWorld* World = ResolveWorldFromParams(Params, *WorldScope);
+	if (!World)
+	{
+		return MCPError(FString::Printf(TEXT("World not available for scope '%s'"), *WorldScope));
+	}
+
+	const int32 MaxResults = FMath::Clamp(
+		OptionalInt(Params, TEXT("maxResults"), DefaultStaticMeshResults),
+		1,
+		MaxStaticMeshResults);
+	const bool bIncludeOccurrences = OptionalBool(Params, TEXT("includeOccurrences"), false);
+	const int32 MaxOccurrences = FMath::Clamp(
+		OptionalInt(Params, TEXT("maxOccurrences"), DefaultStaticMeshOccurrences),
+		0,
+		MaxStaticMeshOccurrences);
+
+	// Actor/component iteration order is not an API guarantee. Exact object-path
+	// ordering makes aggregation and the bounded occurrence sample reproducible.
+	TArray<AActor*> Actors;
+	GetSortedActors(World, Actors);
+
+	TMap<FString, FStaticMeshAggregate> Aggregates;
+	int64 StaticMeshActors = 0;
+	int64 ScannedStaticMeshComponents = 0;
+	int64 NullMeshComponents = 0;
+	int64 TotalComponentCount = 0;
+	int64 TotalPlacementCount = 0;
+
+	for (AActor* Actor : Actors)
+	{
+		if (!IsValid(Actor))
+		{
+			continue;
+		}
+
+		TArray<UStaticMeshComponent*> Components;
+		GetSortedStaticMeshComponents(Actor, Components);
+		if (Components.Num() > 0)
+		{
+			++StaticMeshActors;
+		}
+
+		const FString ActorPath = Actor->GetPathName();
+		for (UStaticMeshComponent* Component : Components)
+		{
+			++ScannedStaticMeshComponents;
+			UStaticMesh* Mesh = Component->GetStaticMesh();
+			if (!IsValid(Mesh))
+			{
+				++NullMeshComponents;
+				continue;
+			}
+
+			const FString MeshPath = Mesh->GetPathName();
+			FStaticMeshAggregate* Aggregate = Aggregates.Find(MeshPath);
+			if (!Aggregate)
+			{
+				if (Aggregates.Num() >= HardMaxUniqueStaticMeshes)
+				{
+					return MCPError(FString::Printf(
+						TEXT("Static mesh usage exceeds the hard limit of %d unique loaded meshes"),
+						HardMaxUniqueStaticMeshes));
+				}
+
+				FStaticMeshAggregate NewAggregate;
+				NewAggregate.MeshPath = MeshPath;
+				Aggregate = &Aggregates.Add(MeshPath, MoveTemp(NewAggregate));
+			}
+
+			const int64 PlacementCount = GetPlacementCount(Component);
+			++TotalComponentCount;
+			TotalPlacementCount += PlacementCount;
+			++Aggregate->ComponentCount;
+			Aggregate->PlacementCount += PlacementCount;
+			if (Aggregate->LastActorPath != ActorPath)
+			{
+				Aggregate->LastActorPath = ActorPath;
+				++Aggregate->ActorCount;
+			}
+		}
+	}
+
+	TArray<FString> SortedMeshPaths;
+	Aggregates.GenerateKeyArray(SortedMeshPaths);
+	SortedMeshPaths.Sort([&Aggregates](const FString& LeftPath, const FString& RightPath)
+	{
+		const FStaticMeshAggregate& Left = Aggregates.FindChecked(LeftPath);
+		const FStaticMeshAggregate& Right = Aggregates.FindChecked(RightPath);
+		if (Left.PlacementCount != Right.PlacementCount)
+		{
+			return Left.PlacementCount > Right.PlacementCount;
+		}
+		return LeftPath < RightPath;
+	});
+
+	const int32 ReturnedMeshCount = FMath::Min(MaxResults, SortedMeshPaths.Num());
+	SortedMeshPaths.SetNum(ReturnedMeshCount);
+	TSet<FString> ReturnedMeshPaths;
+	ReturnedMeshPaths.Reserve(ReturnedMeshCount);
+	for (const FString& MeshPath : SortedMeshPaths)
+	{
+		ReturnedMeshPaths.Add(MeshPath);
+	}
+
+	// Occurrences are examples, globally capped across only the returned meshes.
+	// A second deterministic pass keeps omitted aggregates from consuming the cap.
+	TMap<FString, TArray<TSharedPtr<FJsonValue>>> OccurrencesByMesh;
+	int32 ReturnedOccurrences = 0;
+	if (bIncludeOccurrences && MaxOccurrences > 0)
+	{
+		for (AActor* Actor : Actors)
+		{
+			if (!IsValid(Actor) || ReturnedOccurrences >= MaxOccurrences)
+			{
+				break;
+			}
+
+			TArray<UStaticMeshComponent*> Components;
+			GetSortedStaticMeshComponents(Actor, Components);
+			for (UStaticMeshComponent* Component : Components)
+			{
+				if (ReturnedOccurrences >= MaxOccurrences)
+				{
+					break;
+				}
+
+				UStaticMesh* Mesh = Component->GetStaticMesh();
+				if (!IsValid(Mesh) || !ReturnedMeshPaths.Contains(Mesh->GetPathName()))
+				{
+					continue;
+				}
+
+				TSharedPtr<FJsonObject> Occurrence = MakeShared<FJsonObject>();
+				Occurrence->SetStringField(TEXT("actorPath"), Actor->GetPathName());
+				Occurrence->SetStringField(TEXT("actorLabel"), Actor->GetActorLabel());
+				Occurrence->SetStringField(TEXT("componentPath"), Component->GetPathName());
+				Occurrence->SetStringField(TEXT("componentName"), Component->GetName());
+				Occurrence->SetStringField(TEXT("componentClass"), Component->GetClass()->GetPathName());
+				Occurrence->SetNumberField(TEXT("placementCount"), static_cast<double>(GetPlacementCount(Component)));
+				OccurrencesByMesh.FindOrAdd(Mesh->GetPathName()).Add(MakeShared<FJsonValueObject>(Occurrence));
+				++ReturnedOccurrences;
+			}
+		}
+	}
+
+	TArray<TSharedPtr<FJsonValue>> MeshesJson;
+	MeshesJson.Reserve(ReturnedMeshCount);
+	int64 ReturnedComponentCount = 0;
+	for (const FString& MeshPath : SortedMeshPaths)
+	{
+		const FStaticMeshAggregate& Aggregate = Aggregates.FindChecked(MeshPath);
+		ReturnedComponentCount += Aggregate.ComponentCount;
+
+		TSharedPtr<FJsonObject> MeshJson = MakeShared<FJsonObject>();
+		MeshJson->SetStringField(TEXT("meshPath"), Aggregate.MeshPath);
+		MeshJson->SetNumberField(TEXT("actorCount"), static_cast<double>(Aggregate.ActorCount));
+		MeshJson->SetNumberField(TEXT("componentCount"), static_cast<double>(Aggregate.ComponentCount));
+		MeshJson->SetNumberField(TEXT("placementCount"), static_cast<double>(Aggregate.PlacementCount));
+
+		if (bIncludeOccurrences)
+		{
+			const TArray<TSharedPtr<FJsonValue>>* Occurrences = OccurrencesByMesh.Find(MeshPath);
+			MeshJson->SetArrayField(
+				TEXT("occurrences"),
+				Occurrences ? *Occurrences : TArray<TSharedPtr<FJsonValue>>());
+			MeshJson->SetBoolField(
+				TEXT("occurrencesTruncated"),
+				!Occurrences || Occurrences->Num() < Aggregate.ComponentCount);
+		}
+
+		MeshesJson.Add(MakeShared<FJsonValueObject>(MeshJson));
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPSuccess();
+	Result->SetStringField(TEXT("world"), WorldScope);
+	Result->SetStringField(TEXT("worldName"), World->GetName());
+	Result->SetBoolField(TEXT("loadedOnly"), true);
+	Result->SetNumberField(TEXT("maxResults"), MaxResults);
+	Result->SetBoolField(TEXT("includeOccurrences"), bIncludeOccurrences);
+	Result->SetNumberField(TEXT("maxOccurrences"), MaxOccurrences);
+	Result->SetNumberField(TEXT("hardUniqueMeshLimit"), HardMaxUniqueStaticMeshes);
+	Result->SetNumberField(TEXT("actorsScanned"), Actors.Num());
+	Result->SetNumberField(TEXT("staticMeshActors"), static_cast<double>(StaticMeshActors));
+	Result->SetNumberField(TEXT("scannedStaticMeshComponents"), static_cast<double>(ScannedStaticMeshComponents));
+	Result->SetNumberField(TEXT("nullMeshComponents"), static_cast<double>(NullMeshComponents));
+	Result->SetNumberField(TEXT("totalComponentCount"), static_cast<double>(TotalComponentCount));
+	Result->SetNumberField(TEXT("totalPlacementCount"), static_cast<double>(TotalPlacementCount));
+	Result->SetNumberField(TEXT("totalUniqueMeshes"), Aggregates.Num());
+	Result->SetNumberField(TEXT("returnedMeshCount"), ReturnedMeshCount);
+	Result->SetBoolField(TEXT("truncated"), ReturnedMeshCount < Aggregates.Num());
+	Result->SetNumberField(TEXT("totalOccurrences"), static_cast<double>(TotalComponentCount));
+	Result->SetNumberField(TEXT("eligibleOccurrencesForReturnedMeshes"), static_cast<double>(ReturnedComponentCount));
+	Result->SetNumberField(TEXT("returnedOccurrences"), ReturnedOccurrences);
+	Result->SetBoolField(
+		TEXT("occurrencesTruncated"),
+		bIncludeOccurrences && ReturnedOccurrences < TotalComponentCount);
+	Result->SetArrayField(TEXT("meshes"), MeshesJson);
+	return MCPResult(Result);
+}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/LevelStaticMeshUsageTests.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/LevelStaticMeshUsageTests.cpp
@@ -1,0 +1,412 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "HandlerRegistry.h"
+#include "Handlers/LevelHandlers.h"
+#include "HandlerUtils.h"
+#include "Misc/AutomationTest.h"
+
+#include "Components/InstancedStaticMeshComponent.h"
+#include "Components/StaticMeshComponent.h"
+#include "Editor.h"
+#include "Engine/Engine.h"
+#include "Engine/StaticMesh.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "UObject/Package.h"
+#include "UObject/UObjectGlobals.h"
+
+namespace
+{
+	constexpr const TCHAR* StaticMeshUsageMethod = TEXT("summarize_static_mesh_usage");
+
+	class FScopedEditorTestWorld
+	{
+	public:
+		FScopedEditorTestWorld()
+		{
+			if (!GEditor)
+			{
+				return;
+			}
+
+			OriginalWorld = GEditor->GetEditorWorldContext().World();
+			const FName WorldName = MakeUniqueObjectName(
+				GetTransientPackage(),
+				UWorld::StaticClass(),
+				FName(TEXT("UEMCP_StaticMeshUsageTestWorld")));
+			const UWorld::InitializationValues InitializationValues = UWorld::InitializationValues()
+				.InitializeScenes(false)
+				.AllowAudioPlayback(false)
+				.RequiresHitProxies(false)
+				.CreatePhysicsScene(false)
+				.CreateNavigation(false)
+				.CreateAISystem(false)
+				.ShouldSimulatePhysics(false)
+				.EnableTraceCollision(false)
+				.SetTransactional(false)
+				.CreateFXSystem(false)
+				.CreateWorldPartition(false);
+
+			TestWorld = UWorld::CreateWorld(
+				EWorldType::Editor,
+				false,
+				WorldName,
+				GetTransientPackage(),
+				true,
+				ERHIFeatureLevel::Num,
+				&InitializationValues);
+			if (TestWorld)
+			{
+				GEditor->GetEditorWorldContext().SetCurrentWorld(TestWorld);
+			}
+		}
+
+		~FScopedEditorTestWorld()
+		{
+			if (GEditor && TestWorld)
+			{
+				GEditor->GetEditorWorldContext().SetCurrentWorld(OriginalWorld);
+			}
+
+			if (TestWorld)
+			{
+				TestWorld->DestroyWorld(false);
+			}
+		}
+
+		UWorld* Get() const
+		{
+			return TestWorld;
+		}
+
+	private:
+		UWorld* OriginalWorld = nullptr;
+		UWorld* TestWorld = nullptr;
+	};
+
+	AActor* SpawnTransientActor(UWorld* World, const TCHAR* Name, const TCHAR* Label)
+	{
+		if (!World)
+		{
+			return nullptr;
+		}
+
+		FActorSpawnParameters SpawnParameters;
+		SpawnParameters.Name = MakeUniqueObjectName(
+			World->PersistentLevel,
+			AActor::StaticClass(),
+			FName(Name));
+		SpawnParameters.ObjectFlags = RF_Transient;
+		AActor* Actor = World->SpawnActor<AActor>(
+			AActor::StaticClass(),
+			FTransform::Identity,
+			SpawnParameters);
+		if (Actor)
+		{
+			Actor->SetActorLabel(Label, false);
+		}
+		return Actor;
+	}
+
+	template <typename ComponentType>
+	ComponentType* AddTransientMeshComponent(
+		AActor* Actor,
+		const TCHAR* Name,
+		UStaticMesh* Mesh)
+	{
+		if (!Actor)
+		{
+			return nullptr;
+		}
+
+		ComponentType* Component = NewObject<ComponentType>(Actor, Name, RF_Transient);
+		Actor->AddInstanceComponent(Component);
+		Component->SetStaticMesh(Mesh);
+		return Component;
+	}
+
+	TSharedPtr<FJsonObject> ExecuteStaticMeshUsage(
+		FMCPHandlerRegistry& Registry,
+		int32 MaxResults,
+		bool bIncludeOccurrences,
+		int32 MaxOccurrences)
+	{
+		TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
+		Params->SetStringField(TEXT("world"), TEXT("editor"));
+		Params->SetNumberField(TEXT("maxResults"), MaxResults);
+		Params->SetBoolField(TEXT("includeOccurrences"), bIncludeOccurrences);
+		Params->SetNumberField(TEXT("maxOccurrences"), MaxOccurrences);
+
+		const TSharedPtr<FJsonValue> Response = Registry.ExecuteHandler(StaticMeshUsageMethod, Params);
+		if (!Response.IsValid() || Response->Type != EJson::Object)
+		{
+			return nullptr;
+		}
+		return Response->AsObject();
+	}
+
+	TSharedPtr<FJsonObject> FindMeshResult(
+		const TArray<TSharedPtr<FJsonValue>>& Meshes,
+		const FString& MeshPath)
+	{
+		for (const TSharedPtr<FJsonValue>& MeshValue : Meshes)
+		{
+			if (!MeshValue.IsValid() || MeshValue->Type != EJson::Object)
+			{
+				continue;
+			}
+
+			const TSharedPtr<FJsonObject>& Mesh = MeshValue->AsObject();
+			if (Mesh.IsValid() && Mesh->GetStringField(TEXT("meshPath")) == MeshPath)
+			{
+				return Mesh;
+			}
+		}
+		return TSharedPtr<FJsonObject>();
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FLevelStaticMeshUsageRegistrationTest,
+	"UE.MCP.Level.SummarizeStaticMeshUsage.RegistrationAndWorldValidation",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FLevelStaticMeshUsageRegistrationTest::RunTest(const FString& Parameters)
+{
+	FMCPHandlerRegistry Registry;
+	FLevelHandlers::RegisterHandlers(Registry);
+	TestTrue(TEXT("static-mesh usage handler is registered"), Registry.HasHandler(StaticMeshUsageMethod));
+
+	TSharedPtr<FJsonObject> InvalidWorldParams = MakeShared<FJsonObject>();
+	InvalidWorldParams->SetStringField(TEXT("world"), TEXT("auto"));
+	const TSharedPtr<FJsonValue> InvalidWorldResponse = Registry.ExecuteHandler(
+		StaticMeshUsageMethod,
+		InvalidWorldParams);
+	TestTrue(
+		TEXT("an invalid editor/PIE scope returns an object"),
+		InvalidWorldResponse.IsValid() && InvalidWorldResponse->Type == EJson::Object);
+	if (InvalidWorldResponse.IsValid() && InvalidWorldResponse->Type == EJson::Object)
+	{
+		const TSharedPtr<FJsonObject> Result = InvalidWorldResponse->AsObject();
+		TestFalse(TEXT("an invalid world scope is unsuccessful"), Result->GetBoolField(TEXT("success")));
+		TestTrue(
+			TEXT("the scope error names both supported choices"),
+			Result->GetStringField(TEXT("error")).Contains(TEXT("editor")) &&
+			Result->GetStringField(TEXT("error")).Contains(TEXT("pie")));
+	}
+
+	// The handler must not silently substitute the editor world when PIE was
+	// explicitly requested. Automation normally runs outside PIE; retain the
+	// invalid-scope assertion above when a caller deliberately runs it in PIE.
+	if (GetPIEWorld() == nullptr)
+	{
+		TSharedPtr<FJsonObject> PieParams = MakeShared<FJsonObject>();
+		PieParams->SetStringField(TEXT("world"), TEXT("pie"));
+		const TSharedPtr<FJsonValue> PieResponse = Registry.ExecuteHandler(StaticMeshUsageMethod, PieParams);
+		TestTrue(
+			TEXT("missing PIE returns an object"),
+			PieResponse.IsValid() && PieResponse->Type == EJson::Object);
+		if (PieResponse.IsValid() && PieResponse->Type == EJson::Object)
+		{
+			const TSharedPtr<FJsonObject> Result = PieResponse->AsObject();
+			TestFalse(TEXT("missing PIE is unsuccessful"), Result->GetBoolField(TEXT("success")));
+			TestTrue(
+				TEXT("missing PIE is reported as the requested scope"),
+				Result->GetStringField(TEXT("error")).Contains(TEXT("pie")));
+		}
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FLevelStaticMeshUsageAggregationTest,
+	"UE.MCP.Level.SummarizeStaticMeshUsage.AggregationOrderingAndBounds",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FLevelStaticMeshUsageAggregationTest::RunTest(const FString& Parameters)
+{
+	FScopedEditorTestWorld TestWorldScope;
+	UWorld* World = TestWorldScope.Get();
+	if (!TestNotNull(TEXT("a transient editor world was created"), World))
+	{
+		return false;
+	}
+
+	const FString UniqueSuffix = FGuid::NewGuid().ToString(EGuidFormats::Digits);
+	UStaticMesh* AlphaMesh = NewObject<UStaticMesh>(
+		GetTransientPackage(),
+		*(FString(TEXT("UEMCP_Alpha_")) + UniqueSuffix),
+		RF_Transient);
+	UStaticMesh* BetaMesh = NewObject<UStaticMesh>(
+		GetTransientPackage(),
+		*(FString(TEXT("UEMCP_Beta_")) + UniqueSuffix),
+		RF_Transient);
+	UStaticMesh* ZuluMesh = NewObject<UStaticMesh>(
+		GetTransientPackage(),
+		*(FString(TEXT("UEMCP_Zulu_")) + UniqueSuffix),
+		RF_Transient);
+	TestNotNull(TEXT("alpha mesh fixture exists"), AlphaMesh);
+	TestNotNull(TEXT("beta mesh fixture exists"), BetaMesh);
+	TestNotNull(TEXT("zulu mesh fixture exists"), ZuluMesh);
+	if (!AlphaMesh || !BetaMesh || !ZuluMesh)
+	{
+		return false;
+	}
+
+	AActor* ActorA = SpawnTransientActor(World, TEXT("UEMCP_Actor_A"), TEXT("Usage Actor A"));
+	AActor* ActorB = SpawnTransientActor(World, TEXT("UEMCP_Actor_B"), TEXT("Usage Actor B"));
+	if (!TestNotNull(TEXT("first fixture actor exists"), ActorA) ||
+		!TestNotNull(TEXT("second fixture actor exists"), ActorB))
+	{
+		return false;
+	}
+
+	UStaticMeshComponent* AlphaPlainA =
+		AddTransientMeshComponent<UStaticMeshComponent>(ActorA, TEXT("CompAlphaAPlain"), AlphaMesh);
+	UInstancedStaticMeshComponent* AlphaInstances =
+		AddTransientMeshComponent<UInstancedStaticMeshComponent>(
+			ActorA,
+			TEXT("CompAlphaBInstanced"),
+			AlphaMesh);
+	UInstancedStaticMeshComponent* BetaInstances =
+		AddTransientMeshComponent<UInstancedStaticMeshComponent>(
+			ActorA,
+			TEXT("CompBeta"),
+			BetaMesh);
+	if (!TestNotNull(TEXT("plain alpha component exists"), AlphaPlainA) ||
+		!TestNotNull(TEXT("instanced alpha component exists"), AlphaInstances) ||
+		!TestNotNull(TEXT("instanced beta component exists"), BetaInstances))
+	{
+		return false;
+	}
+	AlphaInstances->AddInstance(FTransform(FVector(10.0, 0.0, 0.0)));
+	AlphaInstances->AddInstance(FTransform(FVector(20.0, 0.0, 0.0)));
+	for (int32 Index = 0; Index < 5; ++Index)
+	{
+		BetaInstances->AddInstance(FTransform(FVector(0.0, Index * 10.0, 0.0)));
+	}
+
+	UInstancedStaticMeshComponent* ZuluZeroInstances =
+		AddTransientMeshComponent<UInstancedStaticMeshComponent>(
+		ActorA,
+		TEXT("CompZuluZeroInstances"),
+		ZuluMesh);
+	UStaticMeshComponent* NullMeshComponent =
+		AddTransientMeshComponent<UStaticMeshComponent>(ActorA, TEXT("CompNullMesh"), nullptr);
+	UStaticMeshComponent* AlphaPlainB =
+		AddTransientMeshComponent<UStaticMeshComponent>(ActorB, TEXT("CompAlphaCPlain"), AlphaMesh);
+	UInstancedStaticMeshComponent* ZuluInstances =
+		AddTransientMeshComponent<UInstancedStaticMeshComponent>(
+			ActorB,
+			TEXT("CompZuluFilled"),
+			ZuluMesh);
+	if (!TestNotNull(TEXT("zero-instance zulu component exists"), ZuluZeroInstances) ||
+		!TestNotNull(TEXT("null-mesh component exists"), NullMeshComponent) ||
+		!TestNotNull(TEXT("second plain alpha component exists"), AlphaPlainB) ||
+		!TestNotNull(TEXT("filled zulu component exists"), ZuluInstances))
+	{
+		return false;
+	}
+	for (int32 Index = 0; Index < 4; ++Index)
+	{
+		ZuluInstances->AddInstance(FTransform(FVector(0.0, 0.0, Index * 10.0)));
+	}
+
+	FMCPHandlerRegistry Registry;
+	FLevelHandlers::RegisterHandlers(Registry);
+	const TSharedPtr<FJsonObject> Result = ExecuteStaticMeshUsage(Registry, 3, true, 2);
+	if (!TestTrue(TEXT("aggregation returns an object"), Result.IsValid()))
+	{
+		return false;
+	}
+
+	TestTrue(TEXT("aggregation succeeds"), Result->GetBoolField(TEXT("success")));
+	TestEqual(TEXT("the transient editor scope is reported"), Result->GetStringField(TEXT("world")), FString(TEXT("editor")));
+	TestTrue(TEXT("the scan explicitly reports loaded-only semantics"), Result->GetBoolField(TEXT("loadedOnly")));
+	TestEqual(TEXT("the requested row cap is reported"), static_cast<int32>(Result->GetNumberField(TEXT("maxResults"))), 3);
+	TestEqual(TEXT("the requested occurrence cap is reported"), static_cast<int32>(Result->GetNumberField(TEXT("maxOccurrences"))), 2);
+	TestEqual(TEXT("all fixture static-mesh components are scanned"), static_cast<int32>(Result->GetNumberField(TEXT("scannedStaticMeshComponents"))), 7);
+	TestEqual(TEXT("the null mesh component is diagnosed"), static_cast<int32>(Result->GetNumberField(TEXT("nullMeshComponents"))), 1);
+	TestEqual(TEXT("assigned components are counted separately"), static_cast<int32>(Result->GetNumberField(TEXT("totalComponentCount"))), 6);
+	TestEqual(TEXT("plain and instanced placements are counted exactly"), static_cast<int32>(Result->GetNumberField(TEXT("totalPlacementCount"))), 13);
+	TestEqual(TEXT("three unique meshes are aggregated"), static_cast<int32>(Result->GetNumberField(TEXT("totalUniqueMeshes"))), 3);
+	TestEqual(TEXT("all three mesh rows are returned"), static_cast<int32>(Result->GetNumberField(TEXT("returnedMeshCount"))), 3);
+	TestFalse(TEXT("the complete result is not truncated"), Result->GetBoolField(TEXT("truncated")));
+	TestEqual(TEXT("the global occurrence cap is honored"), static_cast<int32>(Result->GetNumberField(TEXT("returnedOccurrences"))), 2);
+	TestEqual(TEXT("all returned-row components contribute to the occurrence total"), static_cast<int32>(Result->GetNumberField(TEXT("totalOccurrences"))), 6);
+	TestTrue(TEXT("the occurrence sample reports truncation"), Result->GetBoolField(TEXT("occurrencesTruncated")));
+
+	const TArray<TSharedPtr<FJsonValue>>& Meshes = Result->GetArrayField(TEXT("meshes"));
+	TestEqual(TEXT("three mesh rows are present"), Meshes.Num(), 3);
+	if (Meshes.Num() == 3)
+	{
+		TestEqual(TEXT("highest placement row sorts first"), Meshes[0]->AsObject()->GetStringField(TEXT("meshPath")), BetaMesh->GetPathName());
+		TestEqual(TEXT("equal-placement rows tie-break by path"), Meshes[1]->AsObject()->GetStringField(TEXT("meshPath")), AlphaMesh->GetPathName());
+		TestEqual(TEXT("the remaining equal-placement row sorts last"), Meshes[2]->AsObject()->GetStringField(TEXT("meshPath")), ZuluMesh->GetPathName());
+	}
+
+	const TSharedPtr<FJsonObject> AlphaResult = FindMeshResult(Meshes, AlphaMesh->GetPathName());
+	const TSharedPtr<FJsonObject> BetaResult = FindMeshResult(Meshes, BetaMesh->GetPathName());
+	const TSharedPtr<FJsonObject> ZuluResult = FindMeshResult(Meshes, ZuluMesh->GetPathName());
+	if (TestTrue(TEXT("alpha aggregate exists"), AlphaResult.IsValid()))
+	{
+		TestEqual(TEXT("alpha actor count"), static_cast<int32>(AlphaResult->GetNumberField(TEXT("actorCount"))), 2);
+		TestEqual(TEXT("alpha component count"), static_cast<int32>(AlphaResult->GetNumberField(TEXT("componentCount"))), 3);
+		TestEqual(TEXT("alpha placement count"), static_cast<int32>(AlphaResult->GetNumberField(TEXT("placementCount"))), 4);
+		const TArray<TSharedPtr<FJsonValue>>& Occurrences = AlphaResult->GetArrayField(TEXT("occurrences"));
+		TestEqual(TEXT("alpha receives the two deterministic occurrence slots"), Occurrences.Num(), 2);
+		if (Occurrences.Num() == 2)
+		{
+			TestEqual(TEXT("first occurrence is path-ordered"), Occurrences[0]->AsObject()->GetStringField(TEXT("componentName")), FString(TEXT("CompAlphaAPlain")));
+			TestEqual(TEXT("second occurrence is path-ordered"), Occurrences[1]->AsObject()->GetStringField(TEXT("componentName")), FString(TEXT("CompAlphaBInstanced")));
+		}
+		TestTrue(TEXT("alpha reports its omitted occurrence"), AlphaResult->GetBoolField(TEXT("occurrencesTruncated")));
+	}
+	if (TestTrue(TEXT("beta aggregate exists"), BetaResult.IsValid()))
+	{
+		TestEqual(TEXT("beta actor count"), static_cast<int32>(BetaResult->GetNumberField(TEXT("actorCount"))), 1);
+		TestEqual(TEXT("beta component count"), static_cast<int32>(BetaResult->GetNumberField(TEXT("componentCount"))), 1);
+		TestEqual(TEXT("beta placement count"), static_cast<int32>(BetaResult->GetNumberField(TEXT("placementCount"))), 5);
+	}
+	if (TestTrue(TEXT("zulu aggregate exists"), ZuluResult.IsValid()))
+	{
+		TestEqual(TEXT("zero-instance components still count as components"), static_cast<int32>(ZuluResult->GetNumberField(TEXT("componentCount"))), 2);
+		TestEqual(TEXT("zero-instance components add no placements"), static_cast<int32>(ZuluResult->GetNumberField(TEXT("placementCount"))), 4);
+		TestEqual(TEXT("zulu actor count includes both referencing actors"), static_cast<int32>(ZuluResult->GetNumberField(TEXT("actorCount"))), 2);
+	}
+
+	const TSharedPtr<FJsonObject> BoundedResult = ExecuteStaticMeshUsage(Registry, 2, false, 256);
+	if (TestTrue(TEXT("bounded aggregation returns an object"), BoundedResult.IsValid()))
+	{
+		TestTrue(TEXT("bounded aggregation succeeds"), BoundedResult->GetBoolField(TEXT("success")));
+		TestEqual(TEXT("bounded aggregation reports the effective row cap"), static_cast<int32>(BoundedResult->GetNumberField(TEXT("maxResults"))), 2);
+		TestEqual(TEXT("bounded aggregation returns two rows"), static_cast<int32>(BoundedResult->GetNumberField(TEXT("returnedMeshCount"))), 2);
+		TestTrue(TEXT("bounded aggregation reports truncation"), BoundedResult->GetBoolField(TEXT("truncated")));
+		const TArray<TSharedPtr<FJsonValue>>& BoundedMeshes = BoundedResult->GetArrayField(TEXT("meshes"));
+		if (TestEqual(TEXT("bounded aggregation contains two rows"), BoundedMeshes.Num(), 2))
+		{
+			TestEqual(TEXT("top-N retains the highest placement row"), BoundedMeshes[0]->AsObject()->GetStringField(TEXT("meshPath")), BetaMesh->GetPathName());
+			TestEqual(TEXT("top-N deterministically retains the first tied row"), BoundedMeshes[1]->AsObject()->GetStringField(TEXT("meshPath")), AlphaMesh->GetPathName());
+		}
+	}
+
+	const TSharedPtr<FJsonObject> ClampedResult = ExecuteStaticMeshUsage(Registry, 0, false, 999);
+	if (TestTrue(TEXT("out-of-range bounds return an object"), ClampedResult.IsValid()))
+	{
+		TestTrue(TEXT("clamped aggregation succeeds"), ClampedResult->GetBoolField(TEXT("success")));
+		TestEqual(TEXT("the row cap clamps to one"), static_cast<int32>(ClampedResult->GetNumberField(TEXT("maxResults"))), 1);
+		TestEqual(TEXT("the occurrence cap clamps to 256"), static_cast<int32>(ClampedResult->GetNumberField(TEXT("maxOccurrences"))), 256);
+		TestEqual(TEXT("the clamped result returns one row"), static_cast<int32>(ClampedResult->GetNumberField(TEXT("returnedMeshCount"))), 1);
+		TestTrue(TEXT("the clamped top-one result is truncated"), ClampedResult->GetBoolField(TEXT("truncated")));
+		const TArray<TSharedPtr<FJsonValue>>& ClampedMeshes = ClampedResult->GetArrayField(TEXT("meshes"));
+		if (TestEqual(TEXT("the clamped result contains one row"), ClampedMeshes.Num(), 1))
+		{
+			TestEqual(TEXT("the clamped top-one row is the highest-use mesh"), ClampedMeshes[0]->AsObject()->GetStringField(TEXT("meshPath")), BetaMesh->GetPathName());
+		}
+	}
+
+	return true;
+}
+
+#endif

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
@@ -8,6 +8,7 @@ public class UE_MCP_Bridge : ModuleRules
 	// new .cpp until this file changes.
 	// Private/Handlers/AssetHandlers_BulkUpsert.cpp: UBT caches the module's
 	// file list and will not pick up a new .cpp until this file changes.
+	// Private/Handlers/LevelHandlers_Inspection.cpp and its focused test: same reason.
 	// Private/BridgeStateFiles.cpp, Private/BridgeParamEcho.cpp and
 	// Private/Tests/BridgeProtocolTests.cpp: same reason.
 	public UE_MCP_Bridge(ReadOnlyTargetRules Target) : base(Target)


### PR DESCRIPTION
## What

- add the read-only `summarize_static_mesh_usage` native bridge handler
- aggregate loaded static mesh usage in one deterministic game-thread scan
- distinguish actors, components, and placements, including ISMC and HISM instance counts
- bound top results and occurrence examples while preserving full-scan totals
- add focused plugin-local Automation coverage for registration, world selection, ordering, counts, and limits
- add a living plugin-local progress record with completed, pending, and validation status

## Why

Current level mesh inventory requires repetitive actor, component, and property calls or an `execute_python` aggregation script. This handler provides the common operation natively in one bounded request.

## Scope and safety

- plugin folder only
- read-only and loaded-world-only
- no asset loads, saves, or mutations
- deterministic sorting by placement count then mesh path
- explicit limits for result rows, occurrence examples, and unique meshes

## Validation

- `npm run test:unit`: 83 files, 840 tests passed
- `npx tsc --noEmit`: passed
- `npm run audit:unity`: passed
- `npm run audit:em-dash`: passed
- independent UE 5.8 API and static compile-risk review: passed

The guarded native build stopped before plugin compilation because `-NoEngineChanges` detected protected engine outputs that would need to change. No engine cleanup or override was attempted, so native compilation and Automation execution remain to be confirmed in CI or a prepared test engine.

The living status and remaining validation work are tracked in `plugin/ue_mcp_bridge/NATIVE_STATIC_MESH_USAGE_PROGRESS.md`.

This intentionally exposes the raw native bridge handler in a plugin-only change. A typed server action can be added separately if desired.