### PR TITLE
chore(release): 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ue-mcp",
-  "version": "1.3.1-beta.6",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ue-mcp",
-      "version": "1.3.1-beta.6",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@db-lyon/flowkit": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ue-mcp",
-  "version": "1.3.1-beta.6",
+  "version": "1.3.1",
   "description": "Unreal Engine MCP server - 24 tools, 1090+ actions for AI-driven editor control",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
+++ b/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.3.1-beta.6",
+	"VersionName": "1.3.1",
 	"FriendlyName": "UE MCP Bridge",
 	"Description": "C++ WebSocket bridge for UE-MCP, providing 1029+ editor actions over the MCP protocol",
 	"Category": "Developer Tools",


### PR DESCRIPTION
Cuts the stable from the six 1.3.1 betas. Nothing landed after beta.6, so the release is the union of the prereleases with no new code.

The draft for v1.3.1 is staged as a full release with validated headline frontmatter, so it takes the Latest badge and the npm latest tag on merge.

Notes composed with `scripts/compose-release-notes.mjs`, then hand-edited where the composer flagged it: the summary paragraph it carried forward was written about beta.6, the six-item headline cap dropped every item from beta.4 onward, and a Follow-up section described a defect fixed inside this same release, which is now stated as a fix in Bug fixes.

Re-verified on UE 5.8.1 against tests/ue_mcp on this exact tree:

- Smoke: 1039 handlers, 1035 success, 0 failure, 4 skipped as unsafe to sweep
- Live tier: 220 passed, 0 failed, 6 skipped without the parameter echo
- Unit: 1579 passed
- Audits: em-dash, unity collisions, docs coverage, param drift clean