### PR TITLE
chore(release): 1.3.1-beta.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ue-mcp",
-  "version": "1.3.1-beta.5",
+  "version": "1.3.1-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ue-mcp",
-      "version": "1.3.1-beta.5",
+      "version": "1.3.1-beta.6",
       "license": "MIT",
       "dependencies": {
         "@db-lyon/flowkit": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ue-mcp",
-  "version": "1.3.1-beta.5",
+  "version": "1.3.1-beta.6",
   "description": "Unreal Engine MCP server - 24 tools, 1090+ actions for AI-driven editor control",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
+++ b/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.3.1-beta.5",
+	"VersionName": "1.3.1-beta.6",
 	"FriendlyName": "UE MCP Bridge",
 	"Description": "C++ WebSocket bridge for UE-MCP, providing 1029+ editor actions over the MCP protocol",
 	"Category": "Developer Tools",


### PR DESCRIPTION
Version bump. The draft release for v1.3.1-beta.6 is staged with validated headline frontmatter.

Verified on UE 5.8.1 against tests/ue_mcp with the plugin rebuilt from this tree: build succeeded, UE.MCP.Level.SpatialComponentNudge passed, smoke 1039 handlers 0 failures, live tier 220 passed, 1579 unit tests, all four audits clean.