### PR TITLE
Fix the nudge result contract and refuse discovery on an unbuilt surface

### DIFF
--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Spatial.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/LevelHandlers_Spatial.cpp
@@ -404,15 +404,18 @@ TSharedPtr<FJsonValue> FLevelHandlers::NudgeComponent(const TSharedPtr<FJsonObje
 	Result->SetStringField(TEXT("world"), WorldScope);
 	Result->SetStringField(TEXT("worldName"), World->GetName());
 	Result->SetStringField(TEXT("worldPath"), World->GetPathName());
-	int32 ActualPieInstance = INDEX_NONE;
+	// Only a PIE world has an instance index. An editor world reported -1 here,
+	// which is a valid-looking instance number to anything reading the field.
 	if (GEngine)
 	{
 		if (const FWorldContext* WorldContext = GEngine->GetWorldContextFromWorld(World))
 		{
-			ActualPieInstance = WorldContext->PIEInstance;
+			if (WorldContext->WorldType == EWorldType::PIE)
+			{
+				Result->SetNumberField(TEXT("pieInstance"), WorldContext->PIEInstance);
+			}
 		}
 	}
-	Result->SetNumberField(TEXT("pieInstance"), ActualPieInstance);
 	Result->SetObjectField(TEXT("attachment"), Attachment);
 	Result->SetBoolField(TEXT("absoluteLocation"), Component->IsUsingAbsoluteLocation());
 	Result->SetBoolField(TEXT("absoluteRotation"), Component->IsUsingAbsoluteRotation());
@@ -424,7 +427,8 @@ TSharedPtr<FJsonValue> FLevelHandlers::NudgeComponent(const TSharedPtr<FJsonObje
 	if (bHasRotation)
 	{
 		Result->SetStringField(TEXT("rotationAxis"), RotationAxis);
-		Result->SetNumberField(TEXT("resolvedSignedDegrees"), RotationDegrees);
+		// Signed in the selected frame, whether the caller gave the sign as
+		// axisRotation.degrees or named a viewpoint and let this resolve it.
 		Result->SetNumberField(TEXT("rotationDegrees"), RotationDegrees);
 		Result->SetObjectField(TEXT("resolvedRotationAxisWorld"), MCPVec3ToJsonObject(RotationAxisWorld));
 		if (Params->HasField(TEXT("viewRotation")))
@@ -750,8 +754,8 @@ bool FLevelSpatialComponentNudgeTest::RunTest(const FString& Parameters)
 	TestTrue(TEXT("no-delta dry-run returns the current transform"), Inspection->HasField(TEXT("before")));
 	TestTrue(TEXT("no-delta dry-run reports absolute transform flags"),
 		Inspection->HasField(TEXT("absoluteLocation")) && Inspection->HasField(TEXT("absoluteRotation")) && Inspection->HasField(TEXT("absoluteScale")));
-	TestTrue(TEXT("no-delta dry-run reports exact world identity and PIE instance"),
-		Inspection->HasField(TEXT("worldPath")) && Inspection->HasField(TEXT("pieInstance")));
+	TestTrue(TEXT("no-delta dry-run reports exact world identity"), Inspection->HasField(TEXT("worldPath")));
+	TestFalse(TEXT("no-delta dry-run omits pieInstance for an editor world"), Inspection->HasField(TEXT("pieInstance")));
 	TestTrue(TEXT("no-delta dry-run does not change the relative transform"), Child->GetRelativeTransform().Equals(BeforeDryRun, 1.e-6));
 	TestEqual(TEXT("no-delta dry-run does not dirty its package"), TestWorldScope.GetPackage()->IsDirty(), bPackageDirtyBeforeDryRun);
 	if (Trans)

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,7 +377,18 @@ async function main() {
   const guardedBridge = primary.guarded;
   const getToolGraph = (forSession: EditorSession = primary): ToolDef[] => {
     const load = perSession.get(forSession);
-    return load ? load.surface.tools.filter((t) => !load.surface.disabled.has(t.name)) : [];
+    // D1 again. A session whose surface failed to build has no graph of its
+    // own, and answering from the union would name another project's actions.
+    // Returning nothing instead reads as "no action matched", which sends the
+    // caller to execute_python for something the editor does in fact provide.
+    if (!load) {
+      throw new McpError(
+        ErrorCode.NOT_FOUND,
+        `Editor '${forSession.name}' has no tool surface built, so its actions cannot be searched or described. `
+        + "Re-register it with project(add_editor); discovery does not fall back to another editor's graph.",
+      );
+    }
+    return load.surface.tools.filter((t) => !load.surface.disabled.has(t.name));
   };
   const ctx: ToolContext = {
     bridge: guardedBridge,


### PR DESCRIPTION
The three review nits from #1016, implemented rather than filed.

- **One signed angle.** `nudge_component` returned `resolvedSignedDegrees` and `rotationDegrees` holding the same number, so a caller had to guess which was the contract. One field remains.
- **No `pieInstance` outside PIE.** It came back as `-1` for an editor world, which reads as an instance number rather than "not applicable". Now set only when the world context is PIE, matching `capture_scene_png`'s metadata. The native test asserts its absence on the editor path.
- **Discovery refuses instead of returning nothing.** `getToolGraph` handed back an empty array for a session with no built surface, so `search_tools` answered zero results and `describe_action` said the action was unknown. Both read as "this editor does not provide that", which is what sends a caller to `execute_python` for something the editor does provide. It now names the editor and says the surface was never built.

Verified on UE 5.8.1 against tests/ue_mcp with the plugin rebuilt from this tree:

- Plugin build: succeeded
- `UE.MCP.Level.SpatialComponentNudge`: passed, including the new editor-world assertion
- Smoke: 1039 handlers, 1035 success, 0 failure, 4 skipped as unsafe to sweep
- Live tier: 220 passed, 0 failed, 6 skipped without the parameter echo
- Unit: 1579 passed
- Audits: em-dash, unity collisions, docs coverage, param drift clean