### PR TITLE
Add batched instance surface snap handler

### DIFF
--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers.cpp
@@ -139,6 +139,11 @@ void FLevelHandlers::RegisterHandlers(FMCPHandlerRegistry& Registry)
 	Registry.RegisterHandler(TEXT("get_instance_transforms"), &GetInstanceTransforms);
 	Registry.RegisterHandler(TEXT("update_instance_transform"), &UpdateInstanceTransform);
 	Registry.RegisterHandler(TEXT("remove_instance"), &RemoveInstance);
+	// Native bridge method only in this plugin-scoped change. It appears in
+	// get_bridge_capabilities.actions and can be called directly over JSON-RPC
+	// (or a UeMcpTask bridge.call). A first-class category action also requires a
+	// server schema wrapper, which intentionally lives outside this plugin.
+	Registry.RegisterHandlerWithTimeout(TEXT("snap_instances_to_surface"), &SnapInstancesToSurface, 300.0f);
 	// #696: enable + force-build Nanite on a static mesh.
 	Registry.RegisterHandler(TEXT("set_nanite_settings"), &SetNaniteSettings);
 	Registry.RegisterHandler(TEXT("get_nanite_info"), &GetNaniteInfo);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers.h
@@ -116,6 +116,10 @@ private:
 	// #697: update or remove a single instance on an ISMC/HISMC by index.
 	static TSharedPtr<FJsonValue> UpdateInstanceTransform(const TSharedPtr<FJsonObject>& Params);
 	static TSharedPtr<FJsonValue> RemoveInstance(const TSharedPtr<FJsonObject>& Params);
+	// Preview or commit a bounded batch of ISMC/HISMC instances snapped to a
+	// filtered collision surface. Defaults to dryRun=true and preflights every
+	// trace before one transactional mutation.
+	static TSharedPtr<FJsonValue> SnapInstancesToSurface(const TSharedPtr<FJsonObject>& Params);
 	// #696: enable + force-build Nanite on a UStaticMesh asset, or read its
 	// current Nanite state.
 	static TSharedPtr<FJsonValue> SetNaniteSettings(const TSharedPtr<FJsonObject>& Params);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_InstanceProjection.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_InstanceProjection.cpp
@@ -1,0 +1,657 @@
+// Bounded batch projection for ISMC/HISMC instances.
+// Registration stays in LevelHandlers.cpp::RegisterHandlers.
+
+#include "LevelHandlers.h"
+#include "LevelHandlers_InstanceProjection_Internal.h"
+#include "HandlerUtils.h"
+#include "Editor.h"
+#include "ScopedTransaction.h"
+#include "CollisionQueryParams.h"
+#include "Components/InstancedStaticMeshComponent.h"
+#include "Components/PrimitiveComponent.h"
+#include "Engine/CollisionProfile.h"
+#include "Engine/EngineTypes.h"
+#include "Engine/HitResult.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "GameFramework/Actor.h"
+#include "UObject/Package.h"
+
+namespace UEMCPInstanceProjection
+{
+	bool ParseMissPolicy(const FString& InValue, EMissPolicy& OutPolicy)
+	{
+		const FString Value = InValue.TrimStartAndEnd();
+		if (Value.Equals(TEXT("error"), ESearchCase::IgnoreCase))
+		{
+			OutPolicy = EMissPolicy::Error;
+			return true;
+		}
+		if (Value.Equals(TEXT("skip"), ESearchCase::IgnoreCase))
+		{
+			OutPolicy = EMissPolicy::Skip;
+			return true;
+		}
+		return false;
+	}
+
+	FVector ApplySurfaceOffset(const FVector& ImpactPoint, const FVector& ImpactNormal, double SurfaceOffset)
+	{
+		return ImpactPoint + ImpactNormal.GetSafeNormal() * SurfaceOffset;
+	}
+}
+
+namespace
+{
+	using namespace UEMCPInstanceProjection;
+
+	UInstancedStaticMeshComponent* ResolveProjectionComponent(AActor* Actor, const FString& ComponentName, FString& OutError)
+	{
+		if (!Actor)
+		{
+			OutError = TEXT("Target actor is null");
+			return nullptr;
+		}
+
+		TArray<UInstancedStaticMeshComponent*> Matches;
+		for (UActorComponent* Component : Actor->GetComponents())
+		{
+			if (UInstancedStaticMeshComponent* ISMC = Cast<UInstancedStaticMeshComponent>(Component))
+			{
+				if (ComponentName.IsEmpty() || ISMC->GetName() == ComponentName)
+				{
+					Matches.Add(ISMC);
+				}
+			}
+		}
+
+		if (Matches.Num() == 1) return Matches[0];
+		if (Matches.IsEmpty())
+		{
+			OutError = ComponentName.IsEmpty()
+				? FString::Printf(TEXT("Actor '%s' has no InstancedStaticMeshComponent"), *Actor->GetActorLabel())
+				: FString::Printf(TEXT("Actor '%s' has no InstancedStaticMeshComponent named '%s'"), *Actor->GetActorLabel(), *ComponentName);
+			return nullptr;
+		}
+
+		TArray<FString> Names;
+		for (const UInstancedStaticMeshComponent* Match : Matches) Names.Add(Match->GetName());
+		OutError = FString::Printf(
+			TEXT("Actor '%s' has %d instanced mesh components (%s); pass componentName to select exactly one"),
+			*Actor->GetActorLabel(), Matches.Num(), *FString::Join(Names, TEXT(", ")));
+		return nullptr;
+	}
+
+	bool ResolveProjectionTraceChannel(const FString& InName, ECollisionChannel& OutChannel, FString& OutResolvedName)
+	{
+		FString Name = InName.TrimStartAndEnd();
+		if (Name.StartsWith(TEXT("ECC_"))) Name = Name.RightChop(4);
+		if (Name.IsEmpty()) Name = TEXT("Visibility");
+
+		if (const UCollisionProfile* Profile = UCollisionProfile::Get())
+		{
+			for (int32 Index = 0; Index < ECC_MAX; ++Index)
+			{
+				const FName ChannelName = Profile->ReturnChannelNameFromContainerIndex(Index);
+				if (!ChannelName.IsNone() && ChannelName.ToString().Equals(Name, ESearchCase::IgnoreCase))
+				{
+					OutChannel = static_cast<ECollisionChannel>(Index);
+					OutResolvedName = ChannelName.ToString();
+					return true;
+				}
+			}
+		}
+
+		struct FBuiltInChannel { const TCHAR* Name; ECollisionChannel Channel; };
+		static const FBuiltInChannel BuiltIns[] = {
+			{ TEXT("WorldStatic"), ECC_WorldStatic }, { TEXT("WorldDynamic"), ECC_WorldDynamic },
+			{ TEXT("Pawn"), ECC_Pawn }, { TEXT("Visibility"), ECC_Visibility },
+			{ TEXT("Camera"), ECC_Camera }, { TEXT("PhysicsBody"), ECC_PhysicsBody },
+			{ TEXT("Vehicle"), ECC_Vehicle }, { TEXT("Destructible"), ECC_Destructible },
+		};
+		for (const FBuiltInChannel& Entry : BuiltIns)
+		{
+			if (Name.Equals(Entry.Name, ESearchCase::IgnoreCase))
+			{
+				OutChannel = Entry.Channel;
+				OutResolvedName = Entry.Name;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	TSharedPtr<FJsonValue> ParseInstanceIndices(
+		const TSharedPtr<FJsonObject>& Params,
+		int32 InstanceCount,
+		int32 MaxInstances,
+		TArray<int32>& OutIndices)
+	{
+		const TArray<TSharedPtr<FJsonValue>>* Values = nullptr;
+		if (!Params->HasField(TEXT("instanceIndices")))
+		{
+			if (InstanceCount > MaxInstances)
+			{
+				return MCPError(FString::Printf(
+					TEXT("Refusing to project all %d instances because maxInstances is %d. Pass a bounded instanceIndices subset or explicitly raise maxInstances up to %d."),
+					InstanceCount, MaxInstances, HardMaxInstances));
+			}
+			OutIndices.Reserve(InstanceCount);
+			for (int32 Index = 0; Index < InstanceCount; ++Index) OutIndices.Add(Index);
+			return nullptr;
+		}
+		if (!Params->TryGetArrayField(TEXT("instanceIndices"), Values) || !Values)
+		{
+			return MCPError(TEXT("instanceIndices must be an array of integers"));
+		}
+
+		if (Values->IsEmpty()) return MCPError(TEXT("instanceIndices must not be empty"));
+		if (Values->Num() > MaxInstances)
+		{
+			return MCPError(FString::Printf(
+				TEXT("Refusing to project %d requested instances because maxInstances is %d. Raise maxInstances only for an intentionally bounded batch (hard limit %d)."),
+				Values->Num(), MaxInstances, HardMaxInstances));
+		}
+		TSet<int32> Seen;
+		OutIndices.Reserve(Values->Num());
+		for (int32 Position = 0; Position < Values->Num(); ++Position)
+		{
+			double Raw = 0.0;
+			if (!(*Values)[Position].IsValid()
+				|| !(*Values)[Position]->TryGetNumber(Raw)
+				|| !FMath::IsFinite(Raw)
+				|| Raw != FMath::RoundToDouble(Raw))
+			{
+				return MCPError(FString::Printf(TEXT("instanceIndices[%d] must be an integer"), Position));
+			}
+			const int64 WideIndex = FMath::RoundToInt64(Raw);
+			if (WideIndex < 0 || WideIndex >= InstanceCount)
+			{
+				return MCPError(FString::Printf(
+					TEXT("instanceIndices[%d] is %lld, outside the valid range 0..%d"),
+					Position, WideIndex, InstanceCount - 1));
+			}
+			const int32 Index = static_cast<int32>(WideIndex);
+			if (Seen.Contains(Index))
+			{
+				return MCPError(FString::Printf(TEXT("instanceIndices contains duplicate index %d"), Index));
+			}
+			Seen.Add(Index);
+			OutIndices.Add(Index);
+		}
+		OutIndices.Sort();
+		return nullptr;
+	}
+
+	bool HitMatchesSurface(
+		const FHitResult& Hit,
+		UClass* RequiredClass,
+		const TSet<FString>& RequiredLabels)
+	{
+		AActor* HitActor = Hit.GetActor();
+		if (!HitActor) return false;
+		if (RequiredClass && !HitActor->IsA(RequiredClass)) return false;
+		if (!RequiredLabels.IsEmpty() && !RequiredLabels.Contains(HitActor->GetActorLabel())) return false;
+		return true;
+	}
+
+	bool FindMatchingSurfaceHit(
+		UWorld* World,
+		const FVector& Start,
+		const FVector& End,
+		ECollisionChannel Channel,
+		bool bTraceComplex,
+		AActor* SourceActor,
+		UClass* RequiredClass,
+		const TSet<FString>& RequiredLabels,
+		FHitResult& OutHit,
+		bool& bOutRejectedHit,
+		bool& bOutReachedFilterLimit)
+	{
+		bOutRejectedHit = false;
+		bOutReachedFilterLimit = false;
+		FCollisionQueryParams Query(SCENE_QUERY_STAT(MCPSnapInstancesToSurface), bTraceComplex);
+		Query.bReturnFaceIndex = bTraceComplex;
+		Query.AddIgnoredActor(SourceActor);
+
+		// A channel trace stops at its closest blocking hit. Iteratively ignore a
+		// rejected blocker so a requested landscape or named surface behind it can
+		// still be reached without executing an unbounded trace loop.
+		for (int32 Attempt = 0; Attempt < MaxFilteredSurfaceHits; ++Attempt)
+		{
+			FHitResult Candidate;
+			if (!World->LineTraceSingleByChannel(Candidate, Start, End, Channel, Query))
+			{
+				return false;
+			}
+			if (HitMatchesSurface(Candidate, RequiredClass, RequiredLabels))
+			{
+				OutHit = Candidate;
+				return true;
+			}
+
+			bOutRejectedHit = true;
+			if (AActor* RejectedActor = Candidate.GetActor())
+			{
+				Query.AddIgnoredActor(RejectedActor);
+			}
+			else if (UPrimitiveComponent* RejectedComponent = Candidate.GetComponent())
+			{
+				Query.AddIgnoredComponent(RejectedComponent);
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		bOutReachedFilterLimit = true;
+		return false;
+	}
+
+	struct FProjectionRun
+	{
+		int32 StartIndex = INDEX_NONE;
+		TArray<FTransform> Before;
+		TArray<FTransform> After;
+	};
+
+	TArray<FProjectionRun> BuildProjectionRuns(const FProjectionPlan& Plan)
+	{
+		TArray<FProjectionRun> Runs;
+		for (const FProjectionPlanEntry& Entry : Plan.Entries)
+		{
+			if (!Entry.bHit) continue;
+			if (Runs.IsEmpty() || Entry.InstanceIndex != Runs.Last().StartIndex + Runs.Last().After.Num())
+			{
+				FProjectionRun& NewRun = Runs.AddDefaulted_GetRef();
+				NewRun.StartIndex = Entry.InstanceIndex;
+			}
+			Runs.Last().Before.Add(Entry.Before);
+			Runs.Last().After.Add(Entry.After);
+		}
+		return Runs;
+	}
+
+	TSharedPtr<FJsonObject> MakeProjectionSample(const FProjectionPlanEntry& Entry)
+	{
+		TSharedPtr<FJsonObject> Sample = MakeShared<FJsonObject>();
+		Sample->SetNumberField(TEXT("index"), Entry.InstanceIndex);
+		Sample->SetBoolField(TEXT("hit"), Entry.bHit);
+		Sample->SetObjectField(TEXT("from"), MCPVec3ToJsonObject(Entry.Before.GetLocation()));
+		if (Entry.bHit)
+		{
+			Sample->SetObjectField(TEXT("to"), MCPVec3ToJsonObject(Entry.After.GetLocation()));
+			Sample->SetStringField(TEXT("hitActorLabel"), Entry.HitActorLabel);
+			Sample->SetStringField(TEXT("hitActorClass"), Entry.HitActorClass);
+		}
+		else
+		{
+			Sample->SetStringField(TEXT("missReason"), Entry.MissReason);
+		}
+		return Sample;
+	}
+}
+
+TSharedPtr<FJsonValue> UEMCPInstanceProjection::SnapInstancesToSurfaceInWorld(
+	UWorld* World,
+	const TSharedPtr<FJsonObject>& Params)
+{
+	using namespace UEMCPInstanceProjection;
+	if (!World) return MCPError(TEXT("World is not available"));
+	if (!Params) return MCPError(TEXT("params must be an object"));
+
+	FString ActorLabel;
+	if (TSharedPtr<FJsonValue> Error = RequireString(Params, TEXT("actorLabel"), ActorLabel)) return Error;
+	AActor* Actor = FindActorByLabel(World, ActorLabel);
+	if (!Actor) return MCPError(FString::Printf(TEXT("Actor not found: %s"), *ActorLabel));
+
+	FString ComponentName;
+	if (Params->HasField(TEXT("componentName"))
+		&& !Params->TryGetStringField(TEXT("componentName"), ComponentName))
+	{
+		return MCPError(TEXT("componentName must be a string"));
+	}
+	FString ComponentError;
+	UInstancedStaticMeshComponent* ISMC = ResolveProjectionComponent(
+		Actor, ComponentName, ComponentError);
+	if (!ISMC) return MCPError(ComponentError);
+
+	const int32 InstanceCount = ISMC->GetInstanceCount();
+	if (InstanceCount <= 0) return MCPError(FString::Printf(TEXT("Component '%s' has no instances"), *ISMC->GetName()));
+
+	int32 MaxInstances = DefaultMaxInstances;
+	if (Params->HasField(TEXT("maxInstances")))
+	{
+		double RawMaxInstances = 0.0;
+		if (!Params->TryGetNumberField(TEXT("maxInstances"), RawMaxInstances)
+			|| !FMath::IsFinite(RawMaxInstances)
+			|| RawMaxInstances != FMath::RoundToDouble(RawMaxInstances))
+		{
+			return MCPError(TEXT("maxInstances must be an integer"));
+		}
+		if (RawMaxInstances < 1.0 || RawMaxInstances > HardMaxInstances)
+		{
+			return MCPError(FString::Printf(
+				TEXT("maxInstances must be between 1 and %d (default %d)"),
+				HardMaxInstances, DefaultMaxInstances));
+		}
+		MaxInstances = static_cast<int32>(RawMaxInstances);
+	}
+
+	TArray<int32> Indices;
+	if (TSharedPtr<FJsonValue> Error = ParseInstanceIndices(
+		Params, InstanceCount, MaxInstances, Indices))
+	{
+		return Error;
+	}
+	if (Indices.Num() > MaxInstances)
+	{
+		return MCPError(FString::Printf(
+			TEXT("Refusing to project %d instances because maxInstances is %d. Pass a bounded instanceIndices subset or explicitly raise maxInstances up to %d."),
+			Indices.Num(), MaxInstances, HardMaxInstances));
+	}
+
+	FVector Direction(0.0, 0.0, -1.0);
+	if (Params->HasField(TEXT("direction")))
+	{
+		if (TSharedPtr<FJsonValue> Error = RequireVec3(Params, TEXT("direction"), Direction)) return Error;
+	}
+	if (Direction.ContainsNaN() || !Direction.Normalize())
+	{
+		return MCPError(TEXT("direction must be a finite, non-zero vector"));
+	}
+	double TraceStartOffset = 1000.0;
+	double TraceDistance = 200000.0;
+	double SurfaceOffset = 0.0;
+	if (Params->HasField(TEXT("traceStartOffset"))
+		&& !Params->TryGetNumberField(TEXT("traceStartOffset"), TraceStartOffset))
+	{
+		return MCPError(TEXT("traceStartOffset must be a number"));
+	}
+	if (Params->HasField(TEXT("traceDistance"))
+		&& !Params->TryGetNumberField(TEXT("traceDistance"), TraceDistance))
+	{
+		return MCPError(TEXT("traceDistance must be a number"));
+	}
+	if (Params->HasField(TEXT("surfaceOffset"))
+		&& !Params->TryGetNumberField(TEXT("surfaceOffset"), SurfaceOffset))
+	{
+		return MCPError(TEXT("surfaceOffset must be a number"));
+	}
+	if (!FMath::IsFinite(TraceStartOffset) || TraceStartOffset < 0.0)
+	{
+		return MCPError(TEXT("traceStartOffset must be a finite number greater than or equal to zero"));
+	}
+	if (!FMath::IsFinite(TraceDistance) || TraceDistance <= 0.0)
+	{
+		return MCPError(TEXT("traceDistance must be a finite number greater than zero"));
+	}
+	if (!FMath::IsFinite(SurfaceOffset)) return MCPError(TEXT("surfaceOffset must be finite"));
+
+	EMissPolicy MissPolicy = EMissPolicy::Error;
+	FString MissPolicyText = TEXT("error");
+	if (Params->HasField(TEXT("onMiss"))
+		&& !Params->TryGetStringField(TEXT("onMiss"), MissPolicyText))
+	{
+		return MCPError(TEXT("onMiss must be a string"));
+	}
+	if (!ParseMissPolicy(MissPolicyText, MissPolicy))
+	{
+		return MCPError(FString::Printf(TEXT("Unknown onMiss policy '%s'; expected 'error' or 'skip'"), *MissPolicyText));
+	}
+
+	UClass* SurfaceClass = nullptr;
+	FString SurfaceClassSpec;
+	if (Params->HasField(TEXT("surfaceActorClass"))
+		&& !Params->TryGetStringField(TEXT("surfaceActorClass"), SurfaceClassSpec))
+	{
+		return MCPError(TEXT("surfaceActorClass must be a string"));
+	}
+	if (!SurfaceClassSpec.IsEmpty())
+	{
+		SurfaceClass = MCPResolveClassOfType(SurfaceClassSpec, AActor::StaticClass());
+		if (!SurfaceClass) return MCPClassNotFoundError(SurfaceClassSpec, TEXT("surfaceActorClass"));
+	}
+
+	TSet<FString> SurfaceActorLabels;
+	const TArray<TSharedPtr<FJsonValue>>* LabelValues = nullptr;
+	if (Params->HasField(TEXT("surfaceActorLabels"))
+		&& (!Params->TryGetArrayField(TEXT("surfaceActorLabels"), LabelValues) || !LabelValues))
+	{
+		return MCPError(TEXT("surfaceActorLabels must be an array of non-empty strings"));
+	}
+	if (LabelValues && LabelValues->IsEmpty())
+	{
+		return MCPError(TEXT("surfaceActorLabels must not be empty when provided; omit it for no label filter"));
+	}
+	if (LabelValues)
+	{
+		for (int32 Position = 0; Position < LabelValues->Num(); ++Position)
+		{
+			FString Label;
+			if (!(*LabelValues)[Position].IsValid() || !(*LabelValues)[Position]->TryGetString(Label))
+			{
+				return MCPError(FString::Printf(TEXT("surfaceActorLabels[%d] must be a non-empty string"), Position));
+			}
+			Label = Label.TrimStartAndEnd();
+			if (Label.IsEmpty())
+			{
+				return MCPError(FString::Printf(TEXT("surfaceActorLabels[%d] must be a non-empty string"), Position));
+			}
+			SurfaceActorLabels.Add(Label);
+		}
+	}
+
+	ECollisionChannel Channel = ECC_Visibility;
+	FString ChannelName;
+	FString RequestedChannel = TEXT("Visibility");
+	if (Params->HasField(TEXT("channel"))
+		&& !Params->TryGetStringField(TEXT("channel"), RequestedChannel))
+	{
+		return MCPError(TEXT("channel must be a string"));
+	}
+	if (!ResolveProjectionTraceChannel(RequestedChannel, Channel, ChannelName))
+	{
+		return MCPError(FString::Printf(TEXT("Unknown collision channel '%s'"), *RequestedChannel));
+	}
+	bool bTraceComplex = false;
+	bool bDryRun = true;
+	if (Params->HasField(TEXT("traceComplex"))
+		&& !Params->TryGetBoolField(TEXT("traceComplex"), bTraceComplex))
+	{
+		return MCPError(TEXT("traceComplex must be a boolean"));
+	}
+	if (Params->HasField(TEXT("dryRun"))
+		&& !Params->TryGetBoolField(TEXT("dryRun"), bDryRun))
+	{
+		return MCPError(TEXT("dryRun must be a boolean"));
+	}
+
+	FProjectionPlan Plan;
+	Plan.Entries.Reserve(Indices.Num());
+	for (const int32 Index : Indices)
+	{
+		FProjectionPlanEntry Entry;
+		Entry.InstanceIndex = Index;
+		if (!ISMC->GetInstanceTransform(Index, Entry.Before, true))
+		{
+			return MCPError(FString::Printf(TEXT("Failed to read instance transform at index %d"), Index));
+		}
+		if (Entry.Before.ContainsNaN())
+		{
+			return MCPError(FString::Printf(TEXT("Instance transform at index %d is not finite"), Index));
+		}
+
+		const FVector Start = Entry.Before.GetLocation() - Direction * TraceStartOffset;
+		const FVector End = Start + Direction * (TraceStartOffset + TraceDistance);
+		if (Start.ContainsNaN() || End.ContainsNaN())
+		{
+			return MCPError(FString::Printf(
+				TEXT("Trace bounds overflowed for instance %d; reduce traceStartOffset or traceDistance"),
+				Index));
+		}
+		FHitResult AcceptedHit;
+		bool bRejectedHit = false;
+		bool bReachedFilterLimit = false;
+		if (!FindMatchingSurfaceHit(
+			World,
+			Start,
+			End,
+			Channel,
+			bTraceComplex,
+			Actor,
+			SurfaceClass,
+			SurfaceActorLabels,
+			AcceptedHit,
+			bRejectedHit,
+			bReachedFilterLimit))
+		{
+			Entry.MissReason = bReachedFilterLimit
+				? TEXT("surface_filter_limit_reached")
+				: (bRejectedHit ? TEXT("no_hit_matched_surface_filter") : TEXT("trace_missed"));
+			++Plan.MissCount;
+		}
+		else
+		{
+			Entry.bHit = true;
+			Entry.After = Entry.Before;
+			Entry.After.SetLocation(ApplySurfaceOffset(AcceptedHit.ImpactPoint, AcceptedHit.ImpactNormal, SurfaceOffset));
+			if (Entry.After.ContainsNaN())
+			{
+				return MCPError(FString::Printf(
+					TEXT("Projected transform overflowed for instance %d; reduce surfaceOffset"),
+					Index));
+			}
+			if (AActor* HitActor = AcceptedHit.GetActor())
+			{
+				Entry.HitActorLabel = HitActor->GetActorLabel();
+				Entry.HitActorClass = HitActor->GetClass()->GetPathName();
+			}
+			++Plan.HitCount;
+			Plan.MinDistance = FMath::Min(Plan.MinDistance, static_cast<double>(AcceptedHit.Distance));
+			Plan.MaxDistance = FMath::Max(Plan.MaxDistance, static_cast<double>(AcceptedHit.Distance));
+		}
+		Plan.Entries.Add(MoveTemp(Entry));
+	}
+
+	TArray<TSharedPtr<FJsonValue>> Samples;
+	const int32 SampleCount = FMath::Min(Plan.Entries.Num(), MaxReportedSamples);
+	Samples.Reserve(SampleCount);
+	for (int32 Position = 0; Position < SampleCount; ++Position)
+	{
+		Samples.Add(MakeShared<FJsonValueObject>(MakeProjectionSample(Plan.Entries[Position])));
+	}
+
+	if (MissPolicy == EMissPolicy::Error && Plan.MissCount > 0)
+	{
+		auto Result = MCPSuccess();
+		Result->SetBoolField(TEXT("success"), false);
+		Result->SetStringField(TEXT("error"), FString::Printf(
+			TEXT("Preflight found %d misses; onMiss='error' prevents any mutation."), Plan.MissCount));
+		Result->SetBoolField(TEXT("dryRun"), bDryRun);
+		Result->SetBoolField(TEXT("preflightPassed"), false);
+		Result->SetBoolField(TEXT("mutationPerformed"), false);
+		Result->SetNumberField(TEXT("requestedCount"), Plan.Entries.Num());
+		Result->SetNumberField(TEXT("hitCount"), Plan.HitCount);
+		Result->SetNumberField(TEXT("missCount"), Plan.MissCount);
+		Result->SetNumberField(TEXT("sampleCount"), Samples.Num());
+		Result->SetBoolField(TEXT("samplesTruncated"), Plan.Entries.Num() > Samples.Num());
+		Result->SetArrayField(TEXT("samples"), Samples);
+		return MCPResult(Result);
+	}
+
+	bool bMutationPerformed = false;
+	if (!bDryRun && Plan.HitCount > 0)
+	{
+		const bool bShouldActuallyTransact = GEditor && World->WorldType == EWorldType::Editor;
+		FScopedTransaction Transaction(
+			NSLOCTEXT("UEMCP", "SnapInstancesToSurface", "Snap Instanced Meshes To Surface"),
+			bShouldActuallyTransact);
+		UPackage* Package = ISMC->GetOutermost();
+		const bool bPackageWasDirty = Package && Package->IsDirty();
+		Actor->Modify();
+		ISMC->Modify();
+		const TArray<FProjectionRun> Runs = BuildProjectionRuns(Plan);
+		int32 AppliedRunCount = 0;
+		for (const FProjectionRun& Run : Runs)
+		{
+			if (!ISMC->BatchUpdateInstancesTransforms(
+				Run.StartIndex,
+				Run.After,
+				true,
+				false,
+				true))
+			{
+				// Treat a false batch result as potentially partial. Restore the
+				// current run as well as every previously accepted run.
+				bool bRollbackSucceeded = ISMC->BatchUpdateInstancesTransforms(
+					Run.StartIndex,
+					Run.Before,
+					true,
+					false,
+					true);
+				for (int32 RollbackIndex = AppliedRunCount - 1; RollbackIndex >= 0; --RollbackIndex)
+				{
+					const FProjectionRun& AppliedRun = Runs[RollbackIndex];
+					bRollbackSucceeded &= ISMC->BatchUpdateInstancesTransforms(
+						AppliedRun.StartIndex,
+						AppliedRun.Before,
+						true,
+						false,
+						true);
+				}
+				ISMC->MarkRenderStateDirty();
+				if (Package && !bPackageWasDirty) Package->ClearDirtyFlag();
+				Transaction.Cancel();
+				return MCPError(FString::Printf(
+					TEXT("Unexpected apply failure at instance %d after a successful preflight; rollback %s"),
+					Run.StartIndex,
+					bRollbackSucceeded ? TEXT("succeeded") : TEXT("failed")));
+			}
+			++AppliedRunCount;
+		}
+		ISMC->MarkRenderStateDirty();
+		if (Package && !Package->HasAnyPackageFlags(PKG_Transient)) ISMC->MarkPackageDirty();
+		bMutationPerformed = true;
+	}
+
+	auto Result = MCPSuccess();
+	Result->SetBoolField(TEXT("dryRun"), bDryRun);
+	Result->SetBoolField(TEXT("preflightPassed"), true);
+	Result->SetBoolField(TEXT("mutationPerformed"), bMutationPerformed);
+	Result->SetStringField(TEXT("actorLabel"), ActorLabel);
+	Result->SetStringField(TEXT("componentName"), ISMC->GetName());
+	Result->SetStringField(TEXT("componentClass"), ISMC->GetClass()->GetPathName());
+	Result->SetStringField(TEXT("channel"), ChannelName);
+	Result->SetStringField(TEXT("onMiss"), MissPolicy == EMissPolicy::Error ? TEXT("error") : TEXT("skip"));
+	Result->SetNumberField(TEXT("requestedCount"), Plan.Entries.Num());
+	Result->SetNumberField(TEXT("hitCount"), Plan.HitCount);
+	Result->SetNumberField(TEXT("missCount"), Plan.MissCount);
+	Result->SetNumberField(TEXT("updatedCount"), bMutationPerformed ? Plan.HitCount : 0);
+	Result->SetNumberField(TEXT("sampleCount"), Samples.Num());
+	Result->SetBoolField(TEXT("samplesTruncated"), Plan.Entries.Num() > Samples.Num());
+	Result->SetArrayField(TEXT("samples"), Samples);
+	if (Plan.HitCount > 0)
+	{
+		Result->SetNumberField(TEXT("minHitDistance"), Plan.MinDistance);
+		Result->SetNumberField(TEXT("maxHitDistance"), Plan.MaxDistance);
+	}
+	if (bMutationPerformed)
+	{
+		MCPSetUpdated(Result);
+		Result->SetStringField(TEXT("dirtyPackage"), ISMC->GetOutermost()->GetName());
+		Result->SetStringField(TEXT("note"), TEXT("Changes are dirty in memory and were not saved."));
+	}
+	else if (bDryRun)
+	{
+		Result->SetStringField(TEXT("note"), TEXT("Dry run only; re-call with dryRun=false to apply the preflighted projection."));
+	}
+	return MCPResult(Result);
+}
+
+TSharedPtr<FJsonValue> FLevelHandlers::SnapInstancesToSurface(const TSharedPtr<FJsonObject>& Params)
+{
+	REQUIRE_EDITOR_WORLD(World);
+	return UEMCPInstanceProjection::SnapInstancesToSurfaceInWorld(World, Params);
+}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_InstanceProjection_Internal.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_InstanceProjection_Internal.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+
+class UWorld;
+
+namespace UEMCPInstanceProjection
+{
+	constexpr int32 DefaultMaxInstances = 10000;
+	constexpr int32 HardMaxInstances = 50000;
+	constexpr int32 MaxReportedSamples = 32;
+	constexpr int32 MaxFilteredSurfaceHits = 64;
+
+	enum class EMissPolicy : uint8
+	{
+		Error,
+		Skip,
+	};
+
+	struct FProjectionPlanEntry
+	{
+		int32 InstanceIndex = INDEX_NONE;
+		FTransform Before = FTransform::Identity;
+		FTransform After = FTransform::Identity;
+		bool bHit = false;
+		FString HitActorLabel;
+		FString HitActorClass;
+		FString MissReason;
+	};
+
+	struct FProjectionPlan
+	{
+		TArray<FProjectionPlanEntry> Entries;
+		int32 HitCount = 0;
+		int32 MissCount = 0;
+		double MinDistance = TNumericLimits<double>::Max();
+		double MaxDistance = 0.0;
+	};
+
+	bool ParseMissPolicy(const FString& InValue, EMissPolicy& OutPolicy);
+
+	FVector ApplySurfaceOffset(const FVector& ImpactPoint, const FVector& ImpactNormal, double SurfaceOffset);
+
+	/**
+	 * Testable core for the registered editor-world handler.
+	 *
+	 * Raw bridge parameters:
+	 * - actorLabel (required), componentName (required only when ambiguous)
+	 * - instanceIndices (optional; omitted means all), maxInstances (default
+	 *   10000, hard limit 50000)
+	 * - direction, traceStartOffset, traceDistance, channel, traceComplex
+	 * - surfaceActorClass, surfaceActorLabels, surfaceOffset
+	 * - onMiss (error or skip), dryRun (default true)
+	 *
+	 * A commit still runs the complete preflight in the same game-thread call,
+	 * then applies all hits in one editor transaction without saving a package.
+	 */
+	TSharedPtr<FJsonValue> SnapInstancesToSurfaceInWorld(
+		UWorld* World,
+		const TSharedPtr<FJsonObject>& Params);
+}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/LevelInstanceProjectionTests.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/LevelInstanceProjectionTests.cpp
@@ -1,0 +1,265 @@
+// Native coverage for snap_instances_to_surface. All mutation coverage uses a
+// transient test world and transient actors, never project packages or maps.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "HandlerRegistry.h"
+#include "Handlers/LevelHandlers.h"
+#include "Handlers/LevelHandlers_InstanceProjection_Internal.h"
+#include "Components/BoxComponent.h"
+#include "Components/InstancedStaticMeshComponent.h"
+#include "Engine/Engine.h"
+#include "Engine/EngineBaseTypes.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "GameFramework/Actor.h"
+#include "Misc/AutomationTest.h"
+
+namespace
+{
+	class FScopedProjectionTestWorld
+	{
+	public:
+		FScopedProjectionTestWorld()
+		{
+			check(GEngine);
+			const FName WorldName = MakeUniqueObjectName(
+				nullptr,
+				UWorld::StaticClass(),
+				TEXT("UEMCPInstanceProjectionTestWorld"),
+				EUniqueObjectNameOptions::GloballyUnique);
+			FWorldContext& Context = GEngine->CreateNewWorldContext(EWorldType::Game);
+			World = UWorld::CreateWorld(EWorldType::Game, false, WorldName, GetTransientPackage());
+			check(World);
+			World->AddToRoot();
+			Context.SetCurrentWorld(World);
+			World->InitializeActorsForPlay(FURL());
+			check(World->GetPhysicsScene());
+		}
+
+		~FScopedProjectionTestWorld()
+		{
+			if (!World) return;
+			if (World->AreActorsInitialized())
+			{
+				for (AActor* Actor : FActorRange(World))
+				{
+					if (Actor) Actor->RouteEndPlay(EEndPlayReason::LevelTransition);
+				}
+			}
+			GEngine->ShutdownWorldNetDriver(World);
+			World->DestroyWorld(true);
+			World->SetPhysicsScene(nullptr);
+			GEngine->DestroyWorldContext(World);
+			World->RemoveFromRoot();
+			World = nullptr;
+		}
+
+		UWorld* Get() const { return World; }
+
+	private:
+		UWorld* World = nullptr;
+	};
+
+	AActor* SpawnTransientActor(UWorld* World, const FString& Label)
+	{
+		FActorSpawnParameters SpawnParameters;
+		SpawnParameters.Name = MakeUniqueObjectName(
+			World->PersistentLevel,
+			AActor::StaticClass(),
+			FName(*Label));
+		SpawnParameters.ObjectFlags |= RF_Transient;
+		AActor* Actor = World->SpawnActor<AActor>(
+			AActor::StaticClass(),
+			FTransform::Identity,
+			SpawnParameters);
+		if (Actor) Actor->SetActorLabel(Label, false);
+		return Actor;
+	}
+
+	UInstancedStaticMeshComponent* AddInstanceComponent(
+		AActor* Actor,
+		const TArray<FTransform>& WorldTransforms)
+	{
+		UInstancedStaticMeshComponent* Instances = NewObject<UInstancedStaticMeshComponent>(
+			Actor,
+			TEXT("ProjectedInstances"),
+			RF_Transient | RF_Transactional);
+		Actor->SetRootComponent(Instances);
+		Actor->AddInstanceComponent(Instances);
+		Instances->SetMobility(EComponentMobility::Movable);
+		Instances->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+		Instances->RegisterComponent();
+		for (const FTransform& Transform : WorldTransforms)
+		{
+			Instances->AddInstance(Transform, true);
+		}
+		return Instances;
+	}
+
+	UBoxComponent* AddSurfaceBox(AActor* Actor, const FVector& Extent)
+	{
+		UBoxComponent* Box = NewObject<UBoxComponent>(
+			Actor,
+			TEXT("ProjectionSurface"),
+			RF_Transient);
+		Actor->SetRootComponent(Box);
+		Actor->AddInstanceComponent(Box);
+		Box->SetBoxExtent(Extent, false);
+		Box->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+		Box->SetCollisionObjectType(ECC_WorldStatic);
+		Box->SetCollisionResponseToAllChannels(ECR_Ignore);
+		Box->SetCollisionResponseToChannel(ECC_Visibility, ECR_Block);
+		Box->RegisterComponent();
+		return Box;
+	}
+
+	TSharedPtr<FJsonObject> MakeProjectionRequest(
+		const FString& ActorLabel,
+		const FString& SurfaceLabel)
+	{
+		TSharedPtr<FJsonObject> Request = MakeShared<FJsonObject>();
+		Request->SetStringField(TEXT("actorLabel"), ActorLabel);
+		Request->SetStringField(TEXT("componentName"), TEXT("ProjectedInstances"));
+		Request->SetArrayField(
+			TEXT("surfaceActorLabels"),
+			{ MakeShared<FJsonValueString>(SurfaceLabel) });
+		Request->SetNumberField(TEXT("surfaceOffset"), 10.0);
+		return Request;
+	}
+
+	bool ReadWorldTransform(
+		UInstancedStaticMeshComponent* Instances,
+		int32 Index,
+		FTransform& OutTransform)
+	{
+		return Instances && Instances->GetInstanceTransform(Index, OutTransform, true);
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FLevelInstanceProjectionRegistrationTest,
+	"UE.MCP.Level.InstanceProjection.RegistrationAndPureValidation",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FLevelInstanceProjectionRegistrationTest::RunTest(const FString& Parameters)
+{
+	FMCPHandlerRegistry Registry;
+	FLevelHandlers::RegisterHandlers(Registry);
+	TestTrue(
+		TEXT("native projection handler is registered"),
+		Registry.HasHandler(TEXT("snap_instances_to_surface")));
+	TestTrue(
+		TEXT("bounded batch handler has an explicit timeout"),
+		Registry.GetHandlerTimeout(TEXT("snap_instances_to_surface")) >= 300.0f);
+
+	using namespace UEMCPInstanceProjection;
+	EMissPolicy Policy = EMissPolicy::Error;
+	TestTrue(TEXT("miss policy is case insensitive"), ParseMissPolicy(TEXT(" SKIP "), Policy));
+	TestTrue(TEXT("skip policy is selected"), Policy == EMissPolicy::Skip);
+	TestFalse(TEXT("unknown miss policy is rejected"), ParseMissPolicy(TEXT("continue"), Policy));
+	TestTrue(
+		TEXT("surface offset follows the normalized impact normal"),
+		ApplySurfaceOffset(FVector(1.0, 2.0, 3.0), FVector(0.0, 0.0, 4.0), 7.0)
+			.Equals(FVector(1.0, 2.0, 10.0)));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FLevelInstanceProjectionDryRunAndCommitTest,
+	"UE.MCP.Level.InstanceProjection.DryRunBoundsAndAtomicCommit",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FLevelInstanceProjectionDryRunAndCommitTest::RunTest(const FString& Parameters)
+{
+	FScopedProjectionTestWorld TestWorld;
+	const FString TargetLabel = TEXT("UEMCP_ProjectionTarget");
+	const FString SurfaceLabel = TEXT("UEMCP_ProjectionSurface");
+	const FString BlockerLabel = TEXT("UEMCP_ProjectionBlocker");
+	AActor* Target = SpawnTransientActor(TestWorld.Get(), TargetLabel);
+	AActor* Surface = SpawnTransientActor(TestWorld.Get(), SurfaceLabel);
+	AActor* Blocker = SpawnTransientActor(TestWorld.Get(), BlockerLabel);
+	TestNotNull(TEXT("target actor exists"), Target);
+	TestNotNull(TEXT("surface actor exists"), Surface);
+	TestNotNull(TEXT("non-matching blocker exists"), Blocker);
+	if (!Target || !Surface || !Blocker) return false;
+
+	const FQuat OriginalRotation = FRotator(0.0, 37.0, 0.0).Quaternion();
+	const FVector OriginalScale(1.2, 0.8, 1.5);
+	const TArray<FTransform> OriginalTransforms = {
+		FTransform(OriginalRotation, FVector(0.0, 0.0, 500.0), OriginalScale),
+		FTransform(FQuat::Identity, FVector(1000.0, 0.0, 500.0), FVector::OneVector),
+	};
+	UInstancedStaticMeshComponent* Instances = AddInstanceComponent(Target, OriginalTransforms);
+	UBoxComponent* SurfaceBox = AddSurfaceBox(Surface, FVector(150.0, 150.0, 100.0));
+	UBoxComponent* BlockerBox = AddSurfaceBox(Blocker, FVector(150.0, 150.0, 50.0));
+	TestNotNull(TEXT("instance component exists"), Instances);
+	TestNotNull(TEXT("surface collision exists"), SurfaceBox);
+	TestNotNull(TEXT("blocker collision exists"), BlockerBox);
+	if (!Instances || !SurfaceBox || !BlockerBox) return false;
+	BlockerBox->SetWorldLocation(FVector(0.0, 0.0, 250.0));
+
+	TSharedPtr<FJsonObject> DryRunRequest = MakeProjectionRequest(TargetLabel, SurfaceLabel);
+	DryRunRequest->SetArrayField(TEXT("instanceIndices"), { MakeShared<FJsonValueNumber>(0) });
+	const TSharedPtr<FJsonValue> DryRunResponse =
+		UEMCPInstanceProjection::SnapInstancesToSurfaceInWorld(TestWorld.Get(), DryRunRequest);
+	TestTrue(TEXT("dry run returns an object"), DryRunResponse.IsValid() && DryRunResponse->Type == EJson::Object);
+	if (!DryRunResponse.IsValid() || DryRunResponse->Type != EJson::Object) return false;
+	const TSharedPtr<FJsonObject> DryRunResult = DryRunResponse->AsObject();
+	TestTrue(TEXT("dry run succeeds"), DryRunResult->GetBoolField(TEXT("success")));
+	TestTrue(TEXT("dry run is the default"), DryRunResult->GetBoolField(TEXT("dryRun")));
+	TestTrue(TEXT("dry-run preflight passes"), DryRunResult->GetBoolField(TEXT("preflightPassed")));
+	TestFalse(TEXT("dry run performs no mutation"), DryRunResult->GetBoolField(TEXT("mutationPerformed")));
+	TestEqual(TEXT("dry run reaches the filtered surface behind a blocker"), DryRunResult->GetIntegerField(TEXT("hitCount")), 1);
+
+	FTransform AfterDryRun;
+	TestTrue(TEXT("instance remains readable after dry run"), ReadWorldTransform(Instances, 0, AfterDryRun));
+	TestTrue(TEXT("dry run preserves the original transform"), AfterDryRun.Equals(OriginalTransforms[0], 0.01));
+
+	TSharedPtr<FJsonObject> BoundedRequest = MakeProjectionRequest(TargetLabel, SurfaceLabel);
+	BoundedRequest->SetNumberField(TEXT("maxInstances"), 1);
+	const TSharedPtr<FJsonValue> BoundedResponse =
+		UEMCPInstanceProjection::SnapInstancesToSurfaceInWorld(TestWorld.Get(), BoundedRequest);
+	TestFalse(TEXT("oversized request is rejected"), BoundedResponse->AsObject()->GetBoolField(TEXT("success")));
+	TestTrue(
+		TEXT("oversized rejection reports the bound"),
+		BoundedResponse->AsObject()->GetStringField(TEXT("error")).Contains(TEXT("maxInstances")));
+
+	TSharedPtr<FJsonObject> AtomicRequest = MakeProjectionRequest(TargetLabel, SurfaceLabel);
+	AtomicRequest->SetBoolField(TEXT("dryRun"), false);
+	AtomicRequest->SetStringField(TEXT("onMiss"), TEXT("error"));
+	const TSharedPtr<FJsonValue> AtomicResponse =
+		UEMCPInstanceProjection::SnapInstancesToSurfaceInWorld(TestWorld.Get(), AtomicRequest);
+	const TSharedPtr<FJsonObject> AtomicResult = AtomicResponse->AsObject();
+	TestFalse(TEXT("a preflight miss rejects the commit"), AtomicResult->GetBoolField(TEXT("success")));
+	TestFalse(TEXT("failed preflight reports no mutation"), AtomicResult->GetBoolField(TEXT("mutationPerformed")));
+	TestEqual(TEXT("one instance misses"), AtomicResult->GetIntegerField(TEXT("missCount")), 1);
+
+	FTransform AfterAtomicFailure;
+	TestTrue(TEXT("instance remains readable after rejected commit"), ReadWorldTransform(Instances, 0, AfterAtomicFailure));
+	TestTrue(
+		TEXT("onMiss=error leaves every instance unchanged"),
+		AfterAtomicFailure.Equals(OriginalTransforms[0], 0.01));
+
+	TSharedPtr<FJsonObject> CommitRequest = MakeProjectionRequest(TargetLabel, SurfaceLabel);
+	CommitRequest->SetBoolField(TEXT("dryRun"), false);
+	CommitRequest->SetStringField(TEXT("onMiss"), TEXT("skip"));
+	const TSharedPtr<FJsonValue> CommitResponse =
+		UEMCPInstanceProjection::SnapInstancesToSurfaceInWorld(TestWorld.Get(), CommitRequest);
+	const TSharedPtr<FJsonObject> CommitResult = CommitResponse->AsObject();
+	TestTrue(TEXT("skip commit succeeds"), CommitResult->GetBoolField(TEXT("success")));
+	TestTrue(TEXT("commit performs a mutation"), CommitResult->GetBoolField(TEXT("mutationPerformed")));
+	TestEqual(TEXT("commit updates one instance"), CommitResult->GetIntegerField(TEXT("updatedCount")), 1);
+
+	FTransform UpdatedHit;
+	FTransform UnchangedMiss;
+	TestTrue(TEXT("updated instance remains readable"), ReadWorldTransform(Instances, 0, UpdatedHit));
+	TestTrue(TEXT("skipped instance remains readable"), ReadWorldTransform(Instances, 1, UnchangedMiss));
+	TestTrue(TEXT("projected location uses the surface offset"), FMath::IsNearlyEqual(UpdatedHit.GetLocation().Z, 110.0, 0.1));
+	TestTrue(TEXT("projection preserves rotation"), UpdatedHit.GetRotation().Equals(OriginalRotation, 0.001));
+	TestTrue(TEXT("projection preserves scale"), UpdatedHit.GetScale3D().Equals(OriginalScale, 0.001));
+	TestTrue(TEXT("onMiss=skip leaves the miss unchanged"), UnchangedMiss.Equals(OriginalTransforms[1], 0.01));
+	return true;
+}
+
+#endif

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
@@ -10,6 +10,8 @@ public class UE_MCP_Bridge : ModuleRules
 	// file list and will not pick up a new .cpp until this file changes.
 	// Private/BridgeStateFiles.cpp, Private/BridgeParamEcho.cpp and
 	// Private/Tests/BridgeProtocolTests.cpp: same reason.
+	// Private/Handlers/LevelHandlers_InstanceProjection.cpp and
+	// Private/Tests/LevelInstanceProjectionTests.cpp: same reason.
 	public UE_MCP_Bridge(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;


### PR DESCRIPTION
## Summary

- add the native `snap_instances_to_surface` bridge action for bounded ISMC/HISMC projection
- default to dry-run, preflight every requested instance, and support class, label, collision-channel, and miss-policy filters
- apply successful projections in one editor transaction with rollback on an unexpected batch-update failure
- preserve instance rotation and scale, cap request and response sizes, and avoid automatic package saves
- add focused native automation coverage for registration, bounds, dry-run behavior, atomic miss handling, filtered hits, and transform preservation

## Surface

This change intentionally exposes the operation as a raw bridge action listed by `get_bridge_capabilities`. A first-class TypeScript action/schema is outside this plugin-only change.

## Validation

- `npm run test:unit`
- `npx tsc --noEmit`
- `node scripts/audit-unity-collisions.mjs`
- `node scripts/check-em-dashes.mjs --commits upstream/main..HEAD`
- `git diff --check`

The bundled Unreal test-project build was attempted with engine changes prohibited. Both available source-engine checkouts stopped before plugin compilation because UnrealBuildTool would need to update engine-owned module metadata. No engine files were changed, so the focused `UE.MCP.Level.InstanceProjection` editor automation remains to be run in CI or an engine lane whose binaries already match its source.
