### PR TITLE
feat(plugin): add native Mass and asset validation tools

### DIFF
--- a/plugin/ue_mcp_bridge/README_MassHandlers.md
+++ b/plugin/ue_mcp_bridge/README_MassHandlers.md
@@ -1,0 +1,97 @@
+# Mass entity config handler
+
+`ensure_mass_entity_config` creates or idempotently extends a
+`UMassEntityConfigAsset` without requiring a hard Mass module dependency in
+the bridge. The handler resolves the Mass classes at runtime, so the bridge
+continues to load when Mass is not enabled.
+
+`read_mass_entity_config` is the corresponding read-only audit operation. It
+returns `assetPath`, `assetClass`, `traitCount`, an ordered `traitClasses`
+array, and ordered `traits` records. Each record contains `index`, `classPath`,
+`className`, and a `properties` object. Object and soft-object properties are
+reported as object paths, so a StateTree assignment can be verified exactly.
+
+`read_state_tree` returns `schemaClass` and `schemaPath` plus `subTrees`. Each state record
+contains ordered `tasks`, `enterConditions`, and `transitions`; node records
+include `structType`, `instanceProperties`, and `nodeProperties` (including
+`bConsideredForCompletion`). Transition records include `trigger`,
+`transitionType`, `targetStateId`, `targetStatePath`, `bDelayTransition`,
+`delayDuration`, and `delayRandomVariance`. The response also includes exact
+`editorBindings` records with source/target struct IDs and paths.
+
+## Skeletal mesh instancing build flag
+
+`set_skeletal_mesh_optimize_for_instancing` edits only the requested skeletal
+mesh asset's LOD build settings. Parameters are `assetPath`, required boolean
+`enabled`, and either `lodIndex` (default `0`) or `allLods: true`. It validates
+the mesh and LOD selection before mutation, is idempotent, calls `Modify()`
+before changing settings, and saves only that mesh package. The response
+contains `updated`, `saved`, `changedLods`, and ordered `lods[]` records with
+`lodIndex`, `beforeOptimizeForInstancing`, `afterOptimizeForInstancing`, and
+`changed`. Each record also includes complete `beforeBuildSettings` and
+`afterBuildSettings` objects, including `bOptimizeForInstancing` and the
+other UE 5.8 skeletal build flags.
+
+`read_skeletal_mesh_build_settings` is the read-only counterpart. It accepts
+the same LOD selection parameters and returns `assetPath`, `lodCount`, and
+`lods[]` with the exact current `bOptimizeForInstancing` value and complete
+`afterBuildSettings` object for each LOD.
+
+Example:
+
+```json
+{
+  "assetPath": "/Game/Mass/WorkerAI.WorkerAI",
+  "onConflict": "update",
+  "traits": [
+    {
+      "class": "/Script/MassAIBehavior.MassStateTreeTrait",
+      "properties": {
+        "StateTree": "/Game/Mass/WorkerAIStateTree.WorkerAIStateTree"
+      }
+    }
+  ]
+}
+```
+
+The MMO persistent-pawn validation config uses this exact four-trait list:
+
+```json
+{
+  "assetPath": "/Game/MMOValidation/MassPersistentPawn/DA_MassPersistentPawnWorkerAI.DA_MassPersistentPawnWorkerAI",
+  "onConflict": "update",
+  "traits": [
+    { "class": "/Script/MMOHumanoidMassRuntime.MMOHumanoidMassEntityTrait" },
+    { "class": "/Script/MassNavMeshNavigation.MassNavMeshNavigationTrait" },
+    { "class": "/Script/MassMovement.MassMovementTrait" },
+    {
+      "class": "/Script/MassAIBehavior.MassStateTreeTrait",
+      "properties": {
+        "StateTree": "/Game/MMOValidation/MassPersistentPawn/ST_MassPersistentPawnWorkerAI.ST_MassPersistentPawnWorkerAI"
+      }
+    }
+  ]
+}
+```
+
+Traits are ordered and unique. Existing assets may be extended only when the
+requested list has the existing list as an exact prefix. Conflicting order,
+duplicate classes, replacement, and removal are rejected. `onConflict` accepts
+`skip`, `error`, or `update` (default). Trait properties use the bridge's
+recursive JSON property conversion, including object and soft-object paths.
+
+## Native asset validation
+
+`validate_assets` performs synchronous validation through
+`UEditorValidatorSubsystem::ValidateAssetsWithSettings`; it does not invoke a
+console command or save assets. Use `assetPaths` (an array) or `assetPath` for
+exact package/object paths, or retain the backward-compatible recursive
+`directory` form (default `/Game/`). Explicit package paths must resolve to
+exactly one asset; missing and ambiguous paths fail before validation starts.
+
+The successful response includes `selectionMode`, `selection`,
+`validationUsecase`, `requested`, `checked`, `valid`, `invalid`, `skipped`,
+`warnings`, `unableToValidate`, `externalObjects`, `assetLimitReached`, and an
+overall `result`. Ordered `assets[]` details include `objectPath`, package and
+asset names, per-asset result, `errors`, `warnings`, and tokenized `messages`;
+any non-asset tokenized messages are returned in `validatorMessages`.

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/BridgeServer.cpp
@@ -49,6 +49,8 @@
 #include "Handlers/StateTreeHandlers.h"
 #include "Handlers/ChooserHandlers.h"
 #include "Handlers/EpicHandlers.h"
+#include "Handlers/MassHandlers.h"
+#include "Handlers/SkeletalMeshHandlers.h"
 #include "Handlers/FabHandlers.h"
 #include "Handlers/LockHandlers.h"
 #include "Handlers/DiffHandlers.h"
