### PR TITLE
fix(flow): take flowkit 0.17.2, which unwinds a nested inverse once

### DIFF
--- a/docs/flows.md
+++ b/docs/flows.md
@@ -357,7 +357,9 @@ A step carrying `ignore_failure: true` contributes its record on the same terms.
 
 A **nested** flow behaves the same way. Its records bubble to the parent, so arming rollback on the outer flow reaches a partial write made inside a child, and the child's own steps arrive on `steps[i].nestedSteps`, each reported exactly like a top-level step. The child's run error still carries the undo call in its text as well.
 
-Requires `@db-lyon/flowkit` 0.17.1 or newer. Up to 0.17.0 the runner harvested an inverse only from a step that succeeded, so a failing step's record was discarded on every run and `replayed` was always `false`.
+The outermost flow with rollback armed is the one that invokes the inverses, including the ones a child handed up. A child does not also unwind them itself: the parent holds the full reverse order, and running each inverse at both levels would undo state the first pass had already restored. A nested flow whose parents asked for no rollback still unwinds its own, so `rollback_on_failure` on a child flow means what it says.
+
+Requires `@db-lyon/flowkit` 0.17.2 or newer. 0.17.1 unwound a failed child's records at both levels. Up to 0.17.0 the runner harvested an inverse only from a step that succeeded, so a failing step's record was discarded on every run and `replayed` was always `false`.
 
 Conventions for handlers - natural keys, the `onConflict: skip|update|error` option, and rollback record shape - live in [docs/handler-conventions.md](handler-conventions.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.1-beta.3",
       "license": "MIT",
       "dependencies": {
-        "@db-lyon/flowkit": "^0.17.1",
+        "@db-lyon/flowkit": "^0.17.2",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "js-yaml": "^4.1.0",
         "ws": "^8.18.0",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@db-lyon/flowkit": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@db-lyon/flowkit/-/flowkit-0.17.1.tgz",
-      "integrity": "sha512-r2eUQnDtDT8+2Cz8H1+4GdwPNWQnq8WT0rz3jv2K/Re2aSmyO0SW9i0ZuUXzH73Amz2aTPUAOEhJPAw3Ft5dqQ==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@db-lyon/flowkit/-/flowkit-0.17.2.tgz",
+      "integrity": "sha512-7MQUZOGIPeZFuxnOqPqU2/sO2V4NGJJ1em/2OAvFfcGCQmDwPkL8c1Hb0d7IWfwR/TOTE4WF3Z+Ja5co0UvO9w==",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ue-mcp",
-  "version": "1.3.1-beta.3",
+  "version": "1.3.1-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ue-mcp",
-      "version": "1.3.1-beta.3",
+      "version": "1.3.1-beta.4",
       "license": "MIT",
       "dependencies": {
         "@db-lyon/flowkit": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@db-lyon/flowkit": "^0.17.1",
+    "@db-lyon/flowkit": "^0.17.2",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "js-yaml": "^4.1.0",
     "ws": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ue-mcp",
-  "version": "1.3.1-beta.3",
+  "version": "1.3.1-beta.4",
   "description": "Unreal Engine MCP server - 24 tools, 1090+ actions for AI-driven editor control",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
+++ b/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.3.1-beta.3",
+	"VersionName": "1.3.1-beta.4",
 	"FriendlyName": "UE MCP Bridge",
 	"Description": "C++ WebSocket bridge for UE-MCP, providing 1029+ editor actions over the MCP protocol",
 	"Category": "Developer Tools",

--- a/tests/unit/handler-failure-step.test.ts
+++ b/tests/unit/handler-failure-step.test.ts
@@ -464,6 +464,48 @@ describe("the inverse a FAILING step carries", () => {
     expect(body.steps[0].nestedSteps![0].partialWriteRollback!.replayed).toBe(true);
   });
 
+  it("runs a nested flow's inverse ONCE when the run arms rollback, not once per level", async () => {
+    // Regression for the double-undo. A child bubbles its records to the
+    // parent, and it also unwound them itself, so the same inverse ran twice
+    // against state the first pass had already restored. For the shipped
+    // handlers this class of record belongs to, that second pass is a repeat
+    // `bulk_rename_assets` or `delete_asset_batch`.
+    //
+    // The trigger is rollback_on_failure arriving as a RUN PARAM rather than in
+    // the flow YAML, because run options spread into every nested run. That is
+    // the documented way a caller arms it per-run, and it is what
+    // flow(action="run", rollback_on_failure=true) does. Fixed in flowkit
+    // 0.17.2: the outermost armed flow owns the unwind.
+    const bridge = fakeBridge({
+      touch_the_thing: { success: true, rollback: { method: "untouch_the_thing", payload: { id: 7 } } },
+      wipe_the_thing: PARTIAL,
+      untouch_the_thing: { success: true },
+      rename_asset: { success: true },
+    });
+    const body = await runFlow(probeTool(ACCEPTED), bridge, {
+      child: {
+        description: "the inner flow, which fails after a partial write",
+        steps: { "1": { task: "probe.wipe" } },
+      },
+      parent: {
+        description: "the outer flow",
+        steps: { "1": { task: "probe.touch" }, "2": { flow: "child" } },
+      },
+    }, "parent", { rollback_on_failure: true });
+
+    expect(body.success).toBe(false);
+    // Each inverse exactly once, and in the parent's reverse order: the child's
+    // undo leads, the step before it unwinds behind it.
+    expect(bridge.calls.map((c) => c.method)).toEqual([
+      "touch_the_thing",
+      "wipe_the_thing",
+      "rename_asset",
+      "untouch_the_thing",
+    ]);
+    expect(body.rollback).toMatchObject({ attempted: 2, succeeded: 2 });
+    expect(body.steps[1].nestedSteps![0].partialWriteRollback!.replayed).toBe(true);
+  });
+
   it("leaves a SUCCEEDING step's record alone: that one is replayed, not reported", async () => {
     const bridge = fakeBridge({
       touch_the_thing: { success: true, rollback: { method: "untouch_the_thing", payload: { id: 7 } } },


### PR DESCRIPTION
Fixes the nested double-undo that v1.3.1-beta.3 shipped as a known defect. Cuts 1.3.1-beta.4.

## The bug

A child flow bubbles its rollback records to the parent so one `rollback_on_failure` covers the tree. It also unwound them itself when it failed, and the parent then unwound the same records again on the nested step's failure. Each inverse ran twice against state the first pass had already restored. For the handlers this class of record belongs to, the second pass is a repeat `bulk_rename_assets` or `delete_asset_batch`.

The trigger is `rollback_on_failure` arriving as a run param rather than in the flow YAML, because run options spread into every nested run. That is what `flow(action="run", rollback_on_failure=true)` does, so the documented way to arm it per-run was the way to hit it. A YAML-only flag on the parent does not inherit, which is why this survived the suite.

Reproduced in flowkit's own tests before fixing: the call log was `create:outer, create:inner, remove:inner, remove:inner, remove:outer`.

## The fix

Upstream in db-lyon/flowkit#10, released as 0.17.2. The outermost armed flow owns the unwind, and it is also the only level holding the full reverse order, so a child's records interleave with the parent's steps instead of being unwound early. A nested flow whose ancestors asked for no rollback still unwinds its own. A hook flow always owns its own, since hook records are not bubbled.

Here: floor to `^0.17.2`, a regression test through the flow tool pinning each inverse to exactly one call in the parent's order, and `docs/flows.md` updated.

## Verification

- flowkit: 349 passed / 1 skipped, full CI matrix green on Ubuntu and Windows, Node 20 and 22.
- ue-mcp `npx tsc --noEmit` clean.
- ue-mcp `npm run test:unit`: 1570/1570.
- Em-dash audit clean.

The v1.3.1-beta.3 release notes have been corrected: the "Known, not fixed" section now points at this fix.