### PR TITLE
Restore the convention gate, finish the rollback debt, and make the engine range true

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Details: [Guards](https://ue-mcp.com/docs/plugins-guards/) and [Handler Conventi
 
 | | |
 |---|---|
-| **Unreal Engine** | 5.4-5.8 (Windows), 5.6+ (Linux and macOS). `epic` category needs 5.8+. |
+| **Unreal Engine** | 5.4-5.8 (Windows), 5.6+ (Linux and macOS). Compiled and verified on 5.7 and 5.8; 5.4 to 5.6 are version-gated in source but not built here. `epic` category needs 5.8+. |
 | **Node.js** | 18 or newer |
 | **UE plugins** | `PythonScriptPlugin` (ships with the engine); `init` enables the rest for you |
 | **C++ toolchain** | Required - the bridge is a C++ plugin and compiles on first editor launch. On Windows that means Visual Studio with the C++ workload; on macOS, Xcode command line tools. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ UE-MCP lets you tell an AI assistant what you want done in Unreal. It can place 
 
 ## Prerequisites
 
-1. Install [**Unreal Engine 5.4 to 5.8**](https://www.unrealengine.com/en-US/download "Free download via the Epic Games Launcher.")
+1. Install [**Unreal Engine 5.4 to 5.8**](https://www.unrealengine.com/en-US/download "Free download via the Epic Games Launcher.") (the plugin is compiled and verified on 5.7 and 5.8; older versions are version-gated in source but not built)
 2. Install [**Node.js 18 or newer**](https://nodejs.org/ "JavaScript runtime that UE-MCP needs to run.")
 3. Install an MCP-capable AI client (e.g. [**Claude Code**](https://docs.anthropic.com/en/docs/claude-code "Anthropic's official CLI agent."))
 

--- a/docs/handler-conventions.md
+++ b/docs/handler-conventions.md
@@ -146,6 +146,11 @@ MCPSetDeleteAssetRollback(Result, AssetPath)  // shorthand for delete_asset roll
 MCPSetNoRollback(Result, Reason)              // { rollbackPossible: false, rollbackNote }
                                               // The reason is required: see
                                               // "rollbackPossible" below.
+MCPSetIdempotencyUnobservable(Result, Reason) // { idempotencyObservable: false, idempotencyNote }
+                                              // The same statement, one
+                                              // convention over: this call
+                                              // cannot read whether it changed
+                                              // anything, and here is why.
 
 // Existence probes - return a ready-to-return Existed/Error JSON value
 // on hit, an unset shared pointer on miss.
@@ -358,7 +363,7 @@ A handler with no natural key cannot be idempotent, and one whose effect is an e
 - `level.save` - writing packages to disk has no inverse call
 - `asset.reimport` - the previous import is not recoverable from the asset it replaced
 
-Being on this list is not an exemption from saying so. Each of these still owes the caller a `rollbackPossible: false` and a note, and the ones that do not yet emit one are counted by the `mutationsSilentOnRollback` baseline rather than excused by it. The only entries the audit exempts outright live in `NO_INVERSE` in `tests/unit/handler-conventions.test.ts`, each with a written reason, and that list is deliberately three long.
+Being on this list is not an exemption from saying so. Each of these owes the caller a `rollbackPossible: false` and a note, and every one of them now emits it. There is no allowlist to be added to: the `NO_INVERSE` map that used to exempt four handlers is gone, because it stated their reasons inside a test file where no caller could read them, and all four now state the same reasons in the response body.
 
 `level.load` used to be on this list and is not any more: it captures the level that was open and emits the `load_level` call that returns to it.
 
@@ -371,19 +376,43 @@ node scripts/audit-handler-conventions.mjs        # counts, plus the offenders b
 node scripts/audit-handler-conventions.mjs --json # every handler, one row each
 ```
 
-`tests/unit/handler-conventions.test.ts` pins those counts as a ratchet. A number that goes UP means a new handler skipped a convention. A number that goes DOWN means somebody fixed one, and the fix is not finished until the lower number is committed.
+`tests/unit/handler-conventions.test.ts` pins those counts. Two of them are flat
+rules at zero: a mutation that answers neither question fails the suite outright.
+The rest are a ratchet, where a number that goes UP means a new handler skipped a
+convention, and a number that goes DOWN means somebody fixed one and the fix is
+not finished until the lower number is committed.
+
+Worth knowing when reading any figure quoted from this audit: for most of its
+life the gating test did not run at all. It imports the audit out of a
+`scripts/*.mjs` file that began with a shebang, which Vite hands to the ESM
+loader unstripped, so the suite failed to LOAD rather than to assert and
+contributed no assertions and no failure. Numbers from that period were produced
+by running the CLI by hand.
 
 The shape of what is left, as of the last sweep:
 
 | | |
 |---|---|
 | Registered handlers | ~1040 |
-| Classified as mutations | ~690 |
-| Emitting a rollback record | ~550 |
-| Emitting `rollbackPossible: false` with a reason instead | ~110 |
-| Emitting neither, and therefore actually outstanding | ~26 |
-| Missing an idempotency marker | ~19 |
+| Classified as mutations | ~685 |
+| Emitting a rollback record | ~555 |
+| Emitting `rollbackPossible: false` with a reason instead | ~127 |
+| Emitting neither, and therefore actually outstanding | 0 |
+| Giving no idempotency answer | 0 |
 
 Every authoring category has been swept. Level, Asset, Blueprint, Material, Animation, Audio, Gameplay, GAS, Niagara, PCG, Sequencer, Spline, Widget, Landscape and Networking all emit an inverse from their creates and their modifies, including the ones an older version of this page listed as outstanding: `add_node`, `connect_pins`, `set_class_default`, `add_material_expression`, `delete_material_expression`, `create_state_machine`, `add_state`, `add_transition`, `set_bone_keyframes`, `add_attribute`, `set_ability_tags`, `set_niagara_parameter`, `add_emitter_to_system`, `add_pcg_node`, `set_pcg_node_settings`, `set_spline_points`, `add_widget`, `remove_widget`, `move_widget` and `set_sequence_keyframes`.
 
-What is left is the tail the audit names by hand each run. `foliage(set_settings)` is the clearest of them: it emits no inverse, no reason and no idempotency marker, so a flow that tunes a foliage type cannot be rolled back and a retried call cannot tell you whether it changed anything. Run the audit for the current list rather than reading one from here.
+The last two rows are zero and are held there by flat assertions rather than by a
+ratchet, because there is no debt left to ratchet down. `foliage(set_settings)`
+was the clearest of the tail and is now the clearest of the fixes: it captures
+each property's previous exported value before writing, emits itself as its own
+inverse with those values, and reports `changedCount` against the exported form
+so `1` and `1.000000` do not read as a change.
+
+A caveat that has not changed: this audit is source-level. It proves a rollback
+is EMITTED, never that it is correct. Correctness is what the live tier is for.
+
+`mutationsWithoutRollback` stays a number rather than a rule and stays non-zero
+on purpose. Not every change has an inverse, and a codebase where that count
+reached zero would be one that had started emitting rollbacks that do not roll
+anything back.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ue-mcp",
-  "version": "1.3.1-beta.1",
+  "version": "1.3.1-beta.2",
   "description": "Unreal Engine MCP server - 24 tools, 1090+ actions for AI-driven editor control",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AnimationHandlers_IKRetargeterAuthoring.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AnimationHandlers_IKRetargeterAuthoring.cpp
@@ -655,6 +655,13 @@ TSharedPtr<FJsonValue> FAnimationHandlers::ConfigureIKRetargeter(const TSharedPt
 		PreparedPose = MoveTemp(Pose);
 	}
 
+	// Read before the transaction reassigns them. A rollback payload built after
+	// the write would carry the values this call just installed.
+	const UIKRigDefinition* PreviousSourceRig = Controller->GetIKRig(ERetargetSourceOrTarget::Source);
+	const UIKRigDefinition* PreviousTargetRig = Controller->GetIKRig(ERetargetSourceOrTarget::Target);
+	USkeletalMesh* PreviousSourcePreview = Controller->GetPreviewMesh(ERetargetSourceOrTarget::Source);
+	USkeletalMesh* PreviousTargetPreview = Controller->GetPreviewMesh(ERetargetSourceOrTarget::Target);
+
 	bool bMutationFailed = false;
 	FString MutationError;
 	bool bAddedDefaultOps = false;
@@ -946,6 +953,40 @@ TSharedPtr<FJsonValue> FAnimationHandlers::ConfigureIKRetargeter(const TSharedPt
 	{
 		const FPreparedRetargetPose& Pose = PreparedPose.GetValue();
 		Result->SetObjectField(TEXT("pose"), BuildPoseJson(Controller, Pose.Side, Pose.Name, Pose.bAutoAlignAll));
+	}
+
+	// Only the assignment half of this action is reversible: the rigs and preview
+	// meshes each had a previous asset that a replay of this same action can
+	// point back at. ensureDefaultOps is forced off in that replay so a pure
+	// assignment restore cannot install an op stack of its own.
+	const bool bAssignmentsOnly = !bAddedDefaultOps && !bHasAutoMap
+		&& PreparedMappings.IsEmpty() && !PreparedPose.IsSet();
+	const bool bAssignedAnything = bHasSourceRig || bHasTargetRig || bHasSourcePreview || bHasTargetPreview;
+	const bool bAssignmentsRestorable =
+		(!bHasSourceRig || PreviousSourceRig != nullptr)
+		&& (!bHasTargetRig || PreviousTargetRig != nullptr)
+		&& (!bHasSourcePreview || PreviousSourcePreview != nullptr)
+		&& (!bHasTargetPreview || PreviousTargetPreview != nullptr);
+	if (bAssignmentsOnly && bAssignedAnything && bAssignmentsRestorable)
+	{
+		auto Payload = MakeShared<FJsonObject>();
+		Payload->SetStringField(TEXT("retargeterPath"), Retargeter->GetPathName());
+		Payload->SetBoolField(TEXT("ensureDefaultOps"), false);
+		if (bHasSourceRig) Payload->SetStringField(TEXT("sourceRig"), PreviousSourceRig->GetPathName());
+		if (bHasTargetRig) Payload->SetStringField(TEXT("targetRig"), PreviousTargetRig->GetPathName());
+		if (bHasSourcePreview) Payload->SetStringField(TEXT("sourcePreviewMesh"), PreviousSourcePreview->GetPathName());
+		if (bHasTargetPreview) Payload->SetStringField(TEXT("targetPreviewMesh"), PreviousTargetPreview->GetPathName());
+		MCPSetRollback(Result, TEXT("configure_ik_retargeter"), Payload);
+	}
+	else
+	{
+		TArray<FString> Causes;
+		if (bAddedDefaultOps) Causes.Add(TEXT("a default retarget op stack was installed and no action removes a retarget op"));
+		if (bHasAutoMap || !PreparedMappings.IsEmpty()) Causes.Add(TEXT("chain mappings were rewritten over mappings this call did not capture"));
+		if (PreparedPose.IsSet()) Causes.Add(TEXT("a retarget pose was created, reset or realigned and no action deletes a pose"));
+		if (!bAssignmentsRestorable) Causes.Add(TEXT("a rig or preview mesh this call assigned had none before, and configure_ik_retargeter takes asset paths so it cannot clear one back to unset"));
+		if (Causes.IsEmpty()) Causes.Add(TEXT("this call assigned no rig or preview mesh, so there is no previous asset for a replay to point back at"));
+		MCPSetNoRollback(Result, FString::Join(Causes, TEXT("; ")) + TEXT("."));
 	}
 
 	auto Validation = MakeShared<FJsonObject>();

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AnimationHandlers_IKRigAuthoring.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AnimationHandlers_IKRigAuthoring.cpp
@@ -620,6 +620,11 @@ TSharedPtr<FJsonValue> FAnimationHandlers::ConfigureIKRig(const TSharedPtr<FJson
 	const int32 BeforeGoalCount = Controller->GetAllGoals().Num();
 	const int32 BeforeSolverCount = Controller->GetNumSolvers();
 	const TSet<FName> BeforeExcluded(Skeleton.ExcludedBones);
+	// Read before the transaction writes over them, because the rollback payload
+	// below has to carry the bones this rig used to name, not the ones it names
+	// after this call succeeds.
+	const FName BeforeRetargetRoot = Controller->GetRetargetRoot();
+	const FName BeforeRootMotionBone = Controller->GetRootMotionBone();
 	UPackage* Package = Rig->GetOutermost();
 	const bool bWasDirty = Package && Package->IsDirty();
 	bool bFailed = false;
@@ -892,6 +897,46 @@ TSharedPtr<FJsonValue> FAnimationHandlers::ConfigureIKRig(const TSharedPtr<FJson
 		Result->SetNumberField(TEXT("fullBodyIKSolverIndex"), SolverIndex);
 		Result->SetBoolField(TEXT("fullBodyIKSolverCreated"), Controller->GetNumSolvers() > BeforeSolverCount);
 	}
+	// Only the settings half of this action is reversible. retargetRoot,
+	// rootMotionBone and bone exclusions each had a previous value that a replay
+	// of this same action can write back. The rest of what it does is creation,
+	// and creation is what no registered action can take back.
+	const bool bSettingsOnly = !bAutoRetarget && Chains.IsEmpty() && !FullBody.bPresent
+		&& (RetargetRoot.IsSet() || RootMotionBone.IsSet() || !Exclusions.IsEmpty());
+	const bool bBonesRestorable =
+		(!RetargetRoot.IsSet() || !BeforeRetargetRoot.IsNone())
+		&& (!RootMotionBone.IsSet() || !BeforeRootMotionBone.IsNone());
+	if (bSettingsOnly && bBonesRestorable)
+	{
+		TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+		Payload->SetStringField(TEXT("rigPath"), Rig->GetPathName());
+		if (RetargetRoot.IsSet()) Payload->SetStringField(TEXT("retargetRoot"), BeforeRetargetRoot.ToString());
+		if (RootMotionBone.IsSet()) Payload->SetStringField(TEXT("rootMotionBone"), BeforeRootMotionBone.ToString());
+		if (!Exclusions.IsEmpty())
+		{
+			TArray<TSharedPtr<FJsonValue>> PreviousExclusions;
+			for (const FExclusionRequest& Request : Exclusions)
+			{
+				TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+				Entry->SetStringField(TEXT("bone"), Request.Bone.ToString());
+				Entry->SetBoolField(TEXT("excluded"), BeforeExcluded.Contains(Request.Bone));
+				PreviousExclusions.Add(MakeShared<FJsonValueObject>(Entry));
+			}
+			Payload->SetArrayField(TEXT("exclusions"), PreviousExclusions);
+		}
+		MCPSetRollback(Result, TEXT("configure_ik_rig"), Payload);
+	}
+	else
+	{
+		TArray<FString> Causes;
+		if (bAutoRetarget) Causes.Add(TEXT("autoSetup replaced the rig's retarget definition and no action restores the previous one"));
+		if (!Chains.IsEmpty()) Causes.Add(TEXT("retarget chains were upserted and no action removes a chain"));
+		if (FullBody.bPresent) Causes.Add(TEXT("IK goals and a Full Body IK solver were upserted and no action removes a goal or a solver"));
+		if (!bBonesRestorable) Causes.Add(TEXT("retargetRoot or rootMotionBone had no previous bone, and configure_ik_rig takes a bone name so it cannot clear one back to none"));
+		if (Causes.IsEmpty()) Causes.Add(TEXT("this call changed nothing whose previous value a replay could write back"));
+		MCPSetNoRollback(Result, FString::Join(Causes, TEXT("; ")) + TEXT("."));
+	}
+
 	TArray<TSharedPtr<FJsonValue>> WarningValues;
 	for (const FString& Warning : Warnings) WarningValues.Add(MakeShared<FJsonValueString>(Warning));
 	Result->SetArrayField(TEXT("warnings"), WarningValues);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AnimationHandlers_Validation.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AnimationHandlers_Validation.cpp
@@ -730,6 +730,34 @@ TSharedPtr<FJsonValue> FAnimationHandlers::AnalyzeAnimation(const TSharedPtr<FJs
 		Result->SetStringField(TEXT("outputDirectory"), OutputDirectory);
 		Result->SetStringField(TEXT("manifestPath"), ManifestPath);
 		Result->SetStringField(TEXT("samplesPath"), SamplesPath);
+
+		// The only effect this call has outside the response, and it happens
+		// only when the caller named a directory. The sequence, its skeleton
+		// and the preview mesh are read and never written: the pose evaluation
+		// runs against a stack-local FCompactPose.
+		//
+		// No inverse is named because deleting a report this same call
+		// regenerates on demand is not a meaningful undo, and the bridge has no
+		// delete-file action to name anyway. The files are safe to leave: the
+		// handler refuses to run when either already exists, so a replay cannot
+		// overwrite a report somebody is reading.
+		MCPSetNoRollback(Result, FString::Printf(TEXT(
+			"Wrote the analysis report '%s' and its samples file '%s', and changed no animation, skeleton or "
+			"asset state. An analysis report is an output artifact rather than project state, and this call "
+			"regenerates it on demand, so no inverse is named. Nothing in the bridge deletes a file outside "
+			"the content browser."), *ManifestPath, *SamplesPath));
+		MCPSetCreated(Result);
+	}
+	else
+	{
+		// The whole call is a read on this path: it opens the sequence, samples
+		// poses into a local buffer and reports. Said out loud because a caller
+		// reading a body with neither a rollback nor a note cannot tell that
+		// from a handler that forgot one.
+		MCPSetNoRollback(Result, TEXT(
+			"Read the sequence and reported on it. No file was written and no asset, skeleton or world state "
+			"changed, so there is nothing to undo."));
+		Result->SetBoolField(TEXT("unchanged"), true);
 	}
 	return MCPResult(Result);
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers.cpp
@@ -2566,6 +2566,15 @@ TSharedPtr<FJsonValue> FAssetHandlers::SaveAsset(const TSharedPtr<FJsonObject>& 
 		Result->SetStringField(TEXT("path"), AssetPath);
 		Result->SetBoolField(TEXT("force"), bForce);
 
+		// The dirty flag is the only honest answer to "did this call change
+		// anything", and it has to be read before the save, because afterwards
+		// every package is clean and a save that wrote nothing is
+		// indistinguishable from one that flushed an edit.
+		UObject* PreSaveAsset = MCPLoadAssetObject(AssetPath);
+		UPackage* PreSavePackage = PreSaveAsset ? PreSaveAsset->GetOutermost() : nullptr;
+		const bool bWasDirty = PreSavePackage && PreSavePackage->IsDirty();
+		Result->SetBoolField(TEXT("wasDirty"), bWasDirty);
+
 		bool bSuccess = false;
 		if (bForce)
 		{
@@ -2598,6 +2607,35 @@ TSharedPtr<FJsonValue> FAssetHandlers::SaveAsset(const TSharedPtr<FJsonObject>& 
 			}
 		}
 		Result->SetBoolField(TEXT("success"), bSuccess);
+
+		// A clean package had nothing to flush. Without force the save was a
+		// no-op and says so; with force the file was rewritten anyway, which is
+		// a write to disk even though no edit was pending, so it does not claim
+		// to have changed nothing.
+		if (bWasDirty)
+		{
+			MCPSetUpdated(Result);
+		}
+		else if (bForce && bSuccess)
+		{
+			MCPSetUpdated(Result);
+			Result->SetStringField(TEXT("note"),
+				TEXT("The package was not dirty. force=true rewrote the file on disk anyway; without it this call would have written nothing."));
+		}
+		else
+		{
+			Result->SetBoolField(TEXT("updated"), false);
+			Result->SetBoolField(TEXT("unchanged"), true);
+			if (bSuccess)
+			{
+				// Only when the save itself reported success. A failed save
+				// wrote nothing either, and telling that caller the package was
+				// simply clean would hide the failure behind a no-op.
+				Result->SetStringField(TEXT("note"),
+					TEXT("The package was not dirty, so nothing was written. Pass force=true to write it regardless."));
+			}
+		}
+
 		Result->SetBoolField(TEXT("rollbackPossible"), false);
 		Result->SetStringField(TEXT("rollbackNote"),
 			TEXT("A save overwrites the file on disk with what is in memory. The previous file contents are gone and the ")
@@ -2613,10 +2651,36 @@ TSharedPtr<FJsonValue> FAssetHandlers::SaveAsset(const TSharedPtr<FJsonObject>& 
 		{
 			return MCPError(TEXT("'force' requires an assetPath - it forces one package to disk. To flush everything, use asset(save_all_dirty), which reports exactly which packages were written."));
 		}
+		// Counted before the sweep for the same reason as the single-asset
+		// branch: SaveDirectory is dirty-only, so with nothing dirty it writes
+		// nothing, and afterwards there is no way to tell that from a sweep
+		// that flushed a hundred packages.
+		TArray<UPackage*> DirtyBefore;
+		FEditorFileUtils::GetDirtyContentPackages(DirtyBefore);
+		FEditorFileUtils::GetDirtyWorldPackages(DirtyBefore);
+		int32 DirtyUnderGame = 0;
+		for (UPackage* Package : DirtyBefore)
+		{
+			if (Package && Package->IsDirty() && Package->GetName().StartsWith(TEXT("/Game/")))
+			{
+				++DirtyUnderGame;
+			}
+		}
+
 		UEditorAssetLibrary::SaveDirectory(TEXT("/Game"));
 		auto Result = MCPSuccess();
 		Result->SetBoolField(TEXT("success"), true);
 		Result->SetStringField(TEXT("message"), TEXT("All modified assets under /Game saved (dirty only). Use save_all_dirty for a per-package report."));
+		Result->SetNumberField(TEXT("dirtyPackagesBefore"), DirtyUnderGame);
+		if (DirtyUnderGame > 0)
+		{
+			MCPSetUpdated(Result);
+		}
+		else
+		{
+			Result->SetBoolField(TEXT("updated"), false);
+			Result->SetBoolField(TEXT("unchanged"), true);
+		}
 		Result->SetBoolField(TEXT("rollbackPossible"), false);
 		Result->SetStringField(TEXT("rollbackNote"),
 			TEXT("A save overwrites the files on disk with what is in memory. The previous file contents are gone and the ")

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_Redirectors.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_Redirectors.cpp
@@ -474,5 +474,16 @@ TSharedPtr<FJsonValue> FAssetHandlers::FixupRedirectors(const TSharedPtr<FJsonOb
 	Result->SetNumberField(TEXT("deletedRedirectorCount"), ConfirmedDeleted);
 	Result->SetArrayField(TEXT("redirectors"), RedirectorStatuses);
 	MCPSetUpdated(Result);
+	// Two irreversible writes, neither of which the bridge can undo. The
+	// referencer packages were saved over their previous bytes, and no copy of
+	// those was kept; the redirector packages were deleted from disk once
+	// nothing pointed at them. Restoring the old state needs a call that
+	// recreates an ObjectRedirector at a vacated path and a call that rewinds a
+	// package to its pre-save contents, and neither exists.
+	MCPSetNoRollback(Result, FString::Printf(
+		TEXT("Rewrote and saved %d referencer package(s) over their previous contents and deleted %d redirector ")
+		TEXT("package(s). Undoing this needs an action that recreates an ObjectRedirector at an old path and one that ")
+		TEXT("restores a package's pre-save bytes; neither exists, and no copy of the overwritten packages was kept."),
+		SavedCount, ConfirmedDeleted));
 	return MCPResult(Result);
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_Sockets.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_Sockets.cpp
@@ -318,6 +318,13 @@ TSharedPtr<FJsonValue> FAssetHandlers::RemoveSocket(const TSharedPtr<FJsonObject
 		{
 			if (SM->Sockets[i] && SM->Sockets[i]->SocketName == FName(*SocketName))
 			{
+				// Read before the removal. After RemoveAt the array no longer
+				// holds the socket, and a transform captured then would put
+				// back a socket at the origin rather than where this one was.
+				const FVector PrevLoc = SM->Sockets[i]->RelativeLocation;
+				const FRotator PrevRot = SM->Sockets[i]->RelativeRotation;
+				const FVector PrevScale = SM->Sockets[i]->RelativeScale;
+
 				SM->Modify();
 				SM->Sockets.RemoveAt(i);
 				SM->MarkPackageDirty();
@@ -327,6 +334,18 @@ TSharedPtr<FJsonValue> FAssetHandlers::RemoveSocket(const TSharedPtr<FJsonObject
 				Result->SetStringField(TEXT("meshType"), TEXT("StaticMesh"));
 				Result->SetStringField(TEXT("source"), TEXT("mesh"));
 				Result->SetBoolField(TEXT("deleted"), true);
+
+				// add_socket recreates it with the transform it had.
+				// onConflict=update so the restore lands whether or not a
+				// socket of that name exists again by the time it runs.
+				TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+				Payload->SetStringField(TEXT("assetPath"), AssetPath);
+				Payload->SetStringField(TEXT("socketName"), SocketName);
+				Payload->SetObjectField(TEXT("relativeLocation"), MCPVec3ToJsonObject(PrevLoc));
+				Payload->SetObjectField(TEXT("relativeRotation"), MCPRotatorToJsonObject(PrevRot));
+				Payload->SetObjectField(TEXT("relativeScale"), MCPVec3ToJsonObject(PrevScale));
+				Payload->SetStringField(TEXT("onConflict"), TEXT("update"));
+				MCPSetRollback(Result, TEXT("add_socket"), Payload);
 				return MCPResult(Result);
 			}
 		}
@@ -346,6 +365,14 @@ TSharedPtr<FJsonValue> FAssetHandlers::RemoveSocket(const TSharedPtr<FJsonObject
 		{
 			if (Sockets[i] && Sockets[i]->SocketName == FName(*SocketName))
 			{
+				// Captured before the removal, and the bone with it: a socket
+				// restored onto the wrong bone is attached to the wrong part of
+				// the skeleton however right its transform is.
+				const FVector PrevLoc = Sockets[i]->RelativeLocation;
+				const FRotator PrevRot = Sockets[i]->RelativeRotation;
+				const FVector PrevScale = Sockets[i]->RelativeScale;
+				const FString PrevBone = Sockets[i]->BoneName.ToString();
+
 				SKM->Modify();
 				Sockets[i]->Modify();
 				Sockets.RemoveAt(i);
@@ -357,6 +384,16 @@ TSharedPtr<FJsonValue> FAssetHandlers::RemoveSocket(const TSharedPtr<FJsonObject
 				Result->SetStringField(TEXT("meshType"), TEXT("SkeletalMesh"));
 				Result->SetStringField(TEXT("source"), TEXT("mesh"));
 				Result->SetBoolField(TEXT("deleted"), true);
+
+				TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+				Payload->SetStringField(TEXT("assetPath"), AssetPath);
+				Payload->SetStringField(TEXT("socketName"), SocketName);
+				Payload->SetStringField(TEXT("boneName"), PrevBone);
+				Payload->SetObjectField(TEXT("relativeLocation"), MCPVec3ToJsonObject(PrevLoc));
+				Payload->SetObjectField(TEXT("relativeRotation"), MCPRotatorToJsonObject(PrevRot));
+				Payload->SetObjectField(TEXT("relativeScale"), MCPVec3ToJsonObject(PrevScale));
+				Payload->SetStringField(TEXT("onConflict"), TEXT("update"));
+				MCPSetRollback(Result, TEXT("add_socket"), Payload);
 				return MCPResult(Result);
 			}
 		}
@@ -375,6 +412,11 @@ TSharedPtr<FJsonValue> FAssetHandlers::RemoveSocket(const TSharedPtr<FJsonObject
 		{
 			if (Skel->Sockets[i] && Skel->Sockets[i]->SocketName == FName(*SocketName))
 			{
+				const FVector PrevLoc = Skel->Sockets[i]->RelativeLocation;
+				const FRotator PrevRot = Skel->Sockets[i]->RelativeRotation;
+				const FVector PrevScale = Skel->Sockets[i]->RelativeScale;
+				const FString PrevBone = Skel->Sockets[i]->BoneName.ToString();
+
 				Skel->Modify();
 				Skel->Sockets[i]->Modify();
 				Skel->Sockets.RemoveAt(i);
@@ -385,6 +427,19 @@ TSharedPtr<FJsonValue> FAssetHandlers::RemoveSocket(const TSharedPtr<FJsonObject
 				Result->SetStringField(TEXT("meshType"), TEXT("Skeleton"));
 				Result->SetStringField(TEXT("source"), TEXT("skeleton"));
 				Result->SetBoolField(TEXT("deleted"), true);
+
+				// The same assetPath routes add_socket back to the Skeleton's
+				// own socket array, so the rig-level socket is restored where it
+				// lived rather than on a mesh.
+				TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+				Payload->SetStringField(TEXT("assetPath"), AssetPath);
+				Payload->SetStringField(TEXT("socketName"), SocketName);
+				Payload->SetStringField(TEXT("boneName"), PrevBone);
+				Payload->SetObjectField(TEXT("relativeLocation"), MCPVec3ToJsonObject(PrevLoc));
+				Payload->SetObjectField(TEXT("relativeRotation"), MCPRotatorToJsonObject(PrevRot));
+				Payload->SetObjectField(TEXT("relativeScale"), MCPVec3ToJsonObject(PrevScale));
+				Payload->SetStringField(TEXT("onConflict"), TEXT("update"));
+				MCPSetRollback(Result, TEXT("add_socket"), Payload);
 				return MCPResult(Result);
 			}
 		}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_Subobject.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_Subobject.cpp
@@ -268,6 +268,18 @@ TSharedPtr<FJsonValue> FAssetHandlers::CreateSubobject(const TSharedPtr<FJsonObj
 	OwnerAsset->PostEditChange();
 	OwnerPackage->MarkPackageDirty();
 
+	// The new object lives inside a package that existed before this call, and
+	// nothing in this surface takes one back out: delete_asset would destroy
+	// the owning asset along with everything else in it, which is a larger loss
+	// than the thing being undone. Undoing this needs a remove_subobject that
+	// does not exist, so the property values overwritten on a reused subobject
+	// are not recoverable through the bridge either.
+	MCPSetNoRollback(Result, FString::Printf(
+		TEXT("Created or reconfigured the subobject '%s' inside the existing package '%s'. No action removes a named ")
+		TEXT("subobject from a package or restores its previous property values; delete_asset would destroy the whole ")
+		TEXT("owning asset rather than undo this."),
+		*Name, *OwnerPackage->GetName()));
+
 	// Saving in the same call is what closes the garbage-collection window the
 	// issue is about: after this the subobject is an export on disk, so a later
 	// call resolves it by path even if the in-memory copy is collected.

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_UV.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_UV.cpp
@@ -2743,6 +2743,10 @@ TSharedPtr<FJsonValue> FAssetHandlers::ExportUvLayout(const TSharedPtr<FJsonObje
 			TEXT("The %dx%d UV layout for '%s' could not be PNG-encoded."), Size, Size, *Target.AssetPath));
 	}
 	const TArray64<uint8> PngData = PngWrapper->GetCompressed(100);
+	// Asked before the write, because afterwards every export looks like a
+	// first one. A caller rerunning this over a directory it is collecting
+	// pictures in wants to know which of them it just replaced.
+	const bool bOverwroteExistingFile = FPaths::FileExists(OutputPath);
 	if (!FFileHelper::SaveArrayToFile(PngData, *OutputPath))
 	{
 		return MCPError(FString::Printf(
@@ -2764,6 +2768,33 @@ TSharedPtr<FJsonValue> FAssetHandlers::ExportUvLayout(const TSharedPtr<FJsonObje
 		TEXT("White wire = UV triangle edges. Yellow border = the unit square. Grey grid = quarters. Coloured fill ")
 			TEXT("= one hue per UV island. Red fill = two or more triangles on the same texel, which is what breaks ")
 			TEXT("a lightmap bake."));
+
+	// The render always runs and the file is always written, so the honest
+	// answer to "did this change anything" is whether a picture was already
+	// sitting at that path.
+	if (bOverwroteExistingFile)
+	{
+		MCPSetExisted(Result);
+		MCPSetUpdated(Result);
+	}
+	else
+	{
+		MCPSetCreated(Result);
+	}
+
+	// The mesh is untouched: this writes a preview PNG under Saved/ and nothing
+	// else. An export produces an output artifact rather than project state,
+	// and deleting a picture that regenerates on demand from the same call is
+	// not a meaningful undo, so no inverse is named. The six export_* actions
+	// that predate this one emit no rollback for the same reason.
+	const FString OverwriteNote = bOverwroteExistingFile
+		? FString(TEXT(" The picture that was already at that path is gone and no copy was kept."))
+		: FString();
+	MCPSetNoRollback(Result, FString::Printf(
+		TEXT("Wrote the preview PNG '%s' and changed no project state. An export produces an output artifact, and ")
+		TEXT("deleting a file that this same call regenerates on demand is not a meaningful undo, so no inverse is ")
+		TEXT("named.%s"),
+		*OutputPath, *OverwriteNote));
 	return MCPResult(Result);
 }
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AudioHandlers_Depth.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AudioHandlers_Depth.cpp
@@ -65,10 +65,14 @@
 #include "EdGraph/EdGraphNode.h"
 
 #include "MetasoundBuilderBase.h"
+// MetasoundDocumentBuilderRegistry.h, and never MetasoundFrontendDocumentBuilderRegistry.h:
+// the frontend header ships on 5.8 only. This MetasoundEngine header reaches
+// Metasound::Frontend::IDocumentBuilderRegistry on every supported engine, by
+// including the frontend header on 5.8 and MetasoundDocumentInterface.h, where
+// 5.7 and earlier declare the class, on all of them.
 #include "MetasoundDocumentBuilderRegistry.h"
 #include "MetasoundDocumentInterface.h"
 #include "MetasoundFrontendDocument.h"
-#include "MetasoundFrontendDocumentBuilderRegistry.h"
 #include "MetasoundFrontendLiteral.h"
 #include "MetasoundSource.h"
 
@@ -240,9 +244,18 @@ namespace
 	const FMetasoundFrontendDocument* MSEditDocument(const FMSEditTarget& T)
 	{
 		if (!T.Builder) return nullptr;
-		TScriptInterface<IMetaSoundDocumentInterface> Doc = T.Builder->GetMetaSound();
-		const IMetaSoundDocumentInterface* Iface = Doc.GetInterface();
-		return Iface ? &Iface->GetConstDocument() : nullptr;
+		// Through the builder's own document rather than through the MetaSound
+		// object it is editing. UMetaSoundBuilderBase::GetMetaSound arrived in
+		// 5.8, and the two accessors that would stand in for it on 5.7 are
+		// private in both engines, but GetConstDocumentChecked has been public
+		// on FMetaSoundFrontendDocumentBuilder throughout and is what the
+		// GetMetaSound round trip was reaching for anyway.
+		//
+		// IsValid first, because the Checked form asserts on a builder with no
+		// document while the round trip it replaces returned null for it.
+		const FMetaSoundFrontendDocumentBuilder& Builder = T.Builder->GetConstBuilder();
+		if (!Builder.IsValid()) return nullptr;
+		return &Builder.GetConstDocumentChecked();
 	}
 
 	/**

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AudioHandlers_MetaSound.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AudioHandlers_MetaSound.cpp
@@ -45,9 +45,13 @@
 
 #include "MetasoundBuilderSubsystem.h"
 #include "MetasoundBuilderBase.h"
+// MetasoundDocumentBuilderRegistry.h, and never MetasoundFrontendDocumentBuilderRegistry.h:
+// the frontend header ships on 5.8 only. This MetasoundEngine header reaches
+// Metasound::Frontend::IDocumentBuilderRegistry on every supported engine, by
+// including the frontend header on 5.8 and MetasoundDocumentInterface.h, where
+// 5.7 and earlier declare the class, on all of them.
 #include "MetasoundDocumentBuilderRegistry.h"
 #include "MetasoundDocumentInterface.h"
-#include "MetasoundFrontendDocumentBuilderRegistry.h"
 #include "MetasoundSource.h"
 #include "MetasoundFrontendLiteral.h"
 #include "MetasoundFrontendDocument.h"

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AudioHandlers_MetaSoundRead.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AudioHandlers_MetaSoundRead.cpp
@@ -39,9 +39,14 @@
 
 #include "MetasoundBuilderSubsystem.h"
 #include "MetasoundBuilderBase.h"
+// MetasoundDocumentBuilderRegistry.h, and never MetasoundFrontendDocumentBuilderRegistry.h:
+// the frontend header ships on 5.8 only. This MetasoundEngine header reaches
+// Metasound::Frontend::IDocumentBuilderRegistry on every supported engine, by
+// including the frontend header on 5.8 and MetasoundDocumentInterface.h, where
+// 5.7 and earlier declare the class, on all of them.
+#include "MetasoundDocumentBuilderRegistry.h"
 #include "MetasoundDocumentInterface.h"
 #include "MetasoundFrontendDocument.h"
-#include "MetasoundFrontendDocumentBuilderRegistry.h"
 #include "MetasoundFrontendLiteral.h"
 #include "MetasoundSource.h"
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/BlueprintHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/BlueprintHandlers.cpp
@@ -1697,10 +1697,18 @@ TSharedPtr<FJsonValue> FBlueprintHandlers::CompileBlueprint(const TSharedPtr<FJs
 	// and it is not a claim that this call did no work.
 	Result->SetBoolField(TEXT("wasUpToDate"), bWasUpToDate);
 	Result->SetBoolField(TEXT("idempotent"), false);
+	// The two questions a caller has are different and both get an answer.
+	// `idempotent` is about the work: a compile always rebuilds the generated
+	// class and reinstances its objects, so calling twice does real work twice.
+	// `changed` is about the outcome: a Blueprint that came in up to date and
+	// compiled clean ends where it started, so a retry after a timeout learns
+	// that its second call moved nothing even though it was not free.
+	Result->SetBoolField(TEXT("changed"), !bWasUpToDate || !bCompiled);
 	Result->SetStringField(TEXT("idempotencyNote"),
 		TEXT("A compile always rebuilds the generated class and reinstances its objects, so calling twice does real "
 		     "work twice and there is no 'already compiled' short circuit to report. wasUpToDate says what the "
-		     "Blueprint's status was before this ran, not that this call changed nothing."));
+		     "Blueprint's status was before this ran, and changed says whether that status moved; neither claims the "
+		     "call itself was free."));
 
 	// A compile has no inverse. It rebuilds the generated class from the graphs
 	// that are already saved; there is no call that un-compiles a Blueprint, and
@@ -3503,6 +3511,29 @@ TSharedPtr<FJsonValue> FBlueprintHandlers::RunConstructionScript(const TSharedPt
 	Result->SetStringField(TEXT("className"), SpawnClass->GetName());
 	Result->SetArrayField(TEXT("components"), ComponentsArr);
 	Result->SetNumberField(TEXT("componentCount"), ComponentsArr.Num());
+
+	// Nothing to undo, and the reason is worth stating rather than leaving as
+	// an absent field. This spawns one RF_Transient actor, reads the component
+	// list its construction script produced, and destroys it above before
+	// building this result. The blueprint is not touched, nothing is saved, and
+	// the probe actor does not outlive the call.
+	//
+	// It stays classified as a MUTATION even so, because the construction
+	// script is the user's own graph and it runs. A graph that spawns child
+	// actors, writes to a referenced asset or drives an editor subsystem has
+	// done that by the time this returns, and none of it is visible from here.
+	// So the routing gate keeps asking for an explicit editor, on the grounds
+	// that arbitrary user code should not run in whichever project happens to
+	// be active, and this note says the probe itself left nothing behind.
+	MCPSetNoRollback(Result, TEXT(
+		"Spawned a transient actor from the generated class, read the components its construction script "
+		"built, and destroyed it before returning. The blueprint was not modified and nothing was saved, "
+		"so there is nothing to undo. Whatever the construction script itself did while it ran is not "
+		"observable from here and is not covered by this statement."));
+	MCPSetIdempotencyUnobservable(Result, TEXT(
+		"Every call spawns a fresh probe actor and runs the construction script again, so the work is "
+		"repeated rather than skipped. Whether that run changed anything outside the probe is decided by "
+		"the user's own graph and is not reported back to this handler."));
 
 	return MCPResult(Result);
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/BlueprintHandlers_Graph.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/BlueprintHandlers_Graph.cpp
@@ -2313,6 +2313,10 @@ TSharedPtr<FJsonValue> FBlueprintHandlers::CompileBlueprints(const TSharedPtr<FJ
 
 	TArray<TSharedPtr<FJsonValue>> Results;
 	int32 Compiled = 0, Failed = 0, NotFound = 0, AlreadyUpToDate = 0;
+	// Blueprints whose compiled status actually moved: one that came in stale,
+	// or one that came out in error. A batch where every entry was already up
+	// to date and compiled clean ends where it started.
+	int32 StatusChanged = 0;
 	for (const TSharedPtr<FJsonValue>& Entry : *PathsArray)
 	{
 		FString AssetPath = Entry->AsString();
@@ -2341,6 +2345,10 @@ TSharedPtr<FJsonValue> FBlueprintHandlers::CompileBlueprints(const TSharedPtr<FJ
 		FCompilerResultsLog CompileLog;
 		FKismetEditorUtilities::CompileBlueprint(Blueprint, EBlueprintCompileOptions::None, &CompileLog);
 
+		const bool bItemChanged = !bWasUpToDate || CompileLog.NumErrors > 0;
+		Item->SetBoolField(TEXT("changed"), bItemChanged);
+		if (bItemChanged) StatusChanged++;
+
 		if (CompileLog.NumErrors > 0)
 		{
 			Item->SetStringField(TEXT("status"), TEXT("failed"));
@@ -2364,17 +2372,20 @@ TSharedPtr<FJsonValue> FBlueprintHandlers::CompileBlueprints(const TSharedPtr<FJ
 	Result->SetNumberField(TEXT("failed"), Failed);
 	Result->SetNumberField(TEXT("notFound"), NotFound);
 	Result->SetNumberField(TEXT("alreadyUpToDate"), AlreadyUpToDate);
+	Result->SetNumberField(TEXT("statusChanged"), StatusChanged);
 	Result->SetArrayField(TEXT("results"), Results);
 
-	// No no-op flag here either: CompileBlueprint rebuilds and reinstances on
-	// every call regardless of status, so a batch where every Blueprint was
-	// already up to date still did the full work. alreadyUpToDate reports what
-	// the statuses were on the way in, nothing more.
+	// The work and the outcome are separate answers. CompileBlueprint rebuilds
+	// and reinstances on every call regardless of status, so a batch where
+	// every Blueprint was already up to date still did the full work, which is
+	// what idempotent=false says. `changed` is the outcome: false when no
+	// Blueprint's compiled status moved, which is what a retried batch needs.
 	Result->SetBoolField(TEXT("idempotent"), false);
+	Result->SetBoolField(TEXT("changed"), StatusChanged > 0);
 	Result->SetStringField(TEXT("idempotencyNote"),
 		TEXT("A compile always rebuilds each generated class and reinstances its objects, so calling twice does "
-		     "real work twice. alreadyUpToDate counts the Blueprints whose status said up to date BEFORE this ran; "
-		     "it is not a count of calls that did nothing."));
+		     "real work twice. alreadyUpToDate counts the Blueprints whose status said up to date BEFORE this ran, "
+		     "and statusChanged counts the ones whose status actually moved; neither claims the call was free."));
 
 	// Same as the single-Blueprint compile: a compile rebuilds the generated
 	// class from graphs that were already saved, and nothing un-compiles one.

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/ChooserHandlers_Nested.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/ChooserHandlers_Nested.cpp
@@ -533,5 +533,19 @@ TSharedPtr<FJsonValue> FChooserHandlers::RemapObjectReferences(const TSharedPtr<
 	Result->SetStringField(TEXT("note"), bDryRun
 		? TEXT("Dry run - nothing was written. Re-run with dryRun=false to apply.")
 		: TEXT("References rewritten and the chooser recompiled. The asset is left dirty; save it when ready."));
+	// The swapped pair is not the inverse of this call. Both modes match by
+	// pattern rather than by location, so replaying with from and to exchanged
+	// would also sweep up every reference that already pointed at the new
+	// target before this ran: the rewrite is many-to-one and the reverse cannot
+	// tell the two populations apart. Each entry in 'changes' carries the path
+	// it replaced, but nothing in this surface writes one specific reference
+	// back at its own location, which is what an inverse would need.
+	MCPSetNoRollback(Result, (bDryRun || Rewritten == 0)
+		? TEXT("Nothing was written, so there is nothing to undo.")
+		: TEXT("Every matching reference across the nested chooser tree now points at the new target, and the paths "
+			   "they replaced are reported per entry in 'changes'. Re-running with the pair swapped is not an "
+			   "inverse: it would also drag back references that already pointed at the new target, and no bridge "
+			   "call writes one reference back at its own location. The edit is inside an editor transaction, so "
+			   "undo in the editor is the only way back."));
 	return MCPResult(Result);
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DialogHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DialogHandlers.cpp
@@ -504,20 +504,71 @@ TSharedPtr<FJsonValue> FDialogHandlers::ClearDialogPolicy(const TSharedPtr<FJson
 	auto Result = MCPSuccess();
 
 	FString Pattern = OptionalString(Params, TEXT("pattern"));
+
+	// Copied BEFORE the removal. Re-arming a policy needs the response and the
+	// button label it was armed with, and both are gone the moment it leaves
+	// the list, so a rollback captured afterwards would re-arm the pattern with
+	// a different answer than the one that was cleared.
+	TArray<FDialogPolicy> Cleared;
 	if (!Pattern.IsEmpty())
 	{
-		int32 Removed = Policies.RemoveAll([&Pattern](const FDialogPolicy& P) { return P.Pattern == Pattern; });
+		for (const FDialogPolicy& P : Policies)
+		{
+			if (P.Pattern == Pattern) Cleared.Add(P);
+		}
+		Policies.RemoveAll([&Pattern](const FDialogPolicy& P) { return P.Pattern == Pattern; });
 		Result->SetStringField(TEXT("pattern"), Pattern);
-		Result->SetNumberField(TEXT("removed"), Removed);
 	}
 	else
 	{
-		int32 Count = Policies.Num();
+		Cleared = Policies;
 		Policies.Empty();
-		Result->SetNumberField(TEXT("removed"), Count);
 	}
 
+	Result->SetNumberField(TEXT("removed"), Cleared.Num());
 	Result->SetNumberField(TEXT("policyCount"), Policies.Num());
+
+	// Clearing a pattern nothing was armed for is a no-op, and saying so is the
+	// difference between "your policy is gone" and "there was never one".
+	Result->SetBoolField(TEXT("unchanged"), Cleared.Num() == 0);
+
+	// Every policy that was actually removed, in the form set_dialog_policy
+	// takes back. A caller that cleared several can re-arm them from this
+	// without having read get_dialog_policy first.
+	TArray<TSharedPtr<FJsonValue>> ClearedJson;
+	for (const FDialogPolicy& P : Cleared)
+	{
+		TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+		Entry->SetStringField(TEXT("pattern"), P.Pattern);
+		Entry->SetStringField(TEXT("response"), ResponseTypeToString(P.Response));
+		Entry->SetStringField(TEXT("buttonLabel"), P.ButtonLabel);
+		ClearedJson.Add(MakeShared<FJsonValueObject>(Entry));
+	}
+	Result->SetArrayField(TEXT("cleared"), ClearedJson);
+
+	if (Cleared.Num() == 1)
+	{
+		// A cleared policy has a real inverse: arm it again exactly as it was.
+		TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+		Payload->SetStringField(TEXT("pattern"), Cleared[0].Pattern);
+		Payload->SetStringField(TEXT("response"), ResponseTypeToString(Cleared[0].Response));
+		Payload->SetStringField(TEXT("buttonLabel"), Cleared[0].ButtonLabel);
+		MCPSetRollback(Result, TEXT("set_dialog_policy"), Payload);
+	}
+	else if (Cleared.Num() == 0)
+	{
+		MCPSetNoRollback(Result,
+			TEXT("Nothing was armed for that pattern, so no policy was removed and there is nothing to put back. "
+			     "set_dialog_policy is what arms one."));
+	}
+	else
+	{
+		MCPSetNoRollback(Result, FString::Printf(
+			TEXT("%d policies were cleared, and a rollback record carries one call. set_dialog_policy arms a single "
+			     "pattern, so putting these back takes one call per entry in 'cleared', which lists each pattern with "
+			     "the response and buttonLabel it was armed with."),
+			Cleared.Num()));
+	}
 
 	return MCPResult(Result);
 }
@@ -753,7 +804,17 @@ TSharedPtr<FJsonValue> FDialogHandlers::RespondToDialog(const TSharedPtr<FJsonOb
 	TSharedPtr<SWindow> ActiveModal = CollectActiveModal(Title, Message, Buttons);
 	if (!ActiveModal.IsValid())
 	{
-		return MCPError(TEXT("No active modal dialog"));
+		// Still a failure: nothing was pressed on this call, and a caller
+		// waiting on a particular button must not read this as done. But a
+		// retry after a timeout whose click actually landed arrives here too,
+		// so the reason is named rather than left to be inferred from a
+		// sentence. alreadyClosed separates "the dialog is gone" from "you
+		// aimed at an editor that never had one".
+		TSharedPtr<FJsonObject> Gone = MakeShared<FJsonObject>();
+		Gone->SetBoolField(TEXT("success"), false);
+		Gone->SetStringField(TEXT("error"), TEXT("No active modal dialog"));
+		Gone->SetBoolField(TEXT("alreadyClosed"), true);
+		return MCPResult(Gone);
 	}
 
 	// Determine action: buttonIndex, buttonLabel, or key simulation
@@ -795,6 +856,17 @@ TSharedPtr<FJsonValue> FDialogHandlers::RespondToDialog(const TSharedPtr<FJsonOb
 
 		Result->SetStringField(TEXT("clickedButton"), Buttons[TargetIndex].Label);
 		Result->SetNumberField(TEXT("buttonIndex"), TargetIndex);
+		Result->SetBoolField(TEXT("alreadyClosed"), false);
+
+		// A pressed button cannot be un-pressed. The dialog's own handler ran
+		// on the press and whatever it did - saving packages, discarding them,
+		// aborting an import - belongs to the editor code behind the button,
+		// not to this call, which never saw it.
+		MCPSetNoRollback(Result, FString::Printf(
+			TEXT("Pressed '%s' on the dialog '%s'. The editor code behind that button has already run and this call "
+			     "captured none of what it did, so there is nothing to restore. No action re-raises a dismissed modal "
+			     "or reverses the answer given to it."),
+			*Buttons[TargetIndex].Label, *Title));
 	}
 	else
 	{
@@ -809,6 +881,16 @@ TSharedPtr<FJsonValue> FDialogHandlers::RespondToDialog(const TSharedPtr<FJsonOb
 			FSlateApplication::Get().ProcessKeyUpEvent(FKeyEvent(EKeys::Escape, FModifierKeysState(), 0, false, 0, 0));
 			ActiveModal->RequestDestroyWindow();
 			Result->SetStringField(TEXT("action"), TEXT("closed window"));
+			Result->SetBoolField(TEXT("alreadyClosed"), false);
+
+			// Destroying the window ends the modal loop without answering the
+			// question, so the editor carries on down whatever path it takes
+			// for an unanswered prompt.
+			MCPSetNoRollback(Result, FString::Printf(
+				TEXT("Destroyed the dialog window '%s' without pressing any of its buttons. The editor has already "
+				     "resumed on its unanswered-prompt path and no action re-raises a destroyed modal, so the "
+				     "question cannot be put back to be answered differently."),
+				*Title));
 		}
 		else
 		{

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EditorHandlers_Build.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EditorHandlers_Build.cpp
@@ -355,7 +355,16 @@ TSharedPtr<FJsonValue> FEditorHandlers::ValidateAssets(const TSharedPtr<FJsonObj
 		DetailsArray.Add(MakeShared<FJsonValueObject>(DetailObject));
 	}
 	Result->SetArrayField(TEXT("assets"), DetailsArray);
+#if UE_MCP_HAS_5_8_API
 	Result->SetArrayField(TEXT("validatorMessages"), MCPValidationMessageArray(ValidationResults.ValidatorMessages));
+#else
+	// FValidateAssetsResults::ValidatorMessages arrived in 5.8. Earlier engines
+	// keep no bucket for a message a validator raised outside any one asset, so
+	// the field is omitted rather than sent as an empty array, which would read
+	// as "every validator ran and none had anything to say".
+	Result->SetStringField(TEXT("validatorMessagesNote"),
+		TEXT("validatorMessages omitted: cross-asset validator messages need UE 5.8, and this editor is older. Per-asset messages are still reported under assets[].messages."));
+#endif
 	Result->SetStringField(TEXT("message"), FString::Printf(TEXT("Validated %d assets"), ValidationResults.NumRequested));
 	return MCPResult(Result);
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EditorHandlers_RuntimeVisibility.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EditorHandlers_RuntimeVisibility.cpp
@@ -724,6 +724,10 @@ TSharedPtr<FJsonValue> FEditorHandlers::RestoreRuntimeVisibility(const TSharedPt
 	}
 
 	int32 Changed = 0;
+	// A restore writes state, so its own inverse is the state it is about to
+	// overwrite. Captured target by target as the writes happen, because after
+	// the loop the previous values are the ones that were just discarded.
+	TArray<FMCPRuntimeVisibilityRestoreTarget> UndoTargets;
 	for (const FMCPRuntimeVisibilityRestoreTarget& Target : Snapshot->Targets)
 	{
 		if (USceneComponent* Component = Target.Component.Get())
@@ -732,6 +736,10 @@ TSharedPtr<FJsonValue> FEditorHandlers::RestoreRuntimeVisibility(const TSharedPt
 				(Component->bHiddenInGame != 0) != Target.bComponentHidden)
 			{
 				++Changed;
+				FMCPRuntimeVisibilityRestoreTarget& Undo = UndoTargets.AddDefaulted_GetRef();
+				Undo.Component = Component;
+				Undo.bVisible = Component->GetVisibleFlag();
+				Undo.bComponentHidden = Component->bHiddenInGame != 0;
 				Component->SetVisibility(Target.bVisible, false);
 				Component->SetHiddenInGame(Target.bComponentHidden, false);
 			}
@@ -739,19 +747,50 @@ TSharedPtr<FJsonValue> FEditorHandlers::RestoreRuntimeVisibility(const TSharedPt
 		else if (AActor* Actor = Target.Actor.Get(); Actor && Actor->IsHidden() != Target.bActorHidden)
 		{
 			++Changed;
+			FMCPRuntimeVisibilityRestoreTarget& Undo = UndoTargets.AddDefaulted_GetRef();
+			Undo.Actor = Actor;
+			Undo.bActorHidden = Actor->IsHidden();
 			Actor->SetActorHiddenInGame(Target.bActorHidden);
 		}
 	}
 
+	const int32 SnapshotTargetCount = Snapshot->Targets.Num();
+
 	auto Result = MCPSuccess();
 	Result->SetBoolField(TEXT("restored"), true);
 	Result->SetStringField(TEXT("rollbackToken"), RollbackToken);
-	Result->SetNumberField(TEXT("targetCount"), Snapshot->Targets.Num());
+	Result->SetNumberField(TEXT("targetCount"), SnapshotTargetCount);
 	Result->SetNumberField(TEXT("changed"), Changed);
-	Result->SetNumberField(TEXT("alreadyRestored"), Snapshot->Targets.Num() - Changed);
+	Result->SetNumberField(TEXT("alreadyRestored"), SnapshotTargetCount - Changed);
+	// A restore run twice writes nothing the second time, and a caller retrying
+	// after a timeout needs that as a field rather than as arithmetic on two
+	// counts.
+	Result->SetBoolField(TEXT("unchanged"), Changed == 0);
 	Result->SetStringField(TEXT("worldPath"), World->GetPathName());
 	Result->SetNumberField(TEXT("pieInstance"), WorldContext->PIEInstance);
 	Result->SetStringField(TEXT("netMode"), DescribePIENetMode(World));
 	Result->SetBoolField(TEXT("persisted"), false);
+
+	// The inverse of a restore is another restore, against the state this one
+	// overwrote. Stored last on purpose: making room for a new snapshot can
+	// evict an old one and rehash the map, which would leave `Snapshot`
+	// dangling, so nothing reads it past this point.
+	if (UndoTargets.Num() > 0)
+	{
+		TSharedPtr<FJsonObject> UndoPayload = MakeShared<FJsonObject>();
+		UndoPayload->SetStringField(TEXT("world"), TEXT("pie"));
+		UndoPayload->SetNumberField(TEXT("pieInstance"), WorldContext->PIEInstance);
+		UndoPayload->SetStringField(
+			TEXT("rollbackToken"),
+			MCPRuntimeVisibilityStoreRollback(World, WorldContext->PIEInstance, UndoTargets));
+		MCPSetRollback(Result, TEXT("restore_runtime_visibility"), UndoPayload);
+	}
+	else
+	{
+		MCPSetNoRollback(Result,
+			TEXT("Every target already held the state this token restores, so nothing was overwritten and there is "
+			     "no prior state to put back. Undoing a restore that wrote something emits a restore_runtime_visibility "
+			     "rollback of its own."));
+	}
 	return MCPResult(Result);
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EpicHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EpicHandlers.cpp
@@ -372,6 +372,28 @@ TSharedPtr<FJsonValue> FEpicHandlers::CallTool(const TSharedPtr<FJsonObject>& Pa
 	{
 		Res->SetStringField(TEXT("resultText"), TEXT(""));
 	}
+
+	// No inverse, and the reason is whose code ran rather than a gap here. This
+	// action is a dispatcher: the effect belongs to the wrapped engine tool the
+	// caller named in 'toolset' and 'tool', and the toolset API hands back a
+	// result payload rather than a description of what was written. Naming an
+	// inverse would mean guessing at an effect this wrapper never saw.
+	MCPSetNoRollback(Res, FString::Printf(
+		TEXT("Dispatched the wrapped engine tool '%s.%s'. Whatever that tool changed is its own, and the toolset API "
+		     "reports a result value rather than the writes behind it, so nothing here knows what to reverse. An "
+		     "inverse would be a second epic(call_tool) naming whichever tool undoes it, which only the caller "
+		     "choosing the tool can decide."),
+		*Toolset, *ToolName));
+
+	// Idempotency is unreadable for the same reason. Whether the tool found
+	// work to do, or found its target already in the requested state, is
+	// decided inside the tool and is not part of what it returns. A flag
+	// invented here would be a claim about somebody else's code.
+	Res->SetBoolField(TEXT("idempotencyObservable"), false);
+	Res->SetStringField(TEXT("idempotencyNote"), FString::Printf(
+		TEXT("'%s.%s' decides whether it changed anything, and the toolset API returns its result value without "
+		     "saying so. Read 'result' to see what the tool reported; this wrapper adds no claim of its own."),
+		*Toolset, *ToolName));
 	return MCPResult(Res);
 }
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/FoliageHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/FoliageHandlers.cpp
@@ -321,6 +321,16 @@ TSharedPtr<FJsonValue> FFoliageHandlers::SetFoliageTypeSettings(const TSharedPtr
 	// Apply settings via property reflection
 	TArray<FString> AppliedSettings;
 	TArray<FString> FailedSettings;
+	// Settings whose property already held the requested value. Writing one of
+	// those changed nothing, and a result that counted it as applied would
+	// report a no-op replay as a state change.
+	TArray<FString> UnchangedSettings;
+	// The previous values, captured BEFORE each write and in the same text form
+	// the settings parameter takes, so the record below is a call that restores
+	// them. Reading the properties back afterwards would only ever recover the
+	// values this call just installed.
+	TSharedPtr<FJsonObject> PreviousSettings = MakeShared<FJsonObject>();
+	int32 ChangedCount = 0;
 
 	for (const auto& KV : (*SettingsObj)->Values)
 	{
@@ -358,6 +368,12 @@ TSharedPtr<FJsonValue> FFoliageHandlers::SetFoliageTypeSettings(const TSharedPtr
 		}
 
 		void* PropertyAddr = Property->ContainerPtrToValuePtr<void>(FoliageType);
+		// Exported with no default to compare against, so a value that happens
+		// to equal the class default still comes back in full rather than as
+		// the empty delta a struct property would otherwise write.
+		FString OldText;
+		Property->ExportText_Direct(OldText, PropertyAddr, nullptr, FoliageType, PPF_None);
+
 		const TCHAR* ImportResult = Property->ImportText_Direct(*PropertyValue, PropertyAddr, FoliageType, PPF_None);
 		if (ImportResult == nullptr)
 		{
@@ -366,17 +382,37 @@ TSharedPtr<FJsonValue> FFoliageHandlers::SetFoliageTypeSettings(const TSharedPtr
 		else
 		{
 			AppliedSettings.Add(PropertyName);
+			// Compare the exported forms rather than the caller's string: "1"
+			// and "1.000000" are the same float, and a text comparison against
+			// what was asked for would call that a change.
+			FString NewText;
+			Property->ExportText_Direct(NewText, PropertyAddr, nullptr, FoliageType, PPF_None);
+			if (NewText == OldText)
+			{
+				UnchangedSettings.Add(PropertyName);
+			}
+			else
+			{
+				++ChangedCount;
+				PreviousSettings->SetStringField(PropertyName, OldText);
+			}
 		}
 	}
 
-	// Mark the foliage type as dirty
-	FoliageType->MarkPackageDirty();
-
-	// Save the asset if it has a valid package path
-	FString PackagePath = FoliageType->GetPathName();
-	if (PackagePath.Contains(TEXT("/Game/")))
+	// Dirty and save only when a value actually moved. A call that wrote the
+	// values the asset already held has nothing to persist, and dirtying the
+	// package anyway would hand the user an unsaved asset for a no-op.
+	if (ChangedCount > 0)
 	{
-		UEditorAssetLibrary::SaveAsset(FoliageType->GetOutermost()->GetName(), false);
+		// Mark the foliage type as dirty
+		FoliageType->MarkPackageDirty();
+
+		// Save the asset if it has a valid package path
+		FString PackagePath = FoliageType->GetPathName();
+		if (PackagePath.Contains(TEXT("/Game/")))
+		{
+			UEditorAssetLibrary::SaveAsset(FoliageType->GetOutermost()->GetName(), false);
+		}
 	}
 
 	auto Result = MakeShared<FJsonObject>();
@@ -398,6 +434,38 @@ TSharedPtr<FJsonValue> FFoliageHandlers::SetFoliageTypeSettings(const TSharedPtr
 			FailedArray.Add(MakeShared<FJsonValueString>(S));
 		}
 		Result->SetArrayField(TEXT("failedSettings"), FailedArray);
+	}
+
+	if (UnchangedSettings.Num() > 0)
+	{
+		TArray<TSharedPtr<FJsonValue>> UnchangedArray;
+		for (const FString& S : UnchangedSettings)
+		{
+			UnchangedArray.Add(MakeShared<FJsonValueString>(S));
+		}
+		Result->SetArrayField(TEXT("unchangedSettings"), UnchangedArray);
+	}
+
+	if (ChangedCount > 0) MCPSetUpdated(Result);
+	Result->SetBoolField(TEXT("unchanged"), ChangedCount == 0);
+	Result->SetNumberField(TEXT("changedCount"), ChangedCount);
+
+	if (ChangedCount > 0)
+	{
+		// The inverse is this same action with the values that were there
+		// before. Only the properties that actually moved are listed: replaying
+		// the ones that did not would be a second no-op write, and a property
+		// whose import failed was never touched.
+		TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+		Payload->SetStringField(TEXT("foliageTypePath"), FoliageType->GetPathName());
+		Payload->SetObjectField(TEXT("settings"), PreviousSettings);
+		MCPSetRollback(Result, TEXT("set_foliage_type_settings"), Payload);
+	}
+	else
+	{
+		MCPSetNoRollback(Result, TEXT(
+			"No property value moved, so nothing was written to the foliage type and there is nothing to undo. "
+			"Anything listed in failedSettings was rejected before the write and never reached the asset."));
 	}
 
 	Result->SetBoolField(TEXT("success"), FailedSettings.Num() == 0);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/GameplayHandlers_BTAuthoring.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/GameplayHandlers_BTAuthoring.cpp
@@ -1319,5 +1319,17 @@ TSharedPtr<FJsonValue> FGameplayHandlers::RemoveBTNode(const TSharedPtr<FJsonObj
 	Result->SetArrayField(TEXT("removed"), Removed);
 	Result->SetNumberField(TEXT("compiledNodeCount"), Addresses.Num());
 	Result->SetBoolField(TEXT("saved"), bSaved);
+
+	// add_bt_node is the opposite operation, not the inverse of this one. It
+	// places a single fresh node under a new guid, so it cannot rebuild the
+	// branch that came down with the removed node, nor the decorators and
+	// services the compiler read off those graph nodes, nor the property values
+	// written onto their instances. Naming it here would hand a flow a recovery
+	// step that restores a fragment and reports a whole tree.
+	MCPSetNoRollback(Result, TEXT(
+		"The node, every node beneath it, and their decorators, services and property values are "
+		"gone from the graph and out of the recompiled tree. add_bt_node places one fresh node at a "
+		"time under a new guid, so no call in this surface puts a removed branch back with its old "
+		"structure, ordering and values."));
 	return MCPResult(Result);
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/GameplayHandlers_Input.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/GameplayHandlers_Input.cpp
@@ -1717,11 +1717,26 @@ TSharedPtr<FJsonValue> FGameplayHandlers::GetActionValue(const TSharedPtr<FJsonO
 	}
 	else
 	{
-		// ActionInstanceData is protected, but the applied mapping view is
-		// public and names every action the player currently has bound, which
-		// is the same set.
+		// ActionInstanceData is protected, but the player's applied mappings
+		// name every action it currently has bound, which is the same set.
+		TConstArrayView<FEnhancedActionKeyMapping> Mappings;
+#if UE_MCP_HAS_5_8_API
+		Mappings = Player.PlayerInput->GetEnhancedActionMappingsView();
+#else
+		// GetEnhancedActionMappingsView() arrived in 5.8 and is the only public
+		// route to this list: GetEnhancedActionMappings() is protected. The
+		// backing EnhancedActionMappings is a UPROPERTY though, and FProperty
+		// reflection ignores C++ access specifiers, so the same array is still
+		// readable. Same route gameplay(get_applied_imcs) takes to the applied
+		// contexts.
+		if (FArrayProperty* MappingsProp = CastField<FArrayProperty>(
+				Player.PlayerInput->GetClass()->FindPropertyByName(TEXT("EnhancedActionMappings"))))
+		{
+			Mappings = *MappingsProp->ContainerPtrToValuePtr<TArray<FEnhancedActionKeyMapping>>(Player.PlayerInput);
+		}
+#endif
 		TSet<const UInputAction*> Seen;
-		for (const FEnhancedActionKeyMapping& Mapping : Player.PlayerInput->GetEnhancedActionMappingsView())
+		for (const FEnhancedActionKeyMapping& Mapping : Mappings)
 		{
 			const UInputAction* Action = Mapping.Action;
 			if (Action && !Seen.Contains(Action))

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/GameplayHandlers_Perception.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/GameplayHandlers_Perception.cpp
@@ -1415,6 +1415,23 @@ TSharedPtr<FJsonValue> FGameplayHandlers::ReportNoiseEvent(const TSharedPtr<FJso
 		}
 	}
 
+	// A one-shot stimulus, and the two statements that follow from that.
+	//
+	// There is no inverse. The event is already queued on the perception system
+	// and an AI that receives it has heard it; nothing in the engine or in this
+	// surface un-hears a stimulus or drains the queue behind one.
+	//
+	// It is also not idempotent, and `changed` is unconditionally true for that
+	// reason. A replay after a timeout does not converge on a state the way a
+	// property write does: reporting the same noise twice queues two events,
+	// each one perceived on its own. A caller retrying this call is making a
+	// second noise, not repeating the first.
+	Result->SetBoolField(TEXT("changed"), true);
+	MCPSetNoRollback(Result, TEXT(
+		"The stimulus is already queued on the world's AIPerceptionSystem and is delivered on its "
+		"next update. There is no call that un-hears a reported event or withdraws one from the "
+		"queue, so a flow cannot undo this step; it can only let the perception age out."));
+
 	// Reporting an event is fire-and-forget, so the only way to know it could
 	// possibly land is to say who was listening for that sense when it went
 	// out, and how far away they were.

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LandscapeHandlers_Sculpt.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LandscapeHandlers_Sculpt.cpp
@@ -2394,6 +2394,19 @@ TSharedPtr<FJsonValue> FLandscapeHandlers::ExportHeightmap(const TSharedPtr<FJso
 		bFileExisted
 			? TEXT("This overwrote an existing file and the previous contents were not read back, so the write cannot be undone through the bridge. Move or copy the old file first if it mattered.")
 			: TEXT("No inverse is emitted for a file this call created: the bridge has no delete-file method, and deleting a path the caller chose is not something a rollback should do on its own."));
+	// Both fields, for the same reason remove_layer_info below states: they
+	// answer different questions. rollbackOmitted says the previous file
+	// contents were not carried; rollbackPossible says no call restores them
+	// even if they had been. The landscape itself is untouched, so this is the
+	// argument asset(export_uv_layout) carries, applied to a heightmap file.
+	MCPSetNoRollback(Result, FString::Printf(
+		TEXT("Wrote the %s heightmap '%s' and changed no landscape, actor or asset state. An export produces an ")
+		TEXT("output artifact, and deleting a file that this same call regenerates on demand is not a meaningful ")
+		TEXT("undo, so no inverse is named. Undoing it would need a delete-file call the bridge does not have.%s"),
+		*Format, *Resolved,
+		bFileExisted
+			? TEXT(" The file that was already at that path is gone and no copy was kept.")
+			: TEXT("")));
 	Result->SetStringField(TEXT("note"), FString::Printf(
 		TEXT("%s Row-major from (minX,minY). Values are the landscape's raw uint16 heights, 32768 at the actor's own Z, one unit per 1/128 local cm."),
 		Format == TEXT("png16")

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers.cpp
@@ -3970,6 +3970,11 @@ TSharedPtr<FJsonValue> FLevelHandlers::ExportActorFbx(const TSharedPtr<FJsonObje
 	const int64 FbxSize = IFileManager::Get().FileSize(*AbsPath);
 	auto Result = MCPSuccess();
 	MCPSetCreated(Result);
+	// Nothing in the project or the level changed, but two files did, and a
+	// caller that pointed outputPath at an existing FBX has lost it.
+	MCPSetNoRollback(Result,
+		TEXT("The FBX and its .json sidecar were written to the caller's outputPath, overwriting whatever was already there, and any missing directories were created. ")
+		TEXT("Undoing that would need a call that deletes or restores a file on disk outside the content browser, and the bridge has none."));
 	Result->SetStringField(TEXT("actorLabel"), Actor->GetActorLabel());
 	Result->SetStringField(TEXT("fbx"), AbsPath);
 	Result->SetStringField(TEXT("metadata"), MetaPath);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_BatchWrite.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_BatchWrite.cpp
@@ -988,7 +988,7 @@ TSharedPtr<FJsonValue> FLevelHandlers::SpawnActorsBatch(const TSharedPtr<FJsonOb
 				}
 				else
 				{
-					const FBoxSphereBounds WorldBounds = SceneComponent->GetBounds();
+					const FBoxSphereBounds WorldBounds = MCPComponentWorldBounds(*SceneComponent);
 					Location = WorldBounds.Origin + WorldBounds.BoxExtent * ExtentFraction + Offset;
 				}
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Convert.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Convert.cpp
@@ -309,6 +309,12 @@ TSharedPtr<FJsonValue> FLevelHandlers::ConvertBrushesToStaticMesh(const TSharedP
 	else
 	{
 		MCPSetCreated(Result);
+		// The header says there is no undo path back to a builder brush, and
+		// the result has to say it too: a caller cannot tell a considered
+		// decision from a forgotten one by reading a missing field.
+		MCPSetNoRollback(Result,
+			TEXT("ConvertActors destroyed the source brushes and replaced them with StaticMeshActors and newly generated StaticMesh assets. ")
+			TEXT("Undoing that would need a call that rebuilds an ABrush from its original brush model, and the bridge has no action that creates a brush at all."));
 		Result->SetStringField(TEXT("saveNote"),
 			TEXT("The level is left dirty and is NOT saved, and the generated static meshes are new unsaved packages. Save both when you have checked the result."));
 	}

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_InstanceProjection.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_InstanceProjection.cpp
@@ -651,6 +651,43 @@ TSharedPtr<FJsonValue> UEMCPInstanceProjection::SnapInstancesToSurfaceInWorld(
 		MCPSetUpdated(Result);
 		Result->SetStringField(TEXT("dirtyPackage"), ISMC->GetOutermost()->GetName());
 		Result->SetStringField(TEXT("note"), TEXT("Changes are dirty in memory and were not saved."));
+
+		// Every Before was read in world space during the preflight, before the
+		// batch ran, so it is the transform an inverse has to write back and it
+		// is in the space update_instance_transform replays in.
+		const FProjectionPlanEntry* OnlyMoved = nullptr;
+		for (const FProjectionPlanEntry& Entry : Plan.Entries)
+		{
+			if (!Entry.bHit) continue;
+			if (OnlyMoved) { OnlyMoved = nullptr; break; }
+			OnlyMoved = &Entry;
+		}
+		if (OnlyMoved)
+		{
+			TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+			Payload->SetStringField(TEXT("actorPath"), Actor->GetPathName());
+			Payload->SetStringField(TEXT("actorLabel"), ActorLabel);
+			Payload->SetStringField(TEXT("componentName"), ISMC->GetName());
+			Payload->SetNumberField(TEXT("index"), OnlyMoved->InstanceIndex);
+			Payload->SetBoolField(TEXT("worldSpace"), true);
+			Payload->SetObjectField(TEXT("location"), MCPVec3ToJsonObject(OnlyMoved->Before.GetLocation()));
+			Payload->SetObjectField(TEXT("rotation"), MCPRotatorToJsonObject(OnlyMoved->Before.Rotator()));
+			Payload->SetObjectField(TEXT("scale"), MCPVec3ToJsonObject(OnlyMoved->Before.GetScale3D()));
+			MCPSetRollback(Result, TEXT("update_instance_transform"), Payload);
+			Result->SetStringField(TEXT("rollbackNote"),
+				TEXT("Instances are addressed by index, so the inverse has to run before anything else adds or removes an instance on this component."));
+		}
+		else
+		{
+			// A batch of moves is more than one rollback record can carry, and
+			// the per-instance transforms are not shipped either: this action
+			// projects up to 50000 instances in a call and a response holding
+			// one restore payload each would be larger than the edit.
+			MCPSetNoRollback(Result, FString::Printf(
+				TEXT("%d instance transforms were overwritten in one batch. level(update_instance_transform) restores a single index at a time and there is no batched form taking index/transform pairs, so no one call undoes this. ")
+				TEXT("The whole batch is one editor transaction, which editor(undo) reverses only while it is still the most recent one."),
+				Plan.HitCount));
+		}
 	}
 	else if (bDryRun)
 	{

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Lights.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Lights.cpp
@@ -563,19 +563,35 @@ TSharedPtr<FJsonValue> FLevelHandlers::SetFogProperties(const TSharedPtr<FJsonOb
 	UExponentialHeightFogComponent* FC = Fog->GetComponent();
 	if (!FC) return MCPError(TEXT("Fog component missing"));
 
+	// The inverse of this action is this action, replayed with the values it is
+	// about to overwrite. Every previous value is therefore read BEFORE its
+	// write, and only the keys this call actually touches are carried: a
+	// payload naming a property the caller never set would restore a value
+	// nobody asked to change.
+	TSharedPtr<FJsonObject> Rollback = MakeShared<FJsonObject>();
+	Rollback->SetStringField(TEXT("world"), WorldScope);
+	Rollback->SetStringField(TEXT("actorPath"), Fog->GetPathName());
+	bool bAnyChange = false;
+
 	double Density = 0.0;
 	if (Params->TryGetNumberField(TEXT("fogDensity"), Density))
 	{
+		Rollback->SetNumberField(TEXT("fogDensity"), FC->FogDensity);
+		bAnyChange = true;
 		FC->FogDensity = (float)Density;
 	}
 	double HeightFalloff = 0.0;
 	if (Params->TryGetNumberField(TEXT("fogHeightFalloff"), HeightFalloff))
 	{
+		Rollback->SetNumberField(TEXT("fogHeightFalloff"), FC->FogHeightFalloff);
+		bAnyChange = true;
 		FC->FogHeightFalloff = (float)HeightFalloff;
 	}
 	double StartDistance = 0.0;
 	if (Params->TryGetNumberField(TEXT("startDistance"), StartDistance))
 	{
+		Rollback->SetNumberField(TEXT("startDistance"), FC->StartDistance);
+		bAnyChange = true;
 		FC->StartDistance = (float)StartDistance;
 	}
 	const TSharedPtr<FJsonObject>* ColorObj = nullptr;
@@ -586,27 +602,44 @@ TSharedPtr<FJsonValue> FLevelHandlers::SetFogProperties(const TSharedPtr<FJsonOb
 		(*ColorObj)->TryGetNumberField(TEXT("r"), R);
 		(*ColorObj)->TryGetNumberField(TEXT("g"), G);
 		(*ColorObj)->TryGetNumberField(TEXT("b"), B);
+		// Back out through the same 0-255 scaling the write applies, so the
+		// inverse replays in the units the action reads.
+		const FLinearColor PreviousInscattering = FC->FogInscatteringLuminance;
+		TSharedPtr<FJsonObject> PreviousColor = MakeShared<FJsonObject>();
+		PreviousColor->SetNumberField(TEXT("r"), PreviousInscattering.R * 255.0);
+		PreviousColor->SetNumberField(TEXT("g"), PreviousInscattering.G * 255.0);
+		PreviousColor->SetNumberField(TEXT("b"), PreviousInscattering.B * 255.0);
+		Rollback->SetObjectField(TEXT("fogInscatteringColor"), PreviousColor);
+		bAnyChange = true;
 		FC->FogInscatteringLuminance = FLinearColor(R / 255.0f, G / 255.0f, B / 255.0f);
 	}
 
 	// #608: volumetric fog controls.
 	if (Params->HasField(TEXT("enableVolumetricFog")))
 	{
+		Rollback->SetBoolField(TEXT("enableVolumetricFog"), FC->bEnableVolumetricFog != 0);
+		bAnyChange = true;
 		FC->SetVolumetricFog(OptionalBool(Params, TEXT("enableVolumetricFog"), true));
 	}
 	double VolScatterDist = 0.0;
 	if (Params->TryGetNumberField(TEXT("volumetricFogScatteringDistribution"), VolScatterDist))
 	{
+		Rollback->SetNumberField(TEXT("volumetricFogScatteringDistribution"), FC->VolumetricFogScatteringDistribution);
+		bAnyChange = true;
 		FC->SetVolumetricFogScatteringDistribution((float)VolScatterDist);
 	}
 	double VolExtinction = 0.0;
 	if (Params->TryGetNumberField(TEXT("volumetricFogExtinctionScale"), VolExtinction))
 	{
+		Rollback->SetNumberField(TEXT("volumetricFogExtinctionScale"), FC->VolumetricFogExtinctionScale);
+		bAnyChange = true;
 		FC->SetVolumetricFogExtinctionScale((float)VolExtinction);
 	}
 	double VolDistance = 0.0;
 	if (Params->TryGetNumberField(TEXT("volumetricFogDistance"), VolDistance))
 	{
+		Rollback->SetNumberField(TEXT("volumetricFogDistance"), FC->VolumetricFogDistance);
+		bAnyChange = true;
 		FC->SetVolumetricFogDistance((float)VolDistance);
 	}
 	const TSharedPtr<FJsonObject>* AlbedoObj = nullptr;
@@ -616,17 +649,47 @@ TSharedPtr<FJsonValue> FLevelHandlers::SetFogProperties(const TSharedPtr<FJsonOb
 		(*AlbedoObj)->TryGetNumberField(TEXT("r"), R);
 		(*AlbedoObj)->TryGetNumberField(TEXT("g"), G);
 		(*AlbedoObj)->TryGetNumberField(TEXT("b"), B);
+		// The albedo is stored as an FColor, so its previous value already is
+		// in the 0-255 form this action reads.
+		const FColor PreviousAlbedo = FC->VolumetricFogAlbedo;
+		TSharedPtr<FJsonObject> PreviousAlbedoJson = MakeShared<FJsonObject>();
+		PreviousAlbedoJson->SetNumberField(TEXT("r"), PreviousAlbedo.R);
+		PreviousAlbedoJson->SetNumberField(TEXT("g"), PreviousAlbedo.G);
+		PreviousAlbedoJson->SetNumberField(TEXT("b"), PreviousAlbedo.B);
+		Rollback->SetObjectField(TEXT("volumetricFogAlbedo"), PreviousAlbedoJson);
+		bAnyChange = true;
 		FC->SetVolumetricFogAlbedo(FColor((uint8)R, (uint8)G, (uint8)B));
 	}
 
 	FC->MarkRenderStateDirty();
 
 	auto Result = MCPSuccess();
-	MCPSetUpdated(Result);
+	// Keyed off what was actually written, because the same result body also
+	// says there was nothing to undo when no property was named.
+	if (bAnyChange)
+	{
+		MCPSetUpdated(Result);
+	}
+	else
+	{
+		Result->SetBoolField(TEXT("updated"), false);
+		Result->SetBoolField(TEXT("unchanged"), true);
+	}
 	Result->SetStringField(TEXT("actorLabel"), Fog->GetActorLabel());
 	Result->SetStringField(TEXT("actorPath"), Fog->GetPathName());
 	Result->SetNumberField(TEXT("fogDensity"), FC->FogDensity);
 	Result->SetNumberField(TEXT("fogHeightFalloff"), FC->FogHeightFalloff);
+	if (bAnyChange)
+	{
+		MCPSetRollback(Result, TEXT("set_fog_properties"), Rollback);
+	}
+	else
+	{
+		// A call that named no property wrote nothing, so there is nothing to
+		// undo. Saying that is not the same as staying silent about an inverse.
+		MCPSetNoRollback(Result,
+			TEXT("This call set no fog property, so nothing changed and there is nothing to undo."));
+	}
 	return MCPResult(Result);
 }
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_MultiLevel.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_MultiLevel.cpp
@@ -437,6 +437,19 @@ TSharedPtr<FJsonValue> FLevelHandlers::DeleteExactLabeledActorsInLevels(
 		Result->SetNumberField(TEXT("requestedActors"), TotalRequested);
 		Result->SetNumberField(TEXT("matchedActors"), TotalMatched);
 		Result->SetNumberField(TEXT("deletedActors"), TotalDeleted);
+		// Whether this call actually changed anything, rather than leaving the
+		// caller to infer it from two counters. A dry run and an
+		// onMissing=ignore replay whose labels are already gone both reach here
+		// having deleted nothing and saved nothing.
+		Result->SetBoolField(TEXT("unchanged"), !bAnyAppliedChanges);
+		if (bAnyAppliedChanges)
+		{
+			// Stated only when something was really committed, because a dry
+			// run has nothing to undo in the first place.
+			MCPSetNoRollback(Result,
+				TEXT("Actors were destroyed and every changed level was saved to disk, so the .umap files no longer hold them. ")
+				TEXT("Undoing that would need a call that re-creates an actor with its full serialized state inside a named level, and the bridge has no such action."));
+		}
 		Result->SetStringField(TEXT("originalLevelPath"), OriginalLevelPath);
 		Result->SetBoolField(TEXT("restoreOriginalLevelRequested"), bRestoreOriginalLevel);
 		Result->SetBoolField(TEXT("restoredOriginalLevel"), bRestoredOriginalLevel);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Query.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Query.cpp
@@ -597,7 +597,7 @@ TSharedPtr<FJsonValue> FLevelHandlers::QueryComponents(const TSharedPtr<FJsonObj
 			bool bBoundsInvalid = false;
 			if (SceneComponent && (Fields.bBounds || Fields.bHealth))
 			{
-				const FBoxSphereBounds ComponentBounds = SceneComponent->GetBounds();
+				const FBoxSphereBounds ComponentBounds = MCPComponentWorldBounds(*SceneComponent);
 				const FVector Extent = ComponentBounds.BoxExtent;
 				bBoundsZero = Extent.IsNearlyZero() && FMath::IsNearlyZero(ComponentBounds.SphereRadius);
 				bBoundsInvalid =

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Refresh.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Refresh.cpp
@@ -221,7 +221,7 @@ namespace
 		Object->SetObjectField(TEXT("worldTransform"), TransformObject);
 
 		Object->SetObjectField(TEXT("localBounds"), MCPRefreshDescribeBounds(Component->GetLocalBounds()));
-		Object->SetObjectField(TEXT("worldBounds"), MCPRefreshDescribeBounds(Component->GetBounds()));
+		Object->SetObjectField(TEXT("worldBounds"), MCPRefreshDescribeBounds(MCPComponentWorldBounds(*Component)));
 
 		// #914's original ask: the UNSCALED authored extent, which is what the
 		// details panel shows and what no existing read returned.
@@ -696,8 +696,8 @@ TSharedPtr<FJsonValue> FLevelHandlers::TestComponentOverlap(const TSharedPtr<FJs
 
 	if (Method == TEXT("AABB"))
 	{
-		const FBox BoxA = ComponentA->GetBounds().GetBox();
-		const FBox BoxB = ComponentB->GetBounds().GetBox();
+		const FBox BoxA = MCPComponentWorldBounds(*ComponentA).GetBox();
+		const FBox BoxB = MCPComponentWorldBounds(*ComponentB).GetBox();
 		bOverlap = BoxA.Intersect(BoxB);
 		// Per-axis gap or overlap depth, which is what a caller tuning a
 		// placement actually wants back.

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Save.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Save.cpp
@@ -302,6 +302,15 @@ TSharedPtr<FJsonValue> FLevelHandlers::SaveLevel(const TSharedPtr<FJsonObject>& 
 	Result->SetArrayField(TEXT("saved"), Saved);
 	if (Skipped.Num() > 0) Result->SetArrayField(TEXT("skipped"), Skipped);
 
+	// Stated before the failure branch, because a partial save has already
+	// overwritten the packages it did write.
+	if (Saved.Num() > 0)
+	{
+		MCPSetNoRollback(Result,
+			TEXT("The level package, and every external actor package that was dirty, were overwritten on disk with the editor's in-memory state. ")
+			TEXT("Undoing that needs the previous file contents back, and the bridge has no action that snapshots or restores a package file; source control is what holds the old revision."));
+	}
+
 	if (Failed.Num() > 0)
 	{
 		Result->SetBoolField(TEXT("success"), false);

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Transient.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Transient.cpp
@@ -264,15 +264,30 @@ TSharedPtr<FJsonValue> FLevelHandlers::DestroyTransientActor(const TSharedPtr<FJ
 		return MCPResult(Result);
 	}
 
+	// What the inverse needs, read while the actor still exists. A destroyed
+	// actor cannot be asked what class it was or where it stood.
+	struct FDestroyedTransient
+	{
+		FString ClassPath;
+		FString Label;
+		FTransform Transform;
+	};
+	TArray<FDestroyedTransient> Restorable;
+
 	TArray<FString> Destroyed;
 	TArray<FString> Failed;
 	for (AActor* Actor : Targets)
 	{
 		const FString Description = FString::Printf(
 			TEXT("%s (%s)"), *Actor->GetActorLabel(), *Actor->GetClass()->GetName());
+		FDestroyedTransient Snapshot;
+		Snapshot.ClassPath = Actor->GetClass()->GetPathName();
+		Snapshot.Label = Actor->GetActorLabel();
+		Snapshot.Transform = Actor->GetActorTransform();
 		if (World->DestroyActor(Actor))
 		{
 			Destroyed.Add(Description);
+			Restorable.Add(MoveTemp(Snapshot));
 		}
 		else
 		{
@@ -288,8 +303,47 @@ TSharedPtr<FJsonValue> FLevelHandlers::DestroyTransientActor(const TSharedPtr<FJ
 	}
 	Result->SetNumberField(TEXT("matched"), Targets.Num());
 	Result->SetNumberField(TEXT("destroyed"), Destroyed.Num());
+	// A replay of the same call finds nothing left to destroy, which is a
+	// success that changed nothing. Saying so is what lets a retried step tell
+	// the two apart.
+	Result->SetBoolField(TEXT("alreadyDeleted"), Targets.IsEmpty());
 	Result->SetArrayField(TEXT("destroyedActors"), MCPStringListToJson(Destroyed));
 	Result->SetArrayField(TEXT("failed"), MCPStringListToJson(Failed));
+	// The spawn_transient_actor call that brings one of them back, in that
+	// action's own parameter names so it can be replayed unedited.
+	auto MakeSpawnPayload = [&WorldScope](const FDestroyedTransient& Entry)
+	{
+		TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
+		Payload->SetStringField(TEXT("world"), WorldScope);
+		Payload->SetStringField(TEXT("actorClass"), Entry.ClassPath);
+		if (!Entry.Label.IsEmpty()) Payload->SetStringField(TEXT("label"), Entry.Label);
+		Payload->SetObjectField(TEXT("location"), MCPVec3ToJsonObject(Entry.Transform.GetLocation()));
+		Payload->SetObjectField(TEXT("rotation"), MCPRotatorToJsonObject(Entry.Transform.Rotator()));
+		Payload->SetObjectField(TEXT("scale"), MCPVec3ToJsonObject(Entry.Transform.GetScale3D()));
+		return Payload;
+	};
+
+	if (Restorable.Num() == 1)
+	{
+		MCPSetRollback(Result, TEXT("spawn_transient_actor"), MakeSpawnPayload(Restorable[0]));
+		Result->SetStringField(TEXT("rollbackNote"),
+			TEXT("The inverse spawns a fresh verification actor of the same class at the same transform. It is a new actor with a new object path, so anything written onto the destroyed one after it was spawned is not restored."));
+	}
+	else if (Restorable.Num() > 1)
+	{
+		// One rollback record is one call, so a batch destroy has no single
+		// inverse. The per-actor calls are handed over instead of described.
+		TArray<TSharedPtr<FJsonValue>> RestoreCalls;
+		for (const FDestroyedTransient& Entry : Restorable)
+		{
+			RestoreCalls.Add(MakeShared<FJsonValueObject>(MakeSpawnPayload(Entry)));
+		}
+		Result->SetArrayField(TEXT("restorable"), RestoreCalls);
+		MCPSetNoRollback(Result, FString::Printf(
+			TEXT("%d transient verification actors were destroyed in one call, and level(spawn_transient_actor) makes one actor at a time, so no single call undoes the batch. ")
+			TEXT("Each entry of 'restorable' is a ready spawn_transient_actor payload for one of them."),
+			Restorable.Num()));
+	}
 	if (Targets.IsEmpty())
 	{
 		Result->SetStringField(TEXT("zeroMatchNote"),

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/MaterialHandlers_Build.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/MaterialHandlers_Build.cpp
@@ -378,7 +378,19 @@ TSharedPtr<FJsonValue> FMaterialHandlers::BuildMaterial(const TSharedPtr<FJsonOb
 		}
 
 		// ── Wire the sample to its property or properties ────────────────────
+#if UE_MCP_HAS_5_8_API
 		const TArray<FString> OutputNames = UMaterialEditingLibrary::GetMaterialExpressionOutputNames(Sample);
+#else
+		// GetMaterialExpressionOutputNames() arrived in 5.8, but it only reads
+		// back the expression's own output pins, and UMaterialExpression has
+		// exposed those since long before. Read them directly rather than lose
+		// the by-name channel wiring and fall back to channel index on 5.7.
+		TArray<FString> OutputNames;
+		for (const FExpressionOutput& Output : Sample->GetOutputs())
+		{
+			OutputNames.Add(Output.OutputName.ToString());
+		}
+#endif
 		TArray<TSharedPtr<FJsonValue>> ConnectedTargets;
 		for (int32 TargetIndex = 0; TargetIndex < Slot.Targets.Num(); ++TargetIndex)
 		{
@@ -450,7 +462,17 @@ TSharedPtr<FJsonValue> FMaterialHandlers::BuildMaterial(const TSharedPtr<FJsonOb
 	}
 
 	// ── Recompile, then report what actually survived it ─────────────────────
+#if UE_MCP_HAS_5_8_API
 	const TArray<FString> CompileErrors = UMaterialEditingLibrary::RecompileMaterial(Material);
+#else
+	// RecompileMaterial returns void before 5.8, where it started handing back
+	// the compile errors it collected. The recompile itself is identical, so
+	// only the reporting differs: `compileErrors` below stays empty on 5.7 and
+	// the response says the list could not be read rather than implying the
+	// material compiled clean.
+	UMaterialEditingLibrary::RecompileMaterial(Material);
+	const TArray<FString> CompileErrors;
+#endif
 	const bool bSaved = SaveAssetPackage(Material);
 
 	// Re-read the editor-only data: RecompileMaterial can rebuild it, so the
@@ -491,6 +513,14 @@ TSharedPtr<FJsonValue> FMaterialHandlers::BuildMaterial(const TSharedPtr<FJsonOb
 		for (const FString& Error : CompileErrors) Errors.Add(MakeShared<FJsonValueString>(Error));
 		Result->SetArrayField(TEXT("compileErrors"), Errors);
 	}
+#if !UE_MCP_HAS_5_8_API
+	// Said out loud, because an absent compileErrors array otherwise reads as
+	// "the recompile produced no errors", and on this engine it means the call
+	// that recompiles does not report them at all.
+	Result->SetStringField(TEXT("compileErrorsNote"),
+		TEXT("compileErrors is not reported on this engine: UMaterialEditingLibrary::RecompileMaterial "
+		     "returns void before UE 5.8. The material was recompiled; read the editor log for its errors."));
+#endif
 
 	// ── Optional: put the finished material on a mesh's slots ────────────────
 	FString MeshPath = OptionalString(Params, TEXT("assignToMesh"));

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/NiagaraHandlers_Compile.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/NiagaraHandlers_Compile.cpp
@@ -278,8 +278,23 @@ TSharedPtr<FJsonValue> FNiagaraHandlers::CompileSystem(const TSharedPtr<FJsonObj
 			   "the compiler reported one, the node and pin guid that produced it. Read the whole graph "
 			   "back with niagara(get_emitter_info) or niagara(list_dynamic_inputs)."));
 
-	// No rollback: compiling changes no authored state. It writes the compiled
-	// results onto the scripts, which is what an uncompiled system is missing.
+	// Idempotency: RequestCompile answers whether this call actually put a
+	// compile on the queue. With force=false a system whose scripts are already
+	// translated and unchanged returns false, so a replayed flow step is a
+	// no-op rather than a second translation. force=true is the default, and it
+	// requests one every time by design, which the field then reports honestly.
+	Result->SetBoolField(TEXT("unchanged"), !bQueued);
+	if (bQueued) MCPSetUpdated(Result);
+
+	// Compiling changes no authored state. It writes the translated VM bytecode
+	// and shader maps onto the system's scripts, which is exactly what an
+	// uncompiled system is missing, and leaves the package dirty. There is no
+	// previous graph to put back and no bridge call that un-translates a
+	// script; the only route to the old build is to edit the graph back.
+	MCPSetNoRollback(Result, TEXT(
+		"Compiling replaces the translated bytecode and shader maps cached on this system's scripts and leaves the "
+		"package dirty. No authored state changed, so there is nothing to restore, and no bridge call un-translates "
+		"a script back to its previous build."));
 	return MCPResult(Result);
 #endif // WITH_EDITORONLY_DATA
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/SkeletalMeshHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/SkeletalMeshHandlers.cpp
@@ -156,7 +156,9 @@ TSharedPtr<FJsonValue> FSkeletalMeshHandlers::SetOptimizeForInstancing(const TSh
 	}
 
 	TArray<TSharedPtr<FJsonValue>> Lods;
-	int32 ChangedLodCount = 0;
+	// Which LODs this call actually flipped, not how many. The rollback below has
+	// to address exactly those and no others.
+	TArray<int32> ChangedLodIndices;
 	if (bNeedsMutation)
 	{
 		// Establish the transaction before the first setter. The subsystem also
@@ -167,7 +169,7 @@ TSharedPtr<FJsonValue> FSkeletalMeshHandlers::SetOptimizeForInstancing(const TSh
 		{
 			if (Target.Before.bOptimizeForInstancing != bEnabled)
 			{
-				++ChangedLodCount;
+				ChangedLodIndices.Add(Target.Index);
 				FSkeletalMeshBuildSettings Updated = Target.Before;
 				Updated.bOptimizeForInstancing = bEnabled;
 				USkeletalMeshEditorSubsystem::SetLodBuildSettings(Mesh, Target.Index, Updated);
@@ -194,7 +196,44 @@ TSharedPtr<FJsonValue> FSkeletalMeshHandlers::SetOptimizeForInstancing(const TSh
 	Result->SetBoolField(TEXT("enabled"), bEnabled);
 	Result->SetBoolField(TEXT("updated"), bNeedsMutation);
 	Result->SetBoolField(TEXT("saved"), bNeedsMutation);
-	Result->SetNumberField(TEXT("changedLods"), ChangedLodCount);
+	Result->SetNumberField(TEXT("changedLods"), ChangedLodIndices.Num());
 	Result->SetArrayField(TEXT("lods"), Lods);
+
+	// The inverse is this same action carrying the flag the mesh used to hold.
+	// bOptimizeForInstancing is a bool, so every LOD this call flipped held
+	// !bEnabled, and one replay restores all of them. What limits the rollback is
+	// addressing: the action targets one lodIndex or every LOD, so a partial set
+	// of flipped LODs cannot be named.
+	const int32 LodCount = Mesh->GetLODNum();
+	if (ChangedLodIndices.IsEmpty())
+	{
+		MCPSetNoRollback(Result,
+			TEXT("Every targeted LOD already held the requested bOptimizeForInstancing value, ")
+			TEXT("so no build setting was written and there is nothing to undo."));
+	}
+	else if (ChangedLodIndices.Num() == 1 || ChangedLodIndices.Num() == LodCount)
+	{
+		auto Payload = MakeShared<FJsonObject>();
+		Payload->SetStringField(TEXT("assetPath"), Mesh->GetPathName());
+		Payload->SetBoolField(TEXT("enabled"), !bEnabled);
+		if (ChangedLodIndices.Num() == LodCount)
+		{
+			Payload->SetBoolField(TEXT("allLods"), true);
+		}
+		else
+		{
+			Payload->SetNumberField(TEXT("lodIndex"), ChangedLodIndices[0]);
+		}
+		MCPSetRollback(Result, TEXT("set_skeletal_mesh_optimize_for_instancing"), Payload);
+	}
+	else
+	{
+		MCPSetNoRollback(Result, FString::Printf(
+			TEXT("bOptimizeForInstancing was flipped on %d of this mesh's %d LODs, and ")
+			TEXT("set_skeletal_mesh_optimize_for_instancing addresses a single lodIndex or all LODs; ")
+			TEXT("restoring that mixed state needs a call that accepts a list of LOD indices."),
+			ChangedLodIndices.Num(),
+			LodCount));
+	}
 	return MCPResult(Result);
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/SkeletalMeshHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/SkeletalMeshHandlers.cpp
@@ -80,7 +80,9 @@ namespace
 		Out->SetBoolField(TEXT("bUseHighPrecisionSkinWeights"), Settings.bUseHighPrecisionSkinWeights);
 		Out->SetBoolField(TEXT("bUseFullPrecisionUVs"), Settings.bUseFullPrecisionUVs);
 		Out->SetBoolField(TEXT("bUseBackwardsCompatibleF16TruncUVs"), Settings.bUseBackwardsCompatibleF16TruncUVs);
+#if UE_MCP_HAS_5_8_API
 		Out->SetBoolField(TEXT("bOptimizeForInstancing"), Settings.bOptimizeForInstancing);
+#endif
 		Out->SetNumberField(TEXT("thresholdPosition"), Settings.ThresholdPosition);
 		Out->SetNumberField(TEXT("thresholdTangentNormal"), Settings.ThresholdTangentNormal);
 		Out->SetNumberField(TEXT("thresholdUV"), Settings.ThresholdUV);
@@ -95,9 +97,20 @@ namespace
 		Lod->SetNumberField(TEXT("lodIndex"), Index);
 		Lod->SetObjectField(TEXT("beforeBuildSettings"), SerializeBuildSettings(Before));
 		Lod->SetObjectField(TEXT("afterBuildSettings"), SerializeBuildSettings(After));
+#if UE_MCP_HAS_5_8_API
 		Lod->SetBoolField(TEXT("beforeOptimizeForInstancing"), Before.bOptimizeForInstancing);
 		Lod->SetBoolField(TEXT("afterOptimizeForInstancing"), After.bOptimizeForInstancing);
 		Lod->SetBoolField(TEXT("changed"), Before.bOptimizeForInstancing != After.bOptimizeForInstancing);
+#else
+		// Every field below reports one 5.8-only build setting, so on an older
+		// engine they are omitted and named instead. Reporting false would say
+		// the flag is off, which is a different answer from the engine having no
+		// such flag at all.
+		Lod->SetStringField(TEXT("optimizeForInstancingNote"),
+			TEXT("beforeOptimizeForInstancing, afterOptimizeForInstancing, changed and ")
+			TEXT("buildSettings.bOptimizeForInstancing are omitted: ")
+			TEXT("FSkeletalMeshBuildSettings::bOptimizeForInstancing needs UE 5.8, and this editor is older."));
+#endif
 		return Lod;
 	}
 }
@@ -131,6 +144,15 @@ TSharedPtr<FJsonValue> FSkeletalMeshHandlers::ReadBuildSettings(const TSharedPtr
 
 TSharedPtr<FJsonValue> FSkeletalMeshHandlers::SetOptimizeForInstancing(const TSharedPtr<FJsonObject>& Params)
 {
+#if !UE_MCP_HAS_5_8_API
+	// bOptimizeForInstancing is a 5.8 engine feature with no earlier equivalent,
+	// so there is nothing to write and nothing to stand in for it. The action
+	// stays registered and says why, rather than answering "Unknown method".
+	return MCPError(
+		TEXT("set_skeletal_mesh_optimize_for_instancing requires Unreal Engine 5.8 or newer: ")
+		TEXT("FSkeletalMeshBuildSettings::bOptimizeForInstancing does not exist in this engine, ")
+		TEXT("and no earlier skeletal mesh build setting stands in for it."));
+#else
 	FString AssetPath;
 	if (auto Err = RequireString(Params, TEXT("assetPath"), AssetPath)) return Err;
 	bool bEnabled = false;
@@ -236,4 +258,5 @@ TSharedPtr<FJsonValue> FSkeletalMeshHandlers::SetOptimizeForInstancing(const TSh
 			LodCount));
 	}
 	return MCPResult(Result);
+#endif // UE_MCP_HAS_5_8_API
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/WidgetHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/WidgetHandlers.cpp
@@ -2785,6 +2785,45 @@ TSharedPtr<FJsonValue> FWidgetHandlers::InvokeRuntimeWidgetFunction(const TShare
 		{
 			return Err;
 		}
+		// Whether the widget's own value moved. The interactions that carry a
+		// value record what it was and what it became, so this is a reading
+		// rather than an assumption; a click has neither, and gets no flag.
+		//
+		// It says nothing about the blueprint behind the widget. The delegate
+		// is broadcast whether or not the value moved, deliberately, because
+		// re-driving a slider to the value it already holds is still a request
+		// to run the graph. So `valueUnchanged` is about the widget, and the
+		// graph ran either way.
+		//
+		// Compared on the JSON type the interaction wrote rather than through a
+		// string or number accessor: a text field holding "42" and one holding
+		// "042" are different text, and a numeric accessor would call them the
+		// same value.
+		const TSharedPtr<FJsonValue> Before = Result->TryGetField(TEXT("previousValue"));
+		const TSharedPtr<FJsonValue> After = Result->TryGetField(TEXT("value"));
+		if (Before.IsValid() && After.IsValid())
+		{
+			bool bSameValue = false;
+			if (Before->Type == EJson::Number && After->Type == EJson::Number)
+			{
+				bSameValue = Before->AsNumber() == After->AsNumber();
+			}
+			else if (Before->Type == EJson::String && After->Type == EJson::String)
+			{
+				bSameValue = Before->AsString().Equals(After->AsString(), ESearchCase::CaseSensitive);
+			}
+			Result->SetBoolField(TEXT("valueUnchanged"), bSameValue);
+		}
+		else
+		{
+			// A click, a hover, a press: an event, not a state write. Firing it
+			// twice is two events rather than one repeated change, so there is
+			// no value to compare and no no-op to report.
+			Result->SetStringField(TEXT("idempotencyNote"),
+				TEXT("This interaction delivers an event rather than writing a value, so there is nothing to compare "
+				     "against and no valueUnchanged is reported. Sending it twice fires the delegate twice."));
+		}
+
 		// A simulated click, commit or value change fires the child's delegates,
 		// and what those handlers then do is decided by the running blueprint.
 		// Nothing here knows what changed, so nothing here can name an inverse.
@@ -2814,6 +2853,13 @@ TSharedPtr<FJsonValue> FWidgetHandlers::InvokeRuntimeWidgetFunction(const TShare
 	auto Result = MCPSuccess();
 	Result->SetStringField(TEXT("widget"), Found->GetName());
 	Result->SetStringField(TEXT("invoked"), FunctionName);
+	// No valueUnchanged here either: calling a UFUNCTION is an invocation, not a
+	// write of a value this action chose, so there is no before and after to
+	// compare. Whether the function did anything the second time is the
+	// function's own business.
+	Result->SetStringField(TEXT("idempotencyNote"),
+		TEXT("This calls a function rather than setting a value, so no unchanged flag is reported. Calling it twice "
+		     "runs it twice, and whether the second run does anything is decided inside the function."));
 	Result->SetBoolField(TEXT("rollbackPossible"), false);
 	Result->SetStringField(TEXT("rollbackNote"),
 		TEXT("This calls a UFUNCTION the widget's author wrote. What it changed is the function's business, not this action's, so there is ")

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Public/HandlerUtils.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Public/HandlerUtils.h
@@ -13,6 +13,7 @@
 #include "Engine/Blueprint.h"
 #include "EngineUtils.h"
 #include "GameFramework/Actor.h"
+#include "Components/SceneComponent.h"
 #include "EditorAssetLibrary.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
@@ -2185,6 +2186,32 @@ inline void MCPGetNestedSubobjects(const UObjectBase* Outer, TArray<UObject*>& O
 #else
 	GetObjectsWithOuter(Outer, OutObjects, /*bIncludeNestedObjects*/ true,
 		RF_NoFlags, EInternalObjectFlags::Garbage);
+#endif
+}
+
+// ── Component bounds ─────────────────────────────────────────────────────────
+
+/** A scene component's cached world-space bounds, spelled the way each engine
+ *  wants it. 5.8 added USceneComponent::GetBounds(), an inline getter that
+ *  returns a const reference to the public Bounds member; 5.7 and earlier offer
+ *  the member alone. Both branches read the same field, so every supported
+ *  engine returns the same value at the same freshness - the accessor is a
+ *  rename, and UpdateBounds is still what refreshes what either one reads.
+ *
+ *  Bounds is public on 5.8 too, so the gate decides which spelling is used
+ *  rather than which one compiles. Preferring the accessor there is what keeps
+ *  these call sites correct on the engine that eventually makes the member
+ *  private, which is the reason Epic added the getter.
+ *
+ *  Both spellings live here and nowhere else. This module is a unity build, so
+ *  a file-local copy in a second .cpp is a C2084 redefinition the moment the
+ *  adaptive-unity working set puts the two files in one blob. */
+inline const FBoxSphereBounds& MCPComponentWorldBounds(const USceneComponent& Component)
+{
+#if UE_MCP_HAS_5_8_API
+	return Component.GetBounds();
+#else
+	return Component.Bounds;
 #endif
 }
 

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Public/HandlerUtils.h
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Public/HandlerUtils.h
@@ -139,6 +139,34 @@ inline void MCPSetUpdated(TSharedPtr<FJsonObject> Result)
 	Result->SetBoolField(TEXT("updated"), true);
 }
 
+/** State that whether this call changed anything CANNOT BE READ, and say why.
+ *
+ *  The idempotency counterpart to MCPSetNoRollback, and it exists for the same
+ *  reason: a handler that cannot answer and says so has finished the job, and
+ *  one that says nothing has not, but from the outside the two look identical.
+ *
+ *  The cases are real and narrow. epic(call_tool) dispatches a wrapped engine
+ *  tool whose writes it never sees, and the Fab module publishes no
+ *  authentication or library state this build can read back. Both are asking
+ *  about somebody else's code, so a fabricated `unchanged: false` would be a
+ *  claim rather than a reading, which is worse than an honest absence.
+ *
+ *  This is NOT the escape hatch for a handler that could measure its effect and
+ *  did not. If the state is readable, read it before and after and report what
+ *  moved. The reason is a required argument for the same purpose it is on
+ *  MCPSetNoRollback: the flag alone tells a caller that replay safety is
+ *  unknown without telling it why, and the pair cannot come apart if one call
+ *  sets both.
+ *
+ *  The spelling was already in use in FabHandlers before this helper existed,
+ *  which is exactly how the earlier rollbackPossible drift started: an idiom
+ *  spread by copy while the convention audit recognised none of it. */
+inline void MCPSetIdempotencyUnobservable(TSharedPtr<FJsonObject> Result, const FString& Reason)
+{
+	Result->SetBoolField(TEXT("idempotencyObservable"), false);
+	Result->SetStringField(TEXT("idempotencyNote"), Reason);
+}
+
 /** Check for an existing asset at `PackagePath/Name`. Returns a fully-formed
  *  "already existed" result on hit (caller can return it directly), or an
  *  unset pointer on miss so the caller proceeds to create. Also honors an

--- a/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
+++ b/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.3.1-beta.1",
+	"VersionName": "1.3.1-beta.2",
 	"FriendlyName": "UE MCP Bridge",
 	"Description": "C++ WebSocket bridge for UE-MCP, providing 1029+ editor actions over the MCP protocol",
 	"Category": "Developer Tools",

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // Does docs/tool-reference.md list every action the server actually advertises?
 //

--- a/scripts/audit-handler-conventions.mjs
+++ b/scripts/audit-handler-conventions.mjs
@@ -96,6 +96,32 @@ const NO_ROLLBACK_MARKERS = [
 ];
 
 /**
+ * Markers that say a handler CANNOT READ whether it changed anything, and said
+ * so.
+ *
+ * The same distinction as NO_ROLLBACK_MARKERS, one convention over. A handler
+ * that dispatches somebody else's code cannot measure its effect: epic(call_tool)
+ * runs a wrapped engine tool whose writes it never sees, and the Fab module
+ * publishes no authentication or library state this build can read back. An
+ * invented `unchanged: false` there would be a claim rather than a reading.
+ *
+ * This list exists because the spelling was ALREADY in the codebase, in three
+ * Fab handlers, written deliberately and explained in comments, and this audit
+ * recognised none of it and counted all three as omissions. That is the exact
+ * failure the NO_ROLLBACK_MARKERS comment above describes happening to
+ * `rollbackPossible`, repeated: an idiom spreading by copy while the audit
+ * scores it as debt, which makes the ledger wrong in the direction that costs
+ * somebody a day writing markers for handlers that already answered.
+ *
+ * `MCPSetIdempotencyUnobservable(Result, Reason)` in Public/HandlerUtils.h is
+ * the helper spelling, and it sets the flag and its note together so the pair
+ * cannot come apart. Both spellings are recognised because both exist.
+ */
+const NO_IDEMPOTENCY_MARKERS = [
+  "idempotencyObservable", "MCPSetIdempotencyUnobservable",
+];
+
+/**
  * Words that take a parenthesised head and a brace body without being a
  * function definition. Without these the definition scan below reads every
  * `if (...) {` as a function named `if`.
@@ -419,6 +445,7 @@ export function auditHandlers(classify) {
     // Only meaningful when no rollback is emitted, but recorded either way so
     // a handler that emits both can be spotted as the contradiction it is.
     const declaresNoRollback = found ? has(found.body, NO_ROLLBACK_MARKERS) : false;
+    const declaresNoIdempotency = found ? has(found.body, NO_IDEMPOTENCY_MARKERS) : false;
 
     rows.push({
       action,
@@ -432,6 +459,7 @@ export function auditHandlers(classify) {
       idempotent: idempotentDirect || Boolean(idempotentVia),
       rollback: rollbackDirect || Boolean(rollbackVia),
       declaresNoRollback,
+      declaresNoIdempotency,
       idempotentVia,
       rollbackVia,
     });

--- a/scripts/audit-handler-conventions.mjs
+++ b/scripts/audit-handler-conventions.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Convention audit over every registered C++ handler.
  *

--- a/scripts/audit-params.mjs
+++ b/scripts/audit-params.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // Do the parameters an action's description names match the ones its row in
 // docs/tool-reference.md names?

--- a/scripts/live-tier.mjs
+++ b/scripts/live-tier.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * The live test tier (#817, plan items 1.10 and 7.3).
  *

--- a/src/action-class.ts
+++ b/src/action-class.ts
@@ -310,6 +310,26 @@ const OVERRIDES: Readonly<Record<string, ActionClass>> = {
   // it can do.
   "gas.get_live_attribute_value": "mutate",
 
+  // ── Reads whose name leads with a subsystem, not a verb ─────────────
+  // The lexicon only trusts a read verb in the leading segment, so these say
+  // out loud what they read. Each one was confirmed against its handler: they
+  // open an asset, walk a graph or a document, and write nothing back.
+  "audio.metasound_get_graph": "read",
+  "audio.metasound_read_document": "read",
+  "audio.metasound_list_node_classes": "read",
+  "audio.metasound_list_node_pins": "read",
+  "audio.metasound_list_connections": "read",
+  "audio.metasound_list_variables": "read",
+  "audio.metasound_search_nodes": "read",
+  "audio.metasound_inspect_node": "read",
+  // Runs the MetaSound builder's own validation over a document and reports
+  // the errors. It builds nothing and saves nothing.
+  "audio.metasound_validate": "read",
+  "audio.cue_get_graph": "read",
+  // Answers whether a named weightmap layer is present on a landscape. The
+  // `exists` question never creates the layer it asks about.
+  "landscape.layer_exists": "read",
+
   // ── The workflow journal and the skill packs ────────────────────────
   // Neither reaches a bridge, so nothing here can land in the wrong EDITOR.
   // Both are still per project: the journal file is keyed by absolute project
@@ -355,7 +375,20 @@ export function classifyActionClass(tool: string, action: string): ActionClassif
 
   const segments = action.toLowerCase().split(/[._]/).filter(Boolean);
   if (segments.some((s) => MUTATE_VERBS.has(s))) return { class: "mutate", source: "lexicon" };
-  if (segments.some((s) => READ_VERBS.has(s))) return { class: "read", source: "lexicon" };
+  // A read verb only settles the question from the FRONT of the name. Anywhere
+  // else it is a noun as often as a verb, and the direction of that mistake is
+  // the dangerous one: `wire_rvt_sample` was a mutation that classified as a
+  // read on the strength of `sample`, and untargeted dispatch would have let it
+  // edit whichever editor happened to be active. It reached a human review
+  // rather than a release, and was renamed to `add_rvt_sampler`, which is a fix
+  // to one name and not to the rule that produced it.
+  //
+  // So a trailing read verb now decides nothing and falls through to
+  // `unresolved`, which is gated exactly like a mutation and which the drift
+  // guard fails on. The cost is an override line for every genuine read whose
+  // name leads with a subsystem instead of a verb; those are below, each saying
+  // what it reads. The alternative costs a silent wrong-editor write.
+  if (READ_VERBS.has(segments[0] ?? "")) return { class: "read", source: "lexicon" };
 
   // Epic's wrapped engine tools are injected at runtime from a live catalog, so
   // no build-time guard can enumerate them: enrichment can invent whole

--- a/src/action-class.ts
+++ b/src/action-class.ts
@@ -288,7 +288,13 @@ const OVERRIDES: Readonly<Record<string, ActionClass>> = {
   // terrain, but a file appearing on disk is an external side effect and the
   // taxonomy above counts that as a mutation.
   "landscape.export_heightmap": "mutate",
-  "audio.extract_pcm": "mutate",
+  // Not one of the exports above, despite sitting next to them here since it
+  // was written. It decodes a USoundWave's imported audio into memory and
+  // returns the samples base64-encoded in the response: no intermediate file,
+  // no path parameter to write one to, nothing dirtied and nothing saved. It
+  // was classified `mutate` by association with the file-writing exports, and
+  // the handler body settles it the other way.
+  "audio.extract_pcm": "read",
   // Rebuilds the full-text index in the editor's own database.
   "asset.reindex_fts": "mutate",
   // Loads, rewrites and saves the packages that reference a set of
@@ -309,6 +315,13 @@ const OVERRIDES: Readonly<Record<string, ActionClass>> = {
   // The verb says read; what it can do says mutate, and the gate follows what
   // it can do.
   "gas.get_live_attribute_value": "mutate",
+
+  // Runs an EQS query through FEnvQueryManager::RunInstantQuery against an
+  // already-spawned querier and serialises the scored items. `run` is a mutate
+  // verb and this one does not: no spawn, no Modify, no save, nothing written
+  // back to the query asset or the world. Landing it in the wrong editor
+  // returns the wrong scores and changes nothing.
+  "gameplay.run_eqs_query": "read",
 
   // ── Reads whose name leads with a subsystem, not a verb ─────────────
   // The lexicon only trusts a read verb in the leading segment, so these say

--- a/tests/ue_mcp/Source/ue_mcp.Target.cs
+++ b/tests/ue_mcp/Source/ue_mcp.Target.cs
@@ -6,8 +6,8 @@ public class ue_mcpTarget : TargetRules
 	public ue_mcpTarget(TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Game;
-		DefaultBuildSettings = BuildSettingsVersion.V7;
-		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_8;
+		DefaultBuildSettings = BuildSettingsVersion.Latest;
+		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 		ExtraModuleNames.Add("ue_mcp");
 	}
 }

--- a/tests/ue_mcp/Source/ue_mcpEditor.Target.cs
+++ b/tests/ue_mcp/Source/ue_mcpEditor.Target.cs
@@ -6,8 +6,8 @@ public class ue_mcpEditorTarget : TargetRules
 	public ue_mcpEditorTarget(TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Editor;
-		DefaultBuildSettings = BuildSettingsVersion.V7;
-		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_8;
+		DefaultBuildSettings = BuildSettingsVersion.Latest;
+		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 		ExtraModuleNames.Add("ue_mcp");
 	}
 }

--- a/tests/ue_mcp/ue_mcp.uproject
+++ b/tests/ue_mcp/ue_mcp.uproject
@@ -52,15 +52,18 @@
 		},
 		{
 			"Name": "ToolsetRegistry",
-			"Enabled": true
+			"Enabled": true,
+			"Optional": true
 		},
 		{
 			"Name": "ModelContextProtocol",
-			"Enabled": true
+			"Enabled": true,
+			"Optional": true
 		},
 		{
 			"Name": "AllToolsets",
-			"Enabled": true
+			"Enabled": true,
+			"Optional": true
 		},
 		{
 			"Name": "AnimationLocomotionLibrary",

--- a/tests/unit/action-class.test.ts
+++ b/tests/unit/action-class.test.ts
@@ -116,6 +116,39 @@ describe("action classification", () => {
     expect(requiresExplicitEditor(stranger.class)).toBe(true);
   });
 
+  it("does not let a trailing read verb turn a mutation into a read", () => {
+    // The case this rule was written from. `wire_rvt_sample` added a sampler
+    // node to a material and classified as a READ, because `sample` is a read
+    // verb and the old rule accepted one anywhere in the name. Untargeted
+    // dispatch would have let it edit whichever editor was active. It was
+    // caught by a person reading the name, not by anything here, and renamed
+    // to `add_rvt_sampler`, which fixed the name and not the rule.
+    //
+    // A read verb now counts only in the leading segment. Everything else
+    // falls to `unresolved`, which is gated like a mutation and which the
+    // drift guard at the top of this file fails on, so the next one is a CI
+    // failure asking for a decision rather than a wrong-editor write.
+    const trailing = classifyActionClass("material", "wire_rvt_sample");
+    expect(trailing).toEqual({ class: "unknown", source: "unresolved" });
+    expect(requiresExplicitEditor(trailing.class)).toBe(true);
+
+    // The shipped spelling leads with a mutate verb and is unambiguous.
+    expect(classifyActionClass("material", "add_rvt_sampler").class).toBe("mutate");
+
+    // A leading read verb still settles it with no override needed.
+    expect(classifyActionClass("material", "read_runtime_virtual_texture")).toEqual({
+      class: "read",
+      source: "lexicon",
+    });
+
+    // And the genuine reads whose names lead with a subsystem are decided by
+    // an override that says so, not by a verb the scanner happened to find.
+    expect(classifyActionClass("audio", "metasound_validate")).toEqual({
+      class: "read",
+      source: "override",
+    });
+  });
+
   it("does not require a target for the session-registry actions", () => {
     // These never reach a bridge: they name their subject in their own
     // parameters, so no routing decision can send them to the wrong editor.

--- a/tests/unit/handler-conventions.test.ts
+++ b/tests/unit/handler-conventions.test.ts
@@ -45,42 +45,30 @@ import { classifyActionClass } from "../../src/action-class.js";
  * what this file exists to stop.
  */
 const BASELINE = {
-  // Re-pinned from a real measurement, and the numbers moved a long way:
-  // 356 to 135 without a rollback, 129 to 21 without an idempotency marker.
-  // Almost none of that is exemption. It is three things.
+  // What a mutation owes its caller is an ANSWER, and two of these three counts
+  // are now zero because every mutation gives one. They are flat rules below,
+  // not ratchets: there is no debt left to ratchet down.
   //
-  // Most of it is the convention pass itself. Every category was swept and the
-  // mutations that had no inverse got one, or got an honest statement that
-  // they cannot have one.
+  // The journey is worth recording, because the numbers were quoted in review
+  // while none of them were being enforced. 356 and 129 were measured by a
+  // scanner that could not see a marker emitted inside a shared helper and
+  // collided two classes with the same method name. Fixing the scanner put the
+  // real figures at 135 and 21. Fixing the shebang that stopped this file from
+  // LOADING is what made any of it enforced at all.
   //
-  // Some of it is the audit getting STRICTER, which lowered a count only by
-  // making the rest of the sweep necessary. `has()` now strips C++ comments
-  // before matching. Every idempotency marker is a bare English word -
-  // "unchanged", "skipped", "nested" - so a rollbackNote explaining that a
-  // value was left unchanged used to earn the credit it was being audited for,
-  // and an adversarial audit found a handler drawing its ONLY credit from a
-  // comment. That is this file's own failure mode occurring inside this file.
-  //
-  // And some of it was never debt. `classifyActionClass` scans a whole action
-  // name for a mutating verb, because at the routing gate over-classifying
-  // costs an explicit target and nothing else. Reused here it demanded an
-  // inverse for `editor(get_frame_timing)` and nine other reads. A leading read
-  // verb now settles it; see READ_LED below.
-  //
-  // The rule is unchanged: if a number goes UP, a new handler skipped a
-  // convention. If it goes DOWN, lower it here and commit that. Never edit
-  // these to whatever makes the test pass.
-  mutationsWithoutRollback: 135,
-  // Re-measured: 21 -> 19. Two handlers picked up an idempotency marker since
-  // the last pin, and a baseline left at the old number is a ratchet with two
-  // teeth of slack in it, which is the same as no ratchet for the next two
-  // handlers that skip the convention.
-  mutationsWithoutIdempotency: 19,
-  // The count that matters most, and the one nothing measured before: a
-  // mutation that emits neither an inverse nor a reason there is none. The
-  // rest of the 135 above said out loud that they cannot be undone.
-  // Re-measured: 28 -> 26.
-  mutationsSilentOnRollback: 26,
+  // `mutationsWithoutRollback` stays a number rather than a rule, and stays
+  // non-zero, because a rollback is not always possible and pretending
+  // otherwise would mean emitting inverses that do not invert. What is not
+  // allowed is silence: see mutationsSilentOnRollback.
+  mutationsWithoutRollback: 127,
+  // Zero, and held there by a flat assertion. Every mutation with no inverse
+  // now says so in its own result body with the reason, which is the half a
+  // caller can act on.
+  mutationsSilentOnRollback: 0,
+  // Zero on the same terms. A handler that cannot read whether it changed
+  // anything says that too, through MCPSetIdempotencyUnobservable, rather than
+  // inventing an `unchanged` flag about somebody else's code.
+  mutationsWithoutIdempotency: 0,
   orphanedHandlers: 22,
 };
 
@@ -138,35 +126,18 @@ const KNOWN_ORPHANS: Record<string, string> = {
 };
 
 /**
- * Mutations with no meaningful inverse.
+ * There is no allowlist any more, and that is the point.
  *
- * Not every change can be undone by another call, and pretending otherwise
- * would mean emitting a rollback that does not roll anything back. Each entry
- * states why, and the list is short on purpose: "there is no inverse" is a
- * strong claim and almost always wrong.
+ * This file used to carry a `NO_INVERSE` map: four mutations exempted from the
+ * rollback rule with the reason written HERE, in the test, where no caller can
+ * read it. That was the right shape while the reasons had nowhere else to live,
+ * and the wrong shape once `MCPSetNoRollback` existed, because a caller holding
+ * the result body still could not tell a considered decision from an oversight.
+ *
+ * All four now state it in the handler, which is where the caller reads it, so
+ * the audit sees the statement and the exemption is redundant. An exemption
+ * list that outlives its reason is how a convention quietly stops applying.
  */
-const NO_INVERSE: Record<string, string> = {
-  cancel_editor_transaction:
-    "Discarding a transaction IS the undo. There is nothing to un-cancel: the "
-    + "objects were already restored and the transaction no longer exists.",
-  export_uv_layout:
-    "Writes a preview PNG to Saved/. An export produces an output artifact "
-    + "rather than project state, and deleting a file that regenerates on "
-    + "demand is not a meaningful undo. The same reasoning covers the six "
-    + "export_* actions that predate this one, all of which likewise emit no "
-    + "rollback; they belong to the deferred convention pass.",
-  add_smart_object_default_behavior:
-    "Appends an instanced behavior definition to a SmartObjectDefinition's "
-    + "DefaultBehaviorDefinitions. Nothing in this surface removes an entry "
-    + "from that array, exactly as for its per-slot twin "
-    + "add_smart_object_slot_behavior, which carries the same statement. The "
-    + "response says rollbackPossible=false and names the index it wrote.",
-  report_noise_event:
-    "Injects a one-shot stimulus into the running world. An AI either heard it "
-    + "or did not; there is no call that un-hears it. For the same reason it "
-    + "carries no idempotency marker: reporting the same noise twice is two "
-    + "events, not a repeated state change.",
-};
 
 /** bridge method -> the TS tool+action that reaches it. */
 function bridgeToAction(): Map<string, { tool: string; action: string }> {
@@ -184,6 +155,8 @@ type Row = {
   idempotent: boolean; rollback: boolean; bodyFound: boolean;
   /** True when the body emits `rollbackPossible`, i.e. it CONSIDERED the inverse. */
   declaresNoRollback: boolean;
+  /** True when the body emits `idempotencyObservable`, i.e. it cannot measure its own effect and said so. */
+  declaresNoIdempotency: boolean;
   /** The TS action name, which is what the read-verb test above reads. */
   tsAction?: string;
 };
@@ -282,18 +255,25 @@ describe("handler conventions", () => {
     ).toBe(0);
   });
 
-  it("only claims a mutation has no inverse when that is true", () => {
-    // An entry here that DOES emit a rollback is a stale claim, and a stale
-    // exemption is how a convention quietly stops applying.
-    const stale = Object.keys(NO_INVERSE).filter(
-      (action) => rows.find((r) => r.action === action)?.rollback,
-    );
-    expect(stale, `These now emit a rollback and should leave NO_INVERSE: ${stale.join(", ")}`).toEqual([]);
+  it("answers the rollback question in the result body, not in this file", () => {
+    // What the deleted NO_INVERSE allowlist used to assert, asked the right way
+    // round. The four handlers it exempted now carry their reason in the
+    // response, so the property to hold is that no mutation needs an exemption
+    // here at all: every one of them either emits an inverse or says why it
+    // cannot, and a caller can read the answer without reading this repo.
+    const unanswered = mutations
+      .filter((r) => !r.rollback && !r.declaresNoRollback)
+      .map((r) => r.action);
+    expect(
+      unanswered,
+      "A mutation must answer the rollback question in its own result body. There is no "
+        + "allowlist to add it to: emit MCPSetRollback, or MCPSetNoRollback with the reason.",
+    ).toEqual([]);
   });
 
   it("does not add a mutation without a rollback", () => {
     const without = mutations
-      .filter((r) => !r.rollback && !(r.action in NO_INVERSE))
+      .filter((r) => !r.rollback)
       .map((r) => r.action);
     expect(
       without.length,
@@ -316,7 +296,7 @@ describe("handler conventions", () => {
     // inverse, here is why" has finished the job, and one that says nothing has
     // not. This is the assertion nothing in the repo made.
     const silent = mutations
-      .filter((r) => !r.rollback && !r.declaresNoRollback && !(r.action in NO_INVERSE))
+      .filter((r) => !r.rollback && !r.declaresNoRollback)
       .map((r) => r.action);
     expect(
       silent.length,
@@ -329,12 +309,17 @@ describe("handler conventions", () => {
         `Offenders:`,
         ...silent.map((a) => `  ${a}`),
       ].join(String.fromCharCode(10)),
-    ).toBeLessThanOrEqual(BASELINE.mutationsSilentOnRollback);
+    ).toBe(BASELINE.mutationsSilentOnRollback);
   });
 
   it("does not add a mutation without an idempotency marker", () => {
+    // `declaresNoIdempotency` satisfies this the way `declaresNoRollback`
+    // satisfies the silence test above: a handler that CANNOT read whether it
+    // changed anything, and says so with the reason, has answered. The cases
+    // are handlers dispatching somebody else's code, where a fabricated
+    // `unchanged: false` would be a claim rather than a reading.
     const without = mutations
-      .filter((r) => !r.idempotent && !(r.action in NO_INVERSE))
+      .filter((r) => !r.idempotent && !r.declaresNoIdempotency)
       .map((r) => r.action);
     expect(
       without.length,
@@ -343,7 +328,7 @@ describe("handler conventions", () => {
         + `A mutation must report whether it actually changed anything, via MCPSetCreated /\n`
         + `MCPSetExisted / MCPSetUpdated or an explicit already* field, so a retry after a\n`
         + `timeout that in fact succeeded does not double-apply.`,
-    ).toBeLessThanOrEqual(BASELINE.mutationsWithoutIdempotency);
+    ).toBe(BASELINE.mutationsWithoutIdempotency);
   });
 
   it("does not add an unreachable handler", () => {

--- a/tests/unit/script-module-loadable.test.ts
+++ b/tests/unit/script-module-loadable.test.ts
@@ -1,0 +1,68 @@
+/**
+ * A script a test imports has to be importable.
+ *
+ * `scripts/*.mjs` files are dual-purpose: run as a CLI with `node scripts/x.mjs`,
+ * and imported by a test that asserts on what they compute. A `#!/usr/bin/env node`
+ * line is fine for the first job and fatal for the second, because Vite hands the
+ * file to the ESM loader without stripping it and the module fails to parse. The
+ * importing suite then fails to COLLECT, which reports zero assertions rather than
+ * a failure anyone reads as one.
+ *
+ * That is how the handler-conventions ratchet sat inert while its numbers were
+ * being quoted in reviews. The failure is silent in the specific way that matters:
+ * the suite is not red on an assertion, it is absent.
+ *
+ * So this checks the property directly rather than trusting a convention: every
+ * scripts/*.mjs any test imports is really imported here, which is the same thing
+ * the importing suite does and fails the same way if it ever stops working.
+ */
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const SCRIPTS = join(ROOT, "scripts");
+
+/** Every scripts/*.mjs named by an import in any test file. */
+function importedByTests(): string[] {
+  const named = new Set<string>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name === "ue_mcp") continue;
+        walk(path);
+        continue;
+      }
+      if (!entry.name.endsWith(".test.ts") && !entry.name.endsWith(".ts")) continue;
+      const source = readFileSync(path, "utf8");
+      for (const m of source.matchAll(/from\s+"[^"]*\/scripts\/([\w.-]+\.mjs)"/g)) named.add(m[1]);
+    }
+  };
+  walk(join(ROOT, "tests"));
+  return [...named].sort();
+}
+
+describe("scripts a test imports", () => {
+  const names = importedByTests();
+
+  it("finds the imports at all, so an empty pass cannot look like a green one", () => {
+    expect(names.length).toBeGreaterThan(0);
+  });
+
+  it("carries no shebang, which makes the module unparseable under Vite", () => {
+    const offenders = names.filter((n) => readFileSync(join(SCRIPTS, n), "utf8").startsWith("#!"));
+    expect(
+      offenders,
+      "These scripts are imported by a test and start with a shebang, so the importing suite "
+        + "will fail to collect and its assertions will not run:\n  " + offenders.join("\n  "),
+    ).toEqual([]);
+  });
+
+  it("imports cleanly", async () => {
+    for (const name of names) {
+      const url = new URL("file://" + join(SCRIPTS, name).replace(/\\/g, "/"));
+      await expect(import(/* @vite-ignore */ url.href), `${name} failed to import`).resolves.toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
Ships 1.3.1-beta.2. Nine commits, each one logical change. The draft release
v1.3.1-beta.2 is already staged with validated headline frontmatter, so merging
this is what publishes it.

## The finding that matters most

`tests/unit/handler-conventions.test.ts` imports its audit from a
`scripts/*.mjs` file that began with a shebang. Vite hands that to the ESM
loader without stripping the line, so the module never parsed and the suite
failed to LOAD rather than to assert. A suite that fails to collect contributes
no assertions and no red.

The ratchet guarding rollback coverage, idempotency and handler reachability
has therefore been reporting nothing, while its numbers were being quoted as
fact in review. Measured before the fix: 122 suites passed, 1552 tests passed,
one suite silently absent. Three sibling scripts carried the same line, and a
new test now imports every script a test names.

## What that gate was hiding

- 28 mutations emitted neither an inverse nor a statement that there is none.
  Now zero, held by a flat assertion rather than a ratchet.
- 21 mutations gave no answer about whether they had changed anything. Now
  zero, with `MCPSetIdempotencyUnobservable` added for the handlers that
  genuinely cannot measure their own effect because they dispatch somebody
  else's code.
- The `NO_INVERSE` allowlist is deleted. Its four entries stated their reasons
  inside the test file where no caller could read them; all four now state them
  in the response body.

Every inverse was checked by hand against the parameters the inverse handler
actually reads. Three handlers turned out not to be mutations at all, found by
reading rather than assumed.

## The engine range was false

The plugin advertised UE 5.4 to 5.8 and had only ever been compiled on 5.8. It
does not build on 5.7: eight engine APIs that arrived in 5.8 were called
unconditionally, and the test project could not even be configured below 5.8
because of two enum pins and three required 5.8-only Epic plugins.

All fixed. Now built clean on 5.7 and on 5.8 from one source tree. Where an
older engine genuinely cannot answer, the field is omitted and named rather
than defaulted, because an empty array where the engine cannot answer is the
same defect as a call that returns success and writes nothing.

`README.md` and `docs/getting-started.md` now separate the range the source is
gated for from the versions a compiler has actually seen. 5.4 to 5.6 stay
gated but unbuilt: those engines are not installed here.

## The dispatch classifier

A read verb anywhere in an action name made it a read, and reads are the one
class that need not name their editor. A trailing read verb now decides
nothing and falls through to `unresolved`, which is gated like a mutation.
Eleven genuine reads got explicit overrides, each confirmed against its handler
body.

## Verification

- 124 suites, 1566 unit tests, green.
- `npx tsc --noEmit` clean.
- 1090 actions compared, 0 parameter drifts, 0 unity collisions, 0 em dashes.
- UE 5.8: build succeeded. UE 5.7: build succeeded.
- Golden baselines unchanged.

Not done, and stated rather than quietly skipped: rollback CORRECTNESS is still
unproven. The audit is source-level and shows an inverse is emitted, never that
calling it restores anything. A live mutate-rollback-read test belongs in
`tests/live/`. See `plans/TODO.release.md`.