@@ -152,6 +154,8 @@ FMCPBridgeServer::FMCPBridgeServer(int32 Port, const FString& InPortSource, bool
 	FStateTreeHandlers::RegisterHandlers(HandlerRegistry);
 	FChooserHandlers::RegisterHandlers(HandlerRegistry);
 	FEpicHandlers::RegisterHandlers(HandlerRegistry);
+	FMassHandlers::RegisterHandlers(HandlerRegistry);
+	FSkeletalMeshHandlers::RegisterHandlers(HandlerRegistry);
 	FFabHandlers::RegisterHandlers(HandlerRegistry);
 	FLockHandlers::RegisterHandlers(HandlerRegistry);
 	FDiffHandlers::RegisterHandlers(HandlerRegistry);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EditorHandlers_Build.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EditorHandlers_Build.cpp
@@ -19,6 +19,8 @@
 #include "HAL/PlatformFileManager.h"
 #include "HAL/PlatformFile.h"
 #include "Modules/ModuleManager.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetRegistry/ARFilter.h"
 #if PLATFORM_WINDOWS
 #include "ILiveCodingModule.h"
 #endif
@@ -26,6 +28,96 @@
 #include "EditorValidatorSubsystem.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
+
++namespace
+{
+	static FString MCPDataValidationResultToString(const EDataValidationResult Result)
+	{
+		switch (Result)
+		{
+		case EDataValidationResult::Valid:
+			return TEXT("valid");
+		case EDataValidationResult::Invalid:
+			return TEXT("invalid");
+		case EDataValidationResult::NotValidated:
+		default:
+			return TEXT("notValidated");
+		}
+	}
+
+	static TArray<TSharedPtr<FJsonValue>> MCPValidationTextArray(const TArray<FText>& Texts)
+	{
+		TArray<TSharedPtr<FJsonValue>> Values;
+		Values.Reserve(Texts.Num());
+		for (const FText& Text : Texts)
+		{
+			Values.Add(MakeShared<FJsonValueString>(Text.ToString()));
+		}
+		return Values;
+	}
+
+	static TArray<TSharedPtr<FJsonValue>> MCPValidationMessageArray(const TArray<TSharedRef<FTokenizedMessage>>& Messages)
+	{
+		TArray<TSharedPtr<FJsonValue>> Values;
+		Values.Reserve(Messages.Num());
+		for (const TSharedRef<FTokenizedMessage>& Message : Messages)
+		{
+			Values.Add(MakeShared<FJsonValueString>(Message->ToText().ToString()));
+		}
+		return Values;
+	}
+
+	static bool MCPResolveExplicitValidationAsset(
+		IAssetRegistry& AssetRegistry,
+		const FString& RequestedPath,
+		FAssetData& OutAsset,
+		FString& OutError)
+	{
+		const FString TrimmedPath = RequestedPath.TrimStartAndEnd();
+		if (TrimmedPath.IsEmpty())
+		{
+			OutError = TEXT("asset path is empty");
+			return false;
+		}
+
+		if (TrimmedPath.Contains(TEXT(".")) || TrimmedPath.Contains(TEXT(":")))
+		{
+			OutAsset = AssetRegistry.GetAssetByObjectPath(FSoftObjectPath(TrimmedPath));
+			if (!OutAsset.IsValid())
+			{
+				OutError = FString::Printf(TEXT("asset object path was not found: %s"), *TrimmedPath);
+				return false;
+			}
+			return true;
+		}
+
+		TArray<FAssetData> PackageAssets;
+		AssetRegistry.GetAssetsByPackageName(FName(*TrimmedPath), PackageAssets);
+		PackageAssets.Sort([](const FAssetData& A, const FAssetData& B)
+		{
+			return A.GetObjectPathString() < B.GetObjectPathString();
+		});
+
+		if (PackageAssets.Num() == 0)
+		{
+			OutError = FString::Printf(TEXT("asset package path was not found: %s"), *TrimmedPath);
+			return false;
+		}
+		if (PackageAssets.Num() != 1)
+		{
+			OutError = FString::Printf(TEXT("asset package path is ambiguous (%d assets): %s"), PackageAssets.Num(), *TrimmedPath);
+			return false;
+		}
+
+		OutAsset = PackageAssets[0];
+		if (!OutAsset.IsValid())
+		{
+			OutError = FString::Printf(TEXT("asset package path resolved to invalid asset data: %s"), *TrimmedPath);
+			return false;
+		}
+		return true;
+	}
+}
 
 TSharedPtr<FJsonValue> FEditorHandlers::BuildLighting(const TSharedPtr<FJsonObject>& Params)
 {
@@ -83,46 +175,177 @@ TSharedPtr<FJsonValue> FEditorHandlers::BuildAll(const TSharedPtr<FJsonObject>& 
 
 TSharedPtr<FJsonValue> FEditorHandlers::ValidateAssets(const TSharedPtr<FJsonObject>& Params)
 {
-	FString Directory = OptionalString(Params, TEXT("directory"), TEXT("/Game/"));
-
-	// Try to use the EditorValidatorSubsystem if available
-	UEditorValidatorSubsystem* ValidatorSubsystem = GEditor ? GEditor->GetEditorSubsystem<UEditorValidatorSubsystem>() : nullptr;
-
-	if (ValidatorSubsystem)
+	if (!GEditor)
 	{
-		// Use the DataValidation console command for broad validation
-		if (GEditor && GEditor->GetEditorWorldContext().World())
+		return MCPError(TEXT("Editor not available"));
+	}
+
+	UEditorValidatorSubsystem* ValidatorSubsystem = GEditor->GetEditorSubsystem<UEditorValidatorSubsystem>();
+	if (!ValidatorSubsystem)
+	{
+		return MCPError(TEXT("EditorValidatorSubsystem is not available"));
+	}
+
+	const bool bHasAssetPaths = Params->HasField(TEXT("assetPaths"));
+	const bool bHasAssetPath = Params->HasField(TEXT("assetPath"));
+	const bool bHasDirectory = Params->HasField(TEXT("directory"));
+	if ((bHasAssetPaths || bHasAssetPath) && bHasDirectory)
+	{
+		return MCPError(TEXT("Specify either assetPaths/assetPath or directory, not both"));
+	}
+	if (bHasAssetPaths && bHasAssetPath)
+	{
+		return MCPError(TEXT("Specify only one of assetPaths or assetPath"));
+	}
+
+	FAssetRegistryModule* AssetRegistryModule = FModuleManager::LoadModulePtr<FAssetRegistryModule>(TEXT("AssetRegistry"));
+	if (!AssetRegistryModule || !AssetRegistryModule->IsValid())
+	{
+		return MCPError(TEXT("AssetRegistry is not available"));
+	}
+	IAssetRegistry* AssetRegistry = AssetRegistryModule->TryGet();
+	if (!AssetRegistry)
+	{
+		return MCPError(TEXT("AssetRegistry is shutting down"));
+	}
+
+	TArray<FAssetData> AssetDataList;
+	FString SelectionMode;
+	FString Selection;
+	if (bHasAssetPaths || bHasAssetPath)
+	{
+		TArray<FString> RequestedPaths;
+		if (bHasAssetPaths)
 		{
-			FString Command = FString::Printf(TEXT("DataValidation.ValidateAssets %s"), *Directory);
-			UKismetSystemLibrary::ExecuteConsoleCommand(
-				GEditor->GetEditorWorldContext().World(),
-				Command,
-				nullptr
-			);
+			const TArray<TSharedPtr<FJsonValue>>* PathValues = nullptr;
+			if (!Params->TryGetArrayField(TEXT("assetPaths"), PathValues) || !PathValues || PathValues->Num() == 0)
+			{
+				return MCPError(TEXT("assetPaths must be a non-empty array of exact asset paths"));
+			}
+			RequestedPaths.Reserve(PathValues->Num());
+			for (const TSharedPtr<FJsonValue>& PathValue : *PathValues)
+			{
+				FString RequestedPath;
+				if (!PathValue.IsValid() || !PathValue->TryGetString(RequestedPath) || RequestedPath.TrimStartAndEnd().IsEmpty())
+				{
+					return MCPError(TEXT("Every assetPaths entry must be a non-empty string"));
+				}
+				RequestedPaths.Add(RequestedPath);
+			}
+		}
+		else
+		{
+			FString RequestedPath;
+			if (!Params->TryGetStringField(TEXT("assetPath"), RequestedPath) || RequestedPath.TrimStartAndEnd().IsEmpty())
+			{
+				return MCPError(TEXT("assetPath must be a non-empty exact package or object path"));
+			}
+			RequestedPaths.Add(RequestedPath);
 		}
 
-		auto Result = MCPSuccess();
-		Result->SetStringField(TEXT("directory"), Directory);
-		Result->SetStringField(TEXT("message"), TEXT("Asset validation triggered via EditorValidatorSubsystem"));
-		return MCPResult(Result);
+		TSet<FString> SeenObjectPaths;
+		for (const FString& RequestedPath : RequestedPaths)
+		{
+			FAssetData ResolvedAsset;
+			FString ResolveError;
+			if (!MCPResolveExplicitValidationAsset(*AssetRegistry, RequestedPath, ResolvedAsset, ResolveError))
+			{
+				return MCPError(ResolveError);
+			}
+
+			const FString ObjectPath = ResolvedAsset.GetObjectPathString();
+			if (!SeenObjectPaths.Contains(ObjectPath))
+			{
+				SeenObjectPaths.Add(ObjectPath);
+				AssetDataList.Add(ResolvedAsset);
+			}
+		}
+		SelectionMode = TEXT("explicit");
+		Selection = FString::Join(RequestedPaths, TEXT(","));
 	}
 	else
 	{
-		// Fallback: trigger via console command
-		if (GEditor && GEditor->GetEditorWorldContext().World())
+		const FString Directory = OptionalString(Params, TEXT("directory"), TEXT("/Game/")).TrimStartAndEnd();
+		if (Directory.IsEmpty() || !Directory.StartsWith(TEXT("/")))
 		{
-			UKismetSystemLibrary::ExecuteConsoleCommand(
-				GEditor->GetEditorWorldContext().World(),
-				TEXT("DataValidation.ValidateAssets"),
-				nullptr
-			);
+			return MCPError(TEXT("directory must be a non-empty package path such as /Game/"));
 		}
 
-		auto Result = MCPSuccess();
-		Result->SetStringField(TEXT("directory"), Directory);
-		Result->SetStringField(TEXT("message"), TEXT("Asset validation triggered via console command"));
-		return MCPResult(Result);
+		FARFilter Filter;
+		Filter.PackagePaths.Add(FName(*Directory));
+		Filter.bRecursivePaths = true;
+		if (!AssetRegistry->GetAssets(Filter, AssetDataList))
+		{
+			return MCPError(FString::Printf(TEXT("AssetRegistry could not enumerate directory: %s"), *Directory));
+		}
+		SelectionMode = TEXT("directory");
+		Selection = Directory;
 	}
+
+	AssetDataList.Sort([](const FAssetData& A, const FAssetData& B)
+	{
+		return A.GetObjectPathString() < B.GetObjectPathString();
+	});
+
+	FValidateAssetsSettings Settings;
+	Settings.ValidationUsecase = IsRunningCommandlet() ? EDataValidationUsecase::Commandlet : EDataValidationUsecase::Manual;
+	Settings.bCollectPerAssetDetails = true;
+	Settings.bShowIfNoFailures = false;
+	Settings.bSilent = true;
+	FValidateAssetsResults ValidationResults;
+	ValidatorSubsystem->ValidateAssetsWithSettings(AssetDataList, Settings, ValidationResults);
+
+	auto Result = MCPSuccess();
+	Result->SetStringField(TEXT("selectionMode"), SelectionMode);
+	Result->SetStringField(TEXT("selection"), Selection);
+	if (SelectionMode == TEXT("directory"))
+	{
+		// Preserve the legacy response field for { directory: ... } callers.
+		Result->SetStringField(TEXT("directory"), Selection);
+	}
+	Result->SetStringField(TEXT("validationUsecase"), Settings.ValidationUsecase == EDataValidationUsecase::Commandlet ? TEXT("commandlet") : TEXT("manual"));
+	Result->SetNumberField(TEXT("requested"), ValidationResults.NumRequested);
+	Result->SetNumberField(TEXT("checked"), ValidationResults.NumChecked);
+	Result->SetNumberField(TEXT("valid"), ValidationResults.NumValid);
+	Result->SetNumberField(TEXT("invalid"), ValidationResults.NumInvalid);
+	Result->SetNumberField(TEXT("skipped"), ValidationResults.NumSkipped);
+	Result->SetNumberField(TEXT("warnings"), ValidationResults.NumWarnings);
+	Result->SetNumberField(TEXT("unableToValidate"), ValidationResults.NumUnableToValidate);
+	Result->SetNumberField(TEXT("externalObjects"), ValidationResults.NumExternalObjects);
+	Result->SetBoolField(TEXT("assetLimitReached"), ValidationResults.bAssetLimitReached);
+	const FString OverallResult = ValidationResults.NumInvalid > 0
+		? TEXT("invalid")
+		: (ValidationResults.NumUnableToValidate > 0 || ValidationResults.NumRequested == 0 || ValidationResults.NumChecked == 0
+			? TEXT("notValidated")
+			: (ValidationResults.NumWarnings > 0 ? TEXT("warning") : TEXT("valid")));
+	Result->SetStringField(TEXT("result"), OverallResult);
+
+	TArray<FString> DetailKeys;
+	ValidationResults.AssetsDetails.GetKeys(DetailKeys);
+	DetailKeys.Sort();
+	TArray<TSharedPtr<FJsonValue>> DetailsArray;
+	DetailsArray.Reserve(DetailKeys.Num());
+	for (const FString& DetailKey : DetailKeys)
+	{
+		const FValidateAssetsDetails* Details = ValidationResults.AssetsDetails.Find(DetailKey);
+		if (!Details)
+		{
+			continue;
+		}
+		auto DetailObject = MakeShared<FJsonObject>();
+		DetailObject->SetStringField(TEXT("objectPath"), DetailKey);
+		DetailObject->SetStringField(TEXT("packageName"), Details->PackageName.ToString());
+		DetailObject->SetStringField(TEXT("assetName"), Details->AssetName.ToString());
+		DetailObject->SetStringField(TEXT("result"), MCPDataValidationResultToString(Details->Result));
+		DetailObject->SetArrayField(TEXT("errors"), MCPValidationTextArray(Details->ValidationErrors));
+		DetailObject->SetArrayField(TEXT("warnings"), MCPValidationTextArray(Details->ValidationWarnings));
+		DetailObject->SetArrayField(TEXT("messages"), MCPValidationMessageArray(Details->ValidationMessages));
+		DetailsArray.Add(MakeShared<FJsonValueObject>(DetailObject));
+	}
+	Result->SetArrayField(TEXT("assets"), DetailsArray);
+	Result->SetArrayField(TEXT("validatorMessages"), MCPValidationMessageArray(ValidationResults.ValidatorMessages));
+	Result->SetStringField(TEXT("message"), FString::Printf(TEXT("Validated %d assets"), ValidationResults.NumRequested));
+	return MCPResult(Result);
 }
 
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/MassHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/MassHandlers.cpp
@@ -1,0 +1,453 @@
+#include "MassHandlers.h"
+
+#include "HandlerAssetCreate.h"
+#include "HandlerJsonProperty.h"
+#include "HandlerRegistry.h"
+#include "HandlerUtils.h"
+
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Editor.h"
+#include "EditorScriptingUtilities/Public/EditorAssetLibrary.h"
+#include "Engine/DataAsset.h"
+#include "Misc/PackageName.h"
+#include "Misc/Paths.h"
+#include "UObject/UObjectGlobals.h"
+#include "UObject/UnrealType.h"
+
+namespace
+{
+	static const TCHAR* ConfigClassPath = TEXT("/Script/MassSpawner.MassEntityConfigAsset");
+	static const TCHAR* TraitBaseClassPath = TEXT("/Script/MassSpawner.MassEntityTraitBase");
+
+	UClass* ResolveClass(const FString& ClassPath)
+	{
+		if (ClassPath.IsEmpty()) return nullptr;
+		UClass* Result = LoadClass<UObject>(nullptr, *ClassPath);
+		if (!Result) Result = LoadObject<UClass>(nullptr, *ClassPath);
+		if (!Result)
+		{
+			FString ShortName = ClassPath;
+			ShortName.RemoveFromEnd(TEXT("_C"));
+			for (TObjectIterator<UClass> It; It; ++It)
+			{
+				if (It->GetName() == ShortName || It->GetName() == FPackageName::GetShortName(ClassPath))
+				{
+					Result = *It;
+					break;
+				}
+			}
+		}
+		return Result;
+	}
+
+	bool SplitAssetPath(const TSharedPtr<FJsonObject>& Params, FString& OutName, FString& OutPackagePath)
+	{
+		FString AssetPath;
+		Params->TryGetStringField(TEXT("assetPath"), AssetPath);
+		if (AssetPath.IsEmpty())
+		{
+			if (!Params->TryGetStringField(TEXT("name"), OutName) || OutName.IsEmpty()) return false;
+			OutPackagePath = OptionalString(Params, TEXT("packagePath"), TEXT("/Game"));
+			return !OutPackagePath.IsEmpty();
+		}
+
+		FString PackageName = AssetPath;
+		if (AssetPath.Contains(TEXT(".")))
+		{
+			PackageName = AssetPath.LeftChop(AssetPath.Len() - AssetPath.Find(TEXT("."), ESearchCase::CaseSensitive, ESearchDir::FromEnd));
+		}
+		OutName = FPackageName::GetShortName(PackageName);
+		OutPackagePath = FPaths::GetPath(PackageName);
+		return !OutName.IsEmpty() && !OutPackagePath.IsEmpty();
+	}
+
+	UObject* LoadConfigAsset(const FString& Name, const FString& PackagePath)
+	{
+		return LoadObject<UObject>(nullptr, *(PackagePath + TEXT("/") + Name + TEXT(".") + Name));
+	}
+
+	FProperty* FindTraitsProperty(UObject* ConfigAsset, void*& OutTraitsAddress)
+	{
+		OutTraitsAddress = nullptr;
+		if (!ConfigAsset) return nullptr;
+		FStructProperty* ConfigProperty = CastField<FStructProperty>(ConfigAsset->GetClass()->FindPropertyByName(TEXT("Config")));
+		if (!ConfigProperty) return nullptr;
+		void* ConfigAddress = ConfigProperty->ContainerPtrToValuePtr<void>(ConfigAsset);
+		FArrayProperty* TraitsProperty = CastField<FArrayProperty>(ConfigProperty->Struct->FindPropertyByName(TEXT("Traits")));
+		if (!TraitsProperty) return nullptr;
+		OutTraitsAddress = TraitsProperty->ContainerPtrToValuePtr<void>(ConfigAddress);
+		return TraitsProperty;
+	}
+
+	bool ReadTraitClasses(UObject* ConfigAsset, TArray<UClass*>& OutClasses, FString& OutError)
+	{
+		void* TraitsAddress = nullptr;
+		FArrayProperty* TraitsProperty = CastField<FArrayProperty>(FindTraitsProperty(ConfigAsset, TraitsAddress));
+		if (!TraitsProperty) { OutError = TEXT("Mass entity config does not expose Config.Traits"); return false; }
+		FObjectProperty* TraitObjectProperty = CastField<FObjectProperty>(TraitsProperty->Inner);
+		if (!TraitObjectProperty) { OutError = TEXT("Mass entity config Traits is not an object array"); return false; }
+
+		FScriptArrayHelper Helper(TraitsProperty, TraitsAddress);
+		OutClasses.Reserve(Helper.Num());
+		for (int32 Index = 0; Index < Helper.Num(); ++Index)
+		{
+			UObject* Trait = TraitObjectProperty->GetObjectPropertyValue(Helper.GetRawPtr(Index));
+			if (!Trait) { OutError = FString::Printf(TEXT("Config.Traits[%d] is null"), Index); return false; }
+			OutClasses.Add(Trait->GetClass());
+		}
+		return true;
+	}
+
+	bool AddTrait(UObject* ConfigAsset, UClass* TraitClass, UObject*& OutTrait, FString& OutError)
+	{
+		OutTrait = nullptr;
+		void* TraitsAddress = nullptr;
+		FArrayProperty* TraitsProperty = CastField<FArrayProperty>(FindTraitsProperty(ConfigAsset, TraitsAddress));
+		if (!TraitsProperty) { OutError = TEXT("Mass entity config does not expose Config.Traits"); return false; }
+		FObjectProperty* TraitObjectProperty = CastField<FObjectProperty>(TraitsProperty->Inner);
+		if (!TraitObjectProperty) { OutError = TEXT("Mass entity config Traits is not an object array"); return false; }
+
+		const FName TraitName = MakeUniqueObjectName(ConfigAsset, TraitClass, TraitClass->GetFName());
+		UObject* NewTrait = NewObject<UObject>(ConfigAsset, TraitClass, TraitName, RF_Transactional);
+		if (!NewTrait) { OutError = FString::Printf(TEXT("Failed to construct trait %s"), *TraitClass->GetPathName()); return false; }
+
+		FScriptArrayHelper Helper(TraitsProperty, TraitsAddress);
+		const int32 NewIndex = Helper.AddValue();
+		TraitObjectProperty->SetObjectPropertyValue(Helper.GetRawPtr(NewIndex), NewTrait);
+		OutTrait = NewTrait;
+		return true;
+	}
+
+	UObject* GetTraitAtIndex(UObject* ConfigAsset, int32 Index)
+	{
+		void* TraitsAddress = nullptr;
+		FArrayProperty* TraitsProperty = CastField<FArrayProperty>(FindTraitsProperty(ConfigAsset, TraitsAddress));
+		FObjectProperty* TraitObjectProperty = TraitsProperty ? CastField<FObjectProperty>(TraitsProperty->Inner) : nullptr;
+		if (!TraitsProperty || !TraitObjectProperty || Index < 0) return nullptr;
+		FScriptArrayHelper Helper(TraitsProperty, TraitsAddress);
+		return Index < Helper.Num() ? TraitObjectProperty->GetObjectPropertyValue(Helper.GetRawPtr(Index)) : nullptr;
+	}
+
+	TSharedPtr<FJsonValue> ValidateAndApplyProperties(UObject* Trait, const TSharedPtr<FJsonObject>& Properties, int32 TraitIndex, int32& OutSet)
+	{
+		if (!Properties.IsValid()) return nullptr;
+		for (const auto& Pair : Properties->Values)
+		{
+			// UE 5.8 stores JSON object keys in shared string storage; copy the
+			// key before passing it to the FString-based property-path helper.
+			const FString PropertyName(Pair.Key);
+			FString Error;
+			if (!MCPJsonProperty::SetDottedPropertyFromJson(Trait, PropertyName, Pair.Value, Error))
+			{
+				return MCPError(FString::Printf(TEXT("Trait %d property '%s' failed: %s"), TraitIndex, *PropertyName, *Error));
+			}
+			++OutSet;
+		}
+		return nullptr;
+	}
+
+	TSharedPtr<FJsonValue> MakeExistingResult(UObject* Asset, const TArray<UClass*>& ExistingClasses, bool bUpdated, int32 PropertiesSet)
+	{
+		TSharedPtr<FJsonObject> Result = MCPSuccess();
+		MCPSetExisted(Result);
+		if (bUpdated) MCPSetUpdated(Result);
+		Result->SetStringField(TEXT("assetPath"), Asset->GetPathName());
+		Result->SetNumberField(TEXT("traits"), ExistingClasses.Num());
+		Result->SetNumberField(TEXT("propertiesSet"), PropertiesSet);
+		return MCPResult(Result);
+	}
+
+	void ReleasePreviews(TArray<UObject*>& Previews)
+	{
+		for (UObject* Preview : Previews)
+		{
+			if (Preview) Preview->RemoveFromRoot();
+		}
+		Previews.Reset();
+	}
+
+	FString ExportTraitProperty(const FProperty* Property, const UObject* Trait)
+	{
+		if (!Property || !Trait) return TEXT("");
+		if (const FObjectPropertyBase* ObjectProperty = CastField<FObjectPropertyBase>(Property))
+		{
+			if (UObject* Value = ObjectProperty->GetObjectPropertyValue_InContainer(Trait))
+			{
+				return Value->GetPathName();
+			}
+			return TEXT("None");
+		}
+		if (const FSoftObjectProperty* SoftObjectProperty = CastField<FSoftObjectProperty>(Property))
+		{
+			return SoftObjectProperty->GetPropertyValue_InContainer(Trait).ToSoftObjectPath().ToString();
+		}
+
+		FString Exported;
+		const void* ValueAddress = Property->ContainerPtrToValuePtr<void>(Trait);
+		Property->ExportTextItem_Direct(Exported, ValueAddress, nullptr, nullptr, PPF_None);
+		return Exported;
+	}
+}
+void FMassHandlers::RegisterHandlers(FMCPHandlerRegistry& Registry)
+{
+	Registry.RegisterHandler(TEXT("ensure_mass_entity_config"), &EnsureEntityConfig);
+	Registry.RegisterHandler(TEXT("read_mass_entity_config"), &ReadEntityConfig);
+}
+
+TSharedPtr<FJsonValue> FMassHandlers::ReadEntityConfig(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath;
+	if (auto Err = RequireString(Params, TEXT("assetPath"), AssetPath)) return Err;
+
+	UClass* ConfigClass = ResolveClass(ConfigClassPath);
+	UClass* TraitBaseClass = ResolveClass(TraitBaseClassPath);
+	if (!ConfigClass || !TraitBaseClass)
+	{
+		return MCPError(TEXT("MassSpawner is unavailable; enable MassGameplay/MassSpawner before using read_mass_entity_config"));
+	}
+
+	UObject* Asset = LoadAssetByPath<UObject>(AssetPath);
+	if (!Asset) return MCPError(FString::Printf(TEXT("Mass entity config not found: %s"), *AssetPath));
+	if (!Asset->IsA(ConfigClass))
+	{
+		return MCPError(FString::Printf(TEXT("Asset is not a MassEntityConfigAsset: %s"), *Asset->GetPathName()));
+	}
+
+	TArray<UClass*> TraitClasses;
+	FString Error;
+	if (!ReadTraitClasses(Asset, TraitClasses, Error)) return MCPError(Error);
+
+	auto Result = MCPSuccess();
+	Result->SetStringField(TEXT("assetPath"), Asset->GetPathName());
+	Result->SetStringField(TEXT("assetClass"), Asset->GetClass()->GetPathName());
+
+	TArray<TSharedPtr<FJsonValue>> TraitClassNames;
+	TArray<TSharedPtr<FJsonValue>> TraitRecords;
+	for (int32 Index = 0; Index < TraitClasses.Num(); ++Index)
+	{
+		UObject* Trait = GetTraitAtIndex(Asset, Index);
+		if (!Trait || !Trait->GetClass()->IsChildOf(TraitBaseClass))
+		{
+			return MCPError(FString::Printf(TEXT("Config.Traits[%d] is not a UMassEntityTraitBase"), Index));
+		}
+
+		const FString ClassPath = Trait->GetClass()->GetPathName();
+		TraitClassNames.Add(MakeShared<FJsonValueString>(ClassPath));
+		auto Record = MakeShared<FJsonObject>();
+		Record->SetNumberField(TEXT("index"), Index);
+		Record->SetStringField(TEXT("classPath"), ClassPath);
+		Record->SetStringField(TEXT("className"), Trait->GetClass()->GetName());
+
+		auto Properties = MakeShared<FJsonObject>();
+		for (TFieldIterator<FProperty> PropertyIt(Trait->GetClass()); PropertyIt; ++PropertyIt)
+		{
+			const FProperty* Property = *PropertyIt;
+			if (!Property || Property->HasAnyPropertyFlags(CPF_Transient)) continue;
+			Properties->SetStringField(Property->GetName(), ExportTraitProperty(Property, Trait));
+		}
+		Record->SetObjectField(TEXT("properties"), Properties);
+		TraitRecords.Add(MakeShared<FJsonValueObject>(Record));
+	}
+	Result->SetArrayField(TEXT("traitClasses"), TraitClassNames);
+	Result->SetArrayField(TEXT("traits"), TraitRecords);
+	Result->SetNumberField(TEXT("traitCount"), TraitClasses.Num());
+	return MCPResult(Result);
+}
+
+TSharedPtr<FJsonValue> FMassHandlers::EnsureEntityConfig(const TSharedPtr<FJsonObject>& Params)
+{
+	FString Name;
+	FString PackagePath;
+	if (!SplitAssetPath(Params, Name, PackagePath))
+	{
+		return MCPError(TEXT("Provide assetPath (/Game/Folder/Name[.Name]) or name plus packagePath"));
+	}
+	if (!FPackageName::IsValidLongPackageName(PackagePath))
+	{
+		return MCPError(FString::Printf(TEXT("Invalid package path: %s"), *PackagePath));
+	}
+
+	UClass* ConfigClass = ResolveClass(ConfigClassPath);
+	UClass* TraitBaseClass = ResolveClass(TraitBaseClassPath);
+	if (!ConfigClass || !TraitBaseClass)
+	{
+		return MCPError(TEXT("MassSpawner is unavailable; enable MassGameplay/MassSpawner before using ensure_mass_entity_config"));
+	}
+	if (!ConfigClass->IsChildOf(UDataAsset::StaticClass()) || !TraitBaseClass->IsChildOf(UObject::StaticClass()))
+	{
+		return MCPError(TEXT("MassSpawner classes are incompatible with this engine version"));
+	}
+
+	const FString OnConflict = OptionalString(Params, TEXT("onConflict"), TEXT("update")).ToLower();
+	if (OnConflict != TEXT("skip") && OnConflict != TEXT("error") && OnConflict != TEXT("update"))
+	{
+		return MCPError(TEXT("onConflict must be one of: skip, error, update"));
+	}
+
+	const TSharedPtr<FJsonValue>* TraitsValue = Params->Values.Find(TEXT("traits"));
+	const TArray<TSharedPtr<FJsonValue>>* TraitArray = nullptr;
+	if (!TraitsValue || !(*TraitsValue).IsValid() || !(*TraitsValue)->TryGetArray(TraitArray) || !TraitArray)
+	{
+		return MCPError(TEXT("Missing required 'traits' array"));
+	}
+
+	struct FRequestedTrait { UClass* Class = nullptr; const TSharedPtr<FJsonObject>* Properties = nullptr; };
+	TArray<FRequestedTrait> Requested;
+	TSet<UClass*> SeenClasses;
+	for (int32 Index = 0; Index < TraitArray->Num(); ++Index)
+	{
+		const TSharedPtr<FJsonObject>* TraitObject = nullptr;
+		if (!(*TraitArray)[Index].IsValid() || !(*TraitArray)[Index]->TryGetObject(TraitObject) || !TraitObject || !(*TraitObject).IsValid())
+		{
+			return MCPError(FString::Printf(TEXT("traits[%d] must be an object"), Index));
+		}
+		FString ClassPath;
+		if (!(*TraitObject)->TryGetStringField(TEXT("class"), ClassPath) && !(*TraitObject)->TryGetStringField(TEXT("traitClass"), ClassPath))
+		{
+			return MCPError(FString::Printf(TEXT("traits[%d] requires class or traitClass"), Index));
+		}
+		UClass* TraitClass = ResolveClass(ClassPath);
+		if (!TraitClass || !TraitClass->IsChildOf(TraitBaseClass) || TraitClass->HasAnyClassFlags(CLASS_Abstract))
+		{
+			return MCPError(FString::Printf(TEXT("traits[%d] is not a concrete UMassEntityTraitBase: %s"), Index, *ClassPath));
+		}
+		if (SeenClasses.Contains(TraitClass))
+		{
+			return MCPError(FString::Printf(TEXT("traits[%d] duplicates trait class %s; ordered traits must be unique"), Index, *ClassPath));
+		}
+		SeenClasses.Add(TraitClass);
+		FRequestedTrait& Request = Requested.AddDefaulted_GetRef();
+		Request.Class = TraitClass;
+		(*TraitObject)->TryGetObjectField(TEXT("properties"), Request.Properties);
+	}
+
+	// Validate every property against a transient trait before loading or
+	// creating the real config. This is deliberately done for the whole list,
+	// not while appending traits, so a bad property late in the request cannot
+	// leave a partially authored asset behind.
+	TArray<UObject*> Previews;
+	Previews.Reserve(Requested.Num());
+	for (int32 Index = 0; Index < Requested.Num(); ++Index)
+	{
+		const FName PreviewName = MakeUniqueObjectName(GetTransientPackage(), Requested[Index].Class, Requested[Index].Class->GetFName());
+		UObject* Preview = NewObject<UObject>(GetTransientPackage(), Requested[Index].Class, PreviewName, RF_Transient);
+		if (!Preview)
+		{
+			ReleasePreviews(Previews);
+			return MCPError(FString::Printf(TEXT("Failed to construct transient preview for trait %d (%s)"), Index, *Requested[Index].Class->GetPathName()));
+		}
+		Preview->AddToRoot();
+		Previews.Add(Preview);
+		int32 IgnoredProperties = 0;
+		if (TSharedPtr<FJsonValue> Error = ValidateAndApplyProperties(Preview, Requested[Index].Properties ? *Requested[Index].Properties : nullptr, Index, IgnoredProperties))
+		{
+			ReleasePreviews(Previews);
+			return Error;
+		}
+	}
+	ReleasePreviews(Previews);
+
+	UObject* ExistingAsset = LoadConfigAsset(Name, PackagePath);
+	if (ExistingAsset && !ExistingAsset->IsA(ConfigClass))
+	{
+		return MCPError(FString::Printf(TEXT("Asset exists but is not a MassEntityConfigAsset: %s"), *ExistingAsset->GetPathName()));
+	}
+	if (ExistingAsset && OnConflict == TEXT("error"))
+	{
+		return MCPError(FString::Printf(TEXT("MassEntityConfigAsset '%s' already exists"), *ExistingAsset->GetPathName()));
+	}
+	if (ExistingAsset && OnConflict == TEXT("skip"))
+	{
+		TArray<UClass*> ExistingClasses; FString Error;
+		if (!ReadTraitClasses(ExistingAsset, ExistingClasses, Error)) return MCPError(Error);
+		return MakeExistingResult(ExistingAsset, ExistingClasses, false, 0);
+	}
+
+	bool bCreated = false;
+	if (!ExistingAsset)
+	{
+		auto Created = MCPCreateAssetIdempotent<UObject>(Name, PackagePath, TEXT("error"), TEXT("MassEntityConfigAsset"), ConfigClass, nullptr);
+		if (Created.EarlyReturn) return Created.EarlyReturn;
+		ExistingAsset = Created.Asset;
+		bCreated = true;
+	}
+
+	TArray<UClass*> ExistingClasses;
+	FString ReadError;
+	if (!ReadTraitClasses(ExistingAsset, ExistingClasses, ReadError)) return MCPError(ReadError);
+	if (ExistingClasses.Num() > Requested.Num())
+	{
+		return MCPError(TEXT("Existing config has more traits than requested; refusing destructive replacement"));
+	}
+	for (int32 Index = 0; Index < ExistingClasses.Num(); ++Index)
+	{
+		if (ExistingClasses[Index] != Requested[Index].Class)
+		{
+			return MCPError(FString::Printf(TEXT("Existing trait order conflicts at index %d; refusing destructive replacement"), Index));
+		}
+	}
+
+	// For an update, duplicate the existing instanced traits into the transient
+	// package as a second preflight. This catches property paths that are valid
+	// on the class but invalid for the currently-authored trait instance before
+	// Modify() or any real property write is issued.
+	if (!bCreated)
+	{
+		Previews.Reset();
+		for (int32 Index = 0; Index < Requested.Num(); ++Index)
+		{
+			UObject* SourceTrait = Index < ExistingClasses.Num() ? GetTraitAtIndex(ExistingAsset, Index) : nullptr;
+			UObject* Preview = SourceTrait
+				? StaticDuplicateObject(SourceTrait, GetTransientPackage(), NAME_None, RF_Transient)
+				: NewObject<UObject>(GetTransientPackage(), Requested[Index].Class,
+					MakeUniqueObjectName(GetTransientPackage(), Requested[Index].Class, Requested[Index].Class->GetFName()), RF_Transient);
+			if (!Preview)
+			{
+				ReleasePreviews(Previews);
+				return MCPError(FString::Printf(TEXT("Failed to construct transient update preview for trait %d"), Index));
+			}
+			Preview->AddToRoot();
+			Previews.Add(Preview);
+			int32 IgnoredProperties = 0;
+			if (TSharedPtr<FJsonValue> Error = ValidateAndApplyProperties(Preview, Requested[Index].Properties ? *Requested[Index].Properties : nullptr, Index, IgnoredProperties))
+			{
+				ReleasePreviews(Previews);
+				return Error;
+			}
+		}
+		ReleasePreviews(Previews);
+	}
+
+	// Establish the transaction before any instanced trait is appended or
+	// mutated. This is required for editor undo/redo and keeps the mutation
+	// boundary explicit for callers using onConflict=update.
+	ExistingAsset->Modify();
+	int32 PropertiesSet = 0;
+	for (int32 Index = 0; Index < Requested.Num(); ++Index)
+	{
+		UObject* Trait = nullptr;
+		if (Index < ExistingClasses.Num()) Trait = GetTraitAtIndex(ExistingAsset, Index);
+		else if (!AddTrait(ExistingAsset, Requested[Index].Class, Trait, ReadError))
+		{
+			return MCPError(ReadError);
+		}
+		if (TSharedPtr<FJsonValue> Error = ValidateAndApplyProperties(Trait, Requested[Index].Properties ? *Requested[Index].Properties : nullptr, Index, PropertiesSet))
+		{
+			return Error;
+		}
+	}
+
+	ExistingAsset->MarkPackageDirty();
+	if (!SaveAssetPackage(ExistingAsset))
+	{
+		return MCPError(FString::Printf(TEXT("Failed to save MassEntityConfigAsset: %s"), *ExistingAsset->GetPathName()));
+	}
+
+	TSharedPtr<FJsonObject> Result = MCPSuccess();
+	if (bCreated) MCPSetCreated(Result); else { MCPSetExisted(Result); MCPSetUpdated(Result); }
+	Result->SetStringField(TEXT("assetPath"), ExistingAsset->GetPathName());
+	Result->SetNumberField(TEXT("traits"), Requested.Num());
+	Result->SetNumberField(TEXT("propertiesSet"), PropertiesSet);
+	if (bCreated) MCPSetDeleteAssetRollback(Result, ExistingAsset->GetPathName());
+	return MCPResult(Result);
+}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/MassHandlers.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/MassHandlers.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonValue.h"
+
+/**
+ * Editor-only authoring helpers for Mass entity configuration assets.
+ *
+ * The implementation intentionally resolves Mass classes by reflection. This
+ * keeps the bridge loadable on engine versions/projects where Mass is not
+ * enabled while still providing a strongly validated path when MassSpawner is
+ * present.
+ */
+class FMassHandlers
+{
+public:
+	static void RegisterHandlers(class FMCPHandlerRegistry& Registry);
+
+private:
+	static TSharedPtr<FJsonValue> EnsureEntityConfig(const TSharedPtr<FJsonObject>& Params);
+	static TSharedPtr<FJsonValue> ReadEntityConfig(const TSharedPtr<FJsonObject>& Params);
+};

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/SkeletalMeshHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/SkeletalMeshHandlers.cpp
@@ -1,0 +1,200 @@
+#include "SkeletalMeshHandlers.h"
+
+#include "HandlerRegistry.h"
+#include "HandlerUtils.h"
+
+#include "Engine/SkeletalMesh.h"
+#include "SkeletalMeshEditorSubsystem.h"
+
+namespace
+{
+	struct FTargetLod
+	{
+		int32 Index = INDEX_NONE;
+		FSkeletalMeshBuildSettings Before;
+	};
+
+	TSharedPtr<FJsonValue> ResolveTargetLods(
+		const TSharedPtr<FJsonObject>& Params,
+		USkeletalMesh* Mesh,
+		TArray<FTargetLod>& OutLods)
+	{
+		if (!Mesh) return MCPError(TEXT("SkeletalMesh is null"));
+		const int32 LodCount = Mesh->GetLODNum();
+		if (LodCount <= 0) return MCPError(TEXT("SkeletalMesh has no LODs"));
+
+		const bool bAllLods = OptionalBool(Params, TEXT("allLods"), false);
+		if (bAllLods && Params->HasField(TEXT("lodIndex")))
+		{
+			return MCPError(TEXT("Specify either allLods=true or lodIndex, not both"));
+		}
+
+		TArray<int32> Indices;
+		if (bAllLods)
+		{
+			for (int32 Index = 0; Index < LodCount; ++Index) Indices.Add(Index);
+		}
+		else
+		{
+			int32 LodIndex = 0;
+			if (Params->HasField(TEXT("lodIndex")))
+			{
+				double LodNumber = 0.0;
+				if (!Params->TryGetNumberField(TEXT("lodIndex"), LodNumber)
+					|| !FMath::IsFinite(LodNumber)
+					|| !FMath::IsNearlyEqual(LodNumber, FMath::RoundToDouble(LodNumber)))
+				{
+					return MCPError(TEXT("lodIndex must be a finite integer"));
+				}
+				if (LodNumber < static_cast<double>(MIN_int32) || LodNumber > static_cast<double>(MAX_int32))
+				{
+					return MCPError(TEXT("lodIndex is outside the supported integer range"));
+				}
+				LodIndex = static_cast<int32>(LodNumber);
+			}
+			Indices.Add(LodIndex);
+		}
+
+		for (const int32 Index : Indices)
+		{
+			if (Index < 0 || Index >= LodCount)
+			{
+				return MCPError(FString::Printf(TEXT("Invalid lodIndex %d; mesh has %d LODs"), Index, LodCount));
+			}
+			FTargetLod& Target = OutLods.AddDefaulted_GetRef();
+			Target.Index = Index;
+			USkeletalMeshEditorSubsystem::GetLodBuildSettings(Mesh, Index, Target.Before);
+		}
+		return nullptr;
+	}
+
+	TSharedPtr<FJsonObject> SerializeBuildSettings(const FSkeletalMeshBuildSettings& Settings)
+	{
+		auto Out = MakeShared<FJsonObject>();
+		Out->SetBoolField(TEXT("bRecomputeNormals"), Settings.bRecomputeNormals);
+		Out->SetBoolField(TEXT("bRecomputeTangents"), Settings.bRecomputeTangents);
+		Out->SetBoolField(TEXT("bUseMikkTSpace"), Settings.bUseMikkTSpace);
+		Out->SetBoolField(TEXT("bComputeWeightedNormals"), Settings.bComputeWeightedNormals);
+		Out->SetBoolField(TEXT("bRemoveDegenerates"), Settings.bRemoveDegenerates);
+		Out->SetBoolField(TEXT("bUseHighPrecisionTangentBasis"), Settings.bUseHighPrecisionTangentBasis);
+		Out->SetBoolField(TEXT("bUseHighPrecisionSkinWeights"), Settings.bUseHighPrecisionSkinWeights);
+		Out->SetBoolField(TEXT("bUseFullPrecisionUVs"), Settings.bUseFullPrecisionUVs);
+		Out->SetBoolField(TEXT("bUseBackwardsCompatibleF16TruncUVs"), Settings.bUseBackwardsCompatibleF16TruncUVs);
+		Out->SetBoolField(TEXT("bOptimizeForInstancing"), Settings.bOptimizeForInstancing);
+		Out->SetNumberField(TEXT("thresholdPosition"), Settings.ThresholdPosition);
+		Out->SetNumberField(TEXT("thresholdTangentNormal"), Settings.ThresholdTangentNormal);
+		Out->SetNumberField(TEXT("thresholdUV"), Settings.ThresholdUV);
+		Out->SetNumberField(TEXT("morphThresholdPosition"), Settings.MorphThresholdPosition);
+		Out->SetNumberField(TEXT("boneInfluenceLimit"), Settings.BoneInfluenceLimit);
+		return Out;
+	}
+
+	TSharedPtr<FJsonObject> MakeLodResult(int32 Index, const FSkeletalMeshBuildSettings& Before, const FSkeletalMeshBuildSettings& After)
+	{
+		auto Lod = MakeShared<FJsonObject>();
+		Lod->SetNumberField(TEXT("lodIndex"), Index);
+		Lod->SetObjectField(TEXT("beforeBuildSettings"), SerializeBuildSettings(Before));
+		Lod->SetObjectField(TEXT("afterBuildSettings"), SerializeBuildSettings(After));
+		Lod->SetBoolField(TEXT("beforeOptimizeForInstancing"), Before.bOptimizeForInstancing);
+		Lod->SetBoolField(TEXT("afterOptimizeForInstancing"), After.bOptimizeForInstancing);
+		Lod->SetBoolField(TEXT("changed"), Before.bOptimizeForInstancing != After.bOptimizeForInstancing);
+		return Lod;
+	}
+}
+void FSkeletalMeshHandlers::RegisterHandlers(FMCPHandlerRegistry& Registry)
+{
+	Registry.RegisterHandler(TEXT("set_skeletal_mesh_optimize_for_instancing"), &SetOptimizeForInstancing);
+	Registry.RegisterHandler(TEXT("read_skeletal_mesh_build_settings"), &ReadBuildSettings);
+}
+
+TSharedPtr<FJsonValue> FSkeletalMeshHandlers::ReadBuildSettings(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath;
+	if (auto Err = RequireString(Params, TEXT("assetPath"), AssetPath)) return Err;
+	USkeletalMesh* Mesh = LoadAssetByPath<USkeletalMesh>(AssetPath);
+	if (!Mesh) return MCPError(FString::Printf(TEXT("SkeletalMesh not found: %s"), *AssetPath));
+
+	TArray<FTargetLod> Targets;
+	if (TSharedPtr<FJsonValue> Error = ResolveTargetLods(Params, Mesh, Targets)) return Error;
+
+	auto Result = MCPSuccess();
+	Result->SetStringField(TEXT("assetPath"), Mesh->GetPathName());
+	Result->SetNumberField(TEXT("lodCount"), Mesh->GetLODNum());
+	TArray<TSharedPtr<FJsonValue>> Lods;
+	for (const FTargetLod& Target : Targets)
+	{
+		Lods.Add(MakeShared<FJsonValueObject>(MakeLodResult(Target.Index, Target.Before, Target.Before)));
+	}
+	Result->SetArrayField(TEXT("lods"), Lods);
+	return MCPResult(Result);
+}
+
+TSharedPtr<FJsonValue> FSkeletalMeshHandlers::SetOptimizeForInstancing(const TSharedPtr<FJsonObject>& Params)
+{
+	FString AssetPath;
+	if (auto Err = RequireString(Params, TEXT("assetPath"), AssetPath)) return Err;
+	bool bEnabled = false;
+	if (!Params->TryGetBoolField(TEXT("enabled"), bEnabled))
+	{
+		return MCPError(TEXT("Missing required parameter 'enabled'"));
+	}
+
+	USkeletalMesh* Mesh = LoadAssetByPath<USkeletalMesh>(AssetPath);
+	if (!Mesh) return MCPError(FString::Printf(TEXT("SkeletalMesh not found: %s"), *AssetPath));
+
+	TArray<FTargetLod> Targets;
+	if (TSharedPtr<FJsonValue> Error = ResolveTargetLods(Params, Mesh, Targets)) return Error;
+
+	bool bNeedsMutation = false;
+	for (const FTargetLod& Target : Targets)
+	{
+		if (Target.Before.bOptimizeForInstancing != bEnabled)
+		{
+			bNeedsMutation = true;
+			break;
+		}
+	}
+
+	TArray<TSharedPtr<FJsonValue>> Lods;
+	int32 ChangedLodCount = 0;
+	if (bNeedsMutation)
+	{
+		// Establish the transaction before the first setter. The subsystem also
+		// protects its scoped rebuild, but this preserves the handler's explicit
+		// mutation boundary for undo/redo and fail-closed preflight behavior.
+		Mesh->Modify();
+		for (const FTargetLod& Target : Targets)
+		{
+			if (Target.Before.bOptimizeForInstancing != bEnabled)
+			{
+				++ChangedLodCount;
+				FSkeletalMeshBuildSettings Updated = Target.Before;
+				Updated.bOptimizeForInstancing = bEnabled;
+				USkeletalMeshEditorSubsystem::SetLodBuildSettings(Mesh, Target.Index, Updated);
+			}
+			FSkeletalMeshBuildSettings After;
+			USkeletalMeshEditorSubsystem::GetLodBuildSettings(Mesh, Target.Index, After);
+			Lods.Add(MakeShared<FJsonValueObject>(MakeLodResult(Target.Index, Target.Before, After)));
+		}
+		if (!SaveAssetPackage(Mesh))
+		{
+			return MCPError(FString::Printf(TEXT("Failed to save SkeletalMesh: %s"), *Mesh->GetPathName()));
+		}
+	}
+	else
+	{
+		for (const FTargetLod& Target : Targets)
+		{
+			Lods.Add(MakeShared<FJsonValueObject>(MakeLodResult(Target.Index, Target.Before, Target.Before)));
+		}
+	}
+
+	auto Result = MCPSuccess();
+	Result->SetStringField(TEXT("assetPath"), Mesh->GetPathName());
+	Result->SetBoolField(TEXT("enabled"), bEnabled);
+	Result->SetBoolField(TEXT("updated"), bNeedsMutation);
+	Result->SetBoolField(TEXT("saved"), bNeedsMutation);
+	Result->SetNumberField(TEXT("changedLods"), ChangedLodCount);
+	Result->SetArrayField(TEXT("lods"), Lods);
+	return MCPResult(Result);
+}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/SkeletalMeshHandlers.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/SkeletalMeshHandlers.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonValue.h"
+
+/** Small, editor-only skeletal mesh build-settings handlers. */
+class FSkeletalMeshHandlers
+{
+public:
+	static void RegisterHandlers(class FMCPHandlerRegistry& Registry);
+
+private:
+	static TSharedPtr<FJsonValue> SetOptimizeForInstancing(const TSharedPtr<FJsonObject>& Params);
+	static TSharedPtr<FJsonValue> ReadBuildSettings(const TSharedPtr<FJsonObject>& Params);
+};

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/StateTreeHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/StateTreeHandlers.cpp
@@ -458,9 +458,26 @@ TSharedPtr<FJsonObject> FStateTreeHandlers::SerializeStateHierarchy(const UState
 		if (Trans.State.ID.IsValid())
 		{
 			TransObj->SetStringField(TEXT("targetStateId"), GuidToString(Trans.State.ID));
+			const UStateTreeEditorData* EditorData =
+				Cast<UStateTreeEditorData>(State->GetTypedOuter<UStateTreeEditorData>());
+			if (EditorData)
+			{
+				if (const UStateTreeState* TargetState =
+					EditorData->GetStateByID(Trans.State.ID))
+				{
+					TransObj->SetStringField(
+						TEXT("targetStatePath"),
+						GetStatePath(TargetState));
+				}
+			}
 		}
 
 		TransObj->SetBoolField(TEXT("bEnabled"), Trans.bTransitionEnabled);
+		TransObj->SetBoolField(TEXT("bDelayTransition"), Trans.bDelayTransition);
+		TransObj->SetNumberField(TEXT("delayDuration"), Trans.DelayDuration);
+		TransObj->SetNumberField(
+			TEXT("delayRandomVariance"),
+			Trans.DelayRandomVariance);
 
 		TArray<TSharedPtr<FJsonValue>> TransCondArr;
 		for (const FStateTreeEditorNode& TCond : Trans.Conditions)
@@ -685,7 +702,9 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::ReadStateTree(const TSharedPtr<FJsonO
 
 	if (EditorData->Schema)
 	{
-		Result->SetStringField(TEXT("schemaClass"), EditorData->Schema->GetClass()->GetPathName());
+		const FString SchemaPath = EditorData->Schema->GetClass()->GetPathName();
+		Result->SetStringField(TEXT("schemaClass"), SchemaPath);
+		Result->SetStringField(TEXT("schemaPath"), SchemaPath);
 	}
 
 	// SubTrees (state hierarchy)
@@ -2403,6 +2422,17 @@ TSharedPtr<FJsonValue> FStateTreeHandlers::ValidateStateTree(const TSharedPtr<FJ
 	UStateTreeEditingSubsystem::ValidateStateTree(ST);
 
 	auto Result = MCPSuccess();
+	Result->SetStringField(TEXT("assetPath"), ST->GetPathName());
+	if (UStateTreeEditorData* EditorData = GetEditorData(ST))
+	{
+		if (EditorData->Schema)
+		{
+			const FString SchemaPath =
+				EditorData->Schema->GetClass()->GetPathName();
+			Result->SetStringField(TEXT("schemaClass"), SchemaPath);
+			Result->SetStringField(TEXT("schemaPath"), SchemaPath);
+		}
+	}
 	Result->SetBoolField(TEXT("validated"), true);
 	return MCPResult(Result);
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/UE_MCP_Bridge.Build.cs
@@ -90,6 +90,7 @@ public class UE_MCP_Bridge : ModuleRules
 				"PythonScriptPlugin",
 				"Sequencer",
 				"Settings",
+				"SkeletalMeshEditor",
 				"Slate",
 				"SlateCore",
 				"StateTreeModule",
@@ -139,4 +140,4 @@ public class UE_MCP_Bridge : ModuleRules
 	}
 }
 
-// Rescan trigger: round 2 added handler translation units.
+// Rescan trigger: Mass and skeletal-mesh handler translation units.


### PR DESCRIPTION
## Summary

Adds native UE-MCP editor handlers for:

- Mass entity-config authoring and readback with ordered traits and reflected trait properties.
- StateTree schema, task, binding, transition, and validation inspection.
- Skeletal-mesh LOD instancing build-setting inspection and idempotent updates.
- Synchronous Asset Registry-backed asset validation with deterministic selection and per-asset results.

## Validation

- `npm run test:unit` - 83 files, 840 tests passed.
- `npm run audit:unity` passed.
- `npm run audit:em-dash` passed.
- `npx tsc --noEmit` passed.
- `git diff --cached --check` passed.
- The guarded Unreal build was attempted but could not start because the configured test engine root was invalid and the available engine roots are protected by the repository safety policy.

All changes are confined to `plugin/ue_mcp_bridge`. No project assets or game-specific files are included.
