### PR TITLE
chore(release): 1.3.1-beta.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ue-mcp",
-  "version": "1.3.1-beta.2",
+  "version": "1.3.1-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ue-mcp",
-      "version": "1.3.1-beta.2",
+      "version": "1.3.1-beta.3",
       "license": "MIT",
       "dependencies": {
         "@db-lyon/flowkit": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ue-mcp",
-  "version": "1.3.1-beta.2",
+  "version": "1.3.1-beta.3",
   "description": "Unreal Engine MCP server - 24 tools, 1090+ actions for AI-driven editor control",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
+++ b/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.3.1-beta.2",
+	"VersionName": "1.3.1-beta.3",
 	"FriendlyName": "UE MCP Bridge",
 	"Description": "C++ WebSocket bridge for UE-MCP, providing 1029+ editor actions over the MCP protocol",
 	"Category": "Developer Tools",


### PR DESCRIPTION
Cuts 1.3.1-beta.3 with the flowkit 0.17.1 compatibility fix (#1011, #1012).

Draft release for v1.3.1-beta.3 is staged with validated headline frontmatter. CI publishes on merge.

Verified before the bump:
- Combined tree (main + fix) compiles clean on UE 5.8: `Build succeeded`, UnrealEditor-UE_MCP_Bridge.dll relinked.
- `npm run test:unit`: 1569/1569 against the rebuilt plugin.
- `npm run test:live`: 215 passed, 6 skipped (param-echo leak assertions) against a live editor on tests/ue_mcp.
- `npm run audit:em-dash` clean.