### PR TITLE
Fix the release notes format at the source

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## What changed
+
+<!-- One or two sentences. What this does, not why it is good. -->
+
+## Why
+
+<!-- The problem. Link the issue: Closes #NNN. Delete if the title says it. -->
+
+## Verification
+
+<!-- What you actually ran. Delete the lines you did not run; do not leave
+     one ticked that you skipped. Live rows need the editor on tests/ue_mcp. -->
+
+- [ ] `npx tsc --noEmit`
+- [ ] `npm run test:unit`
+- [ ] `npm run build` (required for any change under `plugin/`)
+- [ ] `npm run test:smoke`
+- [ ] `npm run test:live`
+- [ ] `npm run audit:em-dash` / `audit:unity` / docs / params
+
+## Notes for the release
+
+<!-- Optional. A line in the voice of the release notes, under the section it
+     belongs to. Saves rewriting it at release time.
+
+     ### Features   -> new actions and capabilities
+     ### Fixes      -> defects, one line each, in past tense
+     ### Mentions   -> breaking changes, deprecations, upgrade steps -->

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,46 @@
+<!--
+Release notes skeleton. `npm run release:notes` composes the merged body for a
+stable cut; this is the shape it produces and the shape a hand-written one takes.
+
+Read docs/release-notes-style.md before writing the opening paragraph.
+-->
+---
+headline:
+  - Three to six noun phrases
+  - 3 to 30 characters each
+  - No colons, semicolons, question or exclamation marks
+---
+
+## vX.Y.Z
+
+Unreal Engine 5.4 to 5.8.
+
+```bash
+npx ue-mcp@latest
+```
+
+<!-- One plain sentence of scale if there is one to give, e.g. "N new actions
+     across M categories." No thesis, no metaphor, no three-part list. -->
+
+## Features
+
+### <category> (N new actions)
+
+| Action | What it does |
+|---|---|
+| `action_name` | What it does, present tense. |
+
+## Fixes
+
+- Fixed <what was wrong>. (#NNN)
+
+## Mentions
+
+### Breaking changes
+
+| Change | What to do |
+|---|---|
+
+## Contributions
+
+Thanks to N contributors: [@handle](https://github.com/handle).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,14 @@ CI **gates the publish job** on a single pre-staged input: the draft GitHub rele
 
 4. **CI validates → publishes → promotes.** If the headline frontmatter is missing or malformed, the publish job fails with a pointer to the offending item *before* npm publish runs. On success, the published release page shows the body with frontmatter stripped, and the `landing/headline` commit status is posted automatically.
 
-Release notes structure (below the frontmatter): one-line summary, then `### Server` / `### Bug fixes` / `### Internals` sections. See prior releases on GitHub for the style. (The `docs/release-notes-*.md` files in the repo predate this flow and are kept as references only.)
+Release notes structure (below the frontmatter): **`## Features` / `## Fixes` / `## Mentions` / `## Contributions`**, in that order. Read `docs/release-notes-style.md` before writing any of it. The rules that get broken most:
+
+- **The engine range is 5.4 to 5.8.** Say the range. Never annotate it with which versions have been compiled, verified or gated. A user on 5.5 who hits a problem files an issue; that is the system working, not something to pre-empt in public copy.
+- **No thesis sentence, no three-part summary.** The opening is a compatibility line, an install block, and at most one plain sentence of scale. "N new actions across M categories, every X doing Y, and the Z now W" is a bulleted list flattened into prose.
+- **Cumulative, not archaeological.** A stable release never mentions its own betas or what an earlier release got wrong.
+- **Credit contributors** from `gh api repos/OWNER/REPO/compare/vPREV...vNEW --jq '.commits[].author.login'`, not from memory.
+
+`.github/RELEASE_TEMPLATE.md` is the skeleton, `.github/PULL_REQUEST_TEMPLATE.md` collects the notes line per PR. (The `docs/release-notes-*.md` files in the repo predate this flow and are kept as references only.)
 
 ### Prereleases
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Details: [Guards](https://ue-mcp.com/docs/plugins-guards/) and [Handler Conventi
 
 | | |
 |---|---|
-| **Unreal Engine** | 5.4-5.8 (Windows), 5.6+ (Linux and macOS). Compiled and verified on 5.7 and 5.8; 5.4 to 5.6 are version-gated in source but not built here. `epic` category needs 5.8+. |
+| **Unreal Engine** | 5.4-5.8 (Windows), 5.6+ (Linux and macOS). `epic` category needs 5.8+. |
 | **Node.js** | 18 or newer |
 | **UE plugins** | `PythonScriptPlugin` (ships with the engine); `init` enables the rest for you |
 | **C++ toolchain** | Required - the bridge is a C++ plugin and compiles on first editor launch. On Windows that means Visual Studio with the C++ workload; on macOS, Xcode command line tools. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ UE-MCP lets you tell an AI assistant what you want done in Unreal. It can place 
 
 ## Prerequisites
 
-1. Install [**Unreal Engine 5.4 to 5.8**](https://www.unrealengine.com/en-US/download "Free download via the Epic Games Launcher.") (the plugin is compiled and verified on 5.7 and 5.8; older versions are version-gated in source but not built)
+1. Install [**Unreal Engine 5.4 to 5.8**](https://www.unrealengine.com/en-US/download "Free download via the Epic Games Launcher.")
 2. Install [**Node.js 18 or newer**](https://nodejs.org/ "JavaScript runtime that UE-MCP needs to run.")
 3. Install an MCP-capable AI client (e.g. [**Claude Code**](https://docs.anthropic.com/en/docs/claude-code "Anthropic's official CLI agent."))
 

--- a/docs/release-notes-style.md
+++ b/docs/release-notes-style.md
@@ -20,6 +20,11 @@ buckets by heading, so a section a late beta introduced cannot print after the
 internals. `classifySection` is the rule; extend its patterns rather than
 hand-sorting a composed body.
 
+Feature sections of twelve lines or more render inside a `<details>` block with
+the category name in the summary, so the fixes and the breaking changes stay
+above the fold instead of below four hundred lines of tables. Short sections
+stay open, and fixes and mentions are never collapsed.
+
 ## The opening
 
 A compatibility line, an install block, and at most one plain sentence of scale.

--- a/docs/release-notes-style.md
+++ b/docs/release-notes-style.md
@@ -1,0 +1,92 @@
+# Release notes style
+
+The format is copied from projects that publish a lot of releases: Deno, Zed,
+Bun, Godot, and Epic's own Unreal Engine notes. Follow it rather than inventing
+a voice per release.
+
+## Structure
+
+Four top-level sections, in this order. Omit one only when it is empty.
+
+| Section | Holds |
+|---|---|
+| `## Features` | New actions and capabilities, grouped by category the way Unreal groups by subsystem |
+| `## Fixes` | Defects that were repaired |
+| `## Mentions` | Breaking changes, deprecations, upgrade steps, internals worth knowing |
+| `## Contributions` | Thanks, with GitHub handles |
+
+`scripts/compose-release-notes.mjs` files merged prerelease sections into these
+buckets by heading, so a section a late beta introduced cannot print after the
+internals. `classifySection` is the rule; extend its patterns rather than
+hand-sorting a composed body.
+
+## The opening
+
+A compatibility line, an install block, and at most one plain sentence of scale.
+
+```markdown
+## v1.3.1
+
+Unreal Engine 5.4 to 5.8.
+
+npx ue-mcp@latest
+
+259 new actions across 16 categories.
+```
+
+**The engine range is 5.4 to 5.8.** State it. Do not annotate it with which
+versions have been compiled, verified, gated or built. Someone on 5.5 who hits
+a problem will file an issue, which is the system working. Hedging the range in
+public copy reads as a warning about our own product.
+
+## Writing the entries
+
+- Present tense for a feature, past tense for a fix. "Adds X." / "Fixed Y."
+- One line each. The detail belongs in the linked docs or the PR.
+- Cite the issue or PR number where there is one.
+- Name the action or the parameter. `set_height_region`, not "the new heightmap write".
+
+## What not to write
+
+**No thesis sentence.** Not "The bridge stopped being one-way", not "Two
+guarantees nothing had ever checked". Release notes are a list of what changed.
+No human opens a release page for a framing device.
+
+**No three-part lists as a summary.** "N new actions across M categories, every
+X doing Y, and the Z now W" is a bulleted list flattened into a sentence. It
+asserts nothing and buries whatever was interesting. If three facts matter, they
+are three bullets under a section.
+
+**No editorialising the value.** Say what shipped. The reader decides whether it
+is significant.
+
+**No archaeology.** Do not narrate that something used to be broken, which beta
+fixed it, or what a previous release got wrong. State the current behaviour.
+A stable release is cumulative: the betas are invisible to anyone reading it.
+
+**No competitor or comparison projects.** Ever, in any public artifact.
+
+**No em dashes.** Hyphens, colons, parentheses, or two sentences.
+
+## Headline frontmatter
+
+CI parses it and posts `landing/headline`. Three to six items, 3 to 30
+characters each, letters/digits/spaces and `_ - / ( ) . , +` only. No colons,
+semicolons, question marks, exclamation marks or the joiner. Joined length
+must stay under 140 characters.
+
+Pick the items that represent the whole release. For a stable cut composed from
+prereleases the union is usually over the six-item cap, and the composer keeps
+the first six it saw, which favours the earliest beta. Reread the dropped list
+it prints and swap deliberately.
+
+## Contributions
+
+Take the handles from the commit range, not from memory:
+
+```bash
+gh api repos/OWNER/REPO/compare/vPREV...vNEW --jq '.commits[].author.login' | sort -u
+```
+
+Credit anyone outside the maintainers who landed a PR. The composer generates
+this section when it is given contributors.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
   - Spatial Instructions: spatial-instructions.md
   - Native Tools: native-tools.md
   - Handler Conventions: handler-conventions.md
+  - Release Notes Style: release-notes-style.md
   - Widgets:
     - widgets.md
     - Parameter Contract: widget-parameters.md

--- a/scripts/compose-release-notes.mjs
+++ b/scripts/compose-release-notes.mjs
@@ -440,6 +440,28 @@ export function classifySection(heading) {
   return "Features";
 }
 
+/**
+ * A section long enough that leaving it open buries what follows it. Twelve
+ * lines is about a screen of table once GitHub has rendered it.
+ */
+export const COLLAPSE_MIN_LINES = 12;
+
+/**
+ * One section, collapsed behind a disclosure when it is allowed to be and long
+ * enough to be worth it. GitHub renders markdown inside `<details>` only when a
+ * blank line follows the summary, so the blanks here are load-bearing.
+ */
+export function renderSection(section, collapsible) {
+  const inner = [];
+  if (section.lead) inner.push(section.lead, "");
+  for (const bullet of section.bullets) inner.push(bullet);
+  const body = inner.join("\n").trim();
+  if (!collapsible || body.split("\n").length < COLLAPSE_MIN_LINES) {
+    return [`### ${section.heading}`, "", body, ""];
+  }
+  return ["<details>", `<summary><b>${section.heading}</b></summary>`, "", body, "", "</details>", ""];
+}
+
 /** The thanks line, in the shape every large repo writes it. */
 export function renderContributions(logins) {
   const unique = [...new Set((logins ?? []).filter(Boolean))];
@@ -466,12 +488,10 @@ export function renderBody({ version, headline, preamble, sections, contributors
     const inSection = grouped.get(name);
     if (inSection.length === 0) continue;
     out.push(`## ${name}`, "");
-    for (const section of inSection) {
-      out.push(`### ${section.heading}`, "");
-      if (section.lead) out.push(section.lead, "");
-      for (const bullet of section.bullets) out.push(bullet);
-      out.push("");
-    }
+    // Features carry the per-category action tables, which are most of the
+    // body's length and the least of its reading. Fixes and mentions stay
+    // open: they are short, and they are what a reader came to scan.
+    for (const section of inSection) out.push(...renderSection(section, name === "Features"));
   }
 
   if ((contributors ?? []).length > 0) {

--- a/scripts/compose-release-notes.mjs
+++ b/scripts/compose-release-notes.mjs
@@ -417,18 +417,65 @@ export function hasSummary(preamble) {
     .some((l) => l.trim() !== "");
 }
 
+/**
+ * The four top-level sections a release body is made of, in reading order.
+ * Merged prerelease sections land under one of them by heading, so a section
+ * a late beta introduced cannot end up printed after the internals.
+ */
+export const TOP_SECTIONS = ["Features", "Fixes", "Mentions", "Contributions"];
+
+const FIX_HEADING = /\b(fix|fixes|bug|bugs|regression|correctness|stability|crash|dialog)/i;
+const MENTION_HEADING =
+  /\b(breaking|internal|internals|deprecat|upgrade|migration|known|engine range|follow-up)/i;
+
+/**
+ * Which top-level section a merged heading belongs under. Fixes are tested
+ * first so "Bug fixes" does not read as a mention, and anything unrecognised
+ * is a feature, because that is what a new category section is.
+ */
+export function classifySection(heading) {
+  const h = String(heading ?? "");
+  if (FIX_HEADING.test(h)) return "Fixes";
+  if (MENTION_HEADING.test(h)) return "Mentions";
+  return "Features";
+}
+
+/** The thanks line, in the shape every large repo writes it. */
+export function renderContributions(logins) {
+  const unique = [...new Set((logins ?? []).filter(Boolean))];
+  const links = unique.map((l) => `[@${l}](https://github.com/${l})`);
+  const noun = unique.length === 1 ? "contributor" : "contributors";
+  return `Thanks to ${unique.length} ${noun}: ${links.join(", ")}.`;
+}
+
 /** Renders the composed notes file, frontmatter first. */
-export function renderBody({ version, headline, preamble, sections }) {
+export function renderBody({ version, headline, preamble, sections, contributors = [] }) {
   const out = ["---", "headline:"];
   for (const item of headline) out.push(`  - ${item}`);
   out.push("---", "");
   out.push(retitle(preamble, version), "");
+
+  const grouped = new Map(TOP_SECTIONS.map((name) => [name, []]));
   for (const section of sections) {
     if (!section.lead && section.bullets.length === 0) continue;
-    out.push(`### ${section.heading}`, "");
-    if (section.lead) out.push(section.lead, "");
-    for (const bullet of section.bullets) out.push(bullet);
-    out.push("");
+    grouped.get(classifySection(section.heading)).push(section);
+  }
+
+  for (const name of TOP_SECTIONS) {
+    if (name === "Contributions") continue;
+    const inSection = grouped.get(name);
+    if (inSection.length === 0) continue;
+    out.push(`## ${name}`, "");
+    for (const section of inSection) {
+      out.push(`### ${section.heading}`, "");
+      if (section.lead) out.push(section.lead, "");
+      for (const bullet of section.bullets) out.push(bullet);
+      out.push("");
+    }
+  }
+
+  if ((contributors ?? []).length > 0) {
+    out.push("## Contributions", "", renderContributions(contributors), "");
   }
   return `${out.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd()}\n`;
 }
@@ -447,7 +494,7 @@ export function renderBody({ version, headline, preamble, sections }) {
  * With no prereleases there is nothing to accumulate, so the local file is the
  * answer as written and is returned unchanged.
  */
-export function composeReleaseNotes({ version, prereleases = [], localNotes = null }) {
+export function composeReleaseNotes({ version, prereleases = [], localNotes = null, contributors = [] }) {
   parseVersion(version);
   if (parseVersion(version).prerelease !== null) {
     throw new ComposeError(
@@ -480,16 +527,16 @@ export function composeReleaseNotes({ version, prereleases = [], localNotes = nu
 
   const { sections, duplicates } = mergeBodies(inputs);
 
-  // The summary belongs to the release being cut, so a local file's summary
-  // wins. Falling back to the newest prerelease keeps a body that reads, but
-  // that text was written about a beta and wants a human eye.
+  // The summary belongs to the release being cut. A local file's summary wins.
+  // Inheriting the newest prerelease's used to keep the body reading, but that
+  // text was written about one beta and describes it, so a stable cut carried a
+  // sentence about three fixes over a release with hundreds of changes. With no
+  // local summary the heading stands alone and the run says so.
   const localPreamble = localBody === null ? "" : parseSections(localBody).preamble;
   const newest = prereleases[prereleases.length - 1];
   const usingLocal = hasSummary(localPreamble);
-  const preamble = usingLocal
-    ? localPreamble
-    : parseSections(stripFrontmatter(newest.body)).preamble;
-  const preambleFrom = usingLocal ? "local notes" : newest.tag;
+  const preamble = usingLocal ? localPreamble : `## v${version}`;
+  const preambleFrom = usingLocal ? "local notes" : null;
 
   const headline = mergeHeadlines([
     ...prereleases.map((r) => r.headline ?? []),
@@ -502,7 +549,7 @@ export function composeReleaseNotes({ version, prereleases = [], localNotes = nu
     );
   }
 
-  const body = renderBody({ version, headline: headline.items, preamble, sections });
+  const body = renderBody({ version, headline: headline.items, preamble, sections, contributors });
   validateBody(body);
   return {
     body,
@@ -511,6 +558,7 @@ export function composeReleaseNotes({ version, prereleases = [], localNotes = nu
     duplicates,
     headline,
     preambleFrom,
+    contributors,
     newestTag: newest.tag,
   };
 }
@@ -582,6 +630,52 @@ function currentRepo(run = gh) {
   return JSON.parse(run(["repo", "view", "--json", "nameWithOwner"])).nameWithOwner;
 }
 
+/**
+ * GitHub logins that landed a commit between two tags, maintainers dropped.
+ *
+ * Reads the compare API rather than `git log`, because a release credits
+ * handles and a commit only carries an email. A tag that does not exist yet,
+ * or an API that will not answer, yields nobody rather than failing the cut.
+ */
+export function contributorsBetween(repo, base, head, { exclude = [], run = gh } = {}) {
+  let payload;
+  try {
+    payload = JSON.parse(run(["api", `repos/${repo}/compare/${base}...${head}`, "--paginate"]));
+  } catch {
+    return [];
+  }
+  const skip = new Set(exclude.map((s) => String(s).toLowerCase()));
+  const seen = [];
+  for (const commit of payload.commits ?? []) {
+    const login = commit?.author?.login;
+    if (!login || skip.has(login.toLowerCase())) continue;
+    if (!seen.some((l) => l.toLowerCase() === login.toLowerCase())) seen.push(login);
+  }
+  return seen;
+}
+
+/** The stable release immediately before `version`, or null when it is the first. */
+export function previousStableTag(repo, version, run = gh) {
+  const listed = JSON.parse(
+    run(["release", "list", "--repo", repo, "--limit", "200", "--json", "tagName,isDraft"])
+  );
+  const stables = listed
+    .filter((r) => !r.isDraft)
+    .map((r) => r.tagName)
+    .map((tag) => {
+      try {
+        const v = versionOfTag(tag);
+        return parseVersion(v).prerelease === null ? { tag, v } : null;
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean)
+    .filter((e) => compareVersions(e.v, version) < 0)
+    .sort((a, b) => compareVersions(a.v, b.v));
+  return stables.length ? stables[stables.length - 1].tag : null;
+}
+
 /* ------------------------------------------------------------------ *
  * CLI
  * ------------------------------------------------------------------ */
@@ -618,7 +712,13 @@ function main() {
     const slug = repo ?? currentRepo();
     const prereleases = fetchPrereleases(slug, version);
     const localNotes = notesFile === null ? null : fs.readFileSync(notesFile, "utf8");
-    const result = composeReleaseNotes({ version, prereleases, localNotes });
+    // Handles come from the commit range, so the section cannot be written
+    // from memory and cannot quietly omit somebody who landed a PR.
+    const previous = previousStableTag(slug, version);
+    const contributors = previous
+      ? contributorsBetween(slug, previous, "HEAD", { exclude: [slug.split("/")[0]] })
+      : [];
+    const result = composeReleaseNotes({ version, prereleases, localNotes, contributors });
 
     const target =
       out ??
@@ -666,9 +766,15 @@ function report(version, notesFile, target, result) {
     }
     if (result.preambleFrom !== "local notes") {
       console.log(
-        `  Summary paragraph came from ${result.preambleFrom}; reread it, it was written about a prerelease.`
+        "  No summary written. The body opens on its version heading alone; " +
+          "pass --notes-file with an opening paragraph to give it one."
       );
     }
+    console.log(
+      result.contributors.length
+        ? `  Contributors: ${result.contributors.map((c) => `@${c}`).join(", ")}`
+        : "  Contributors: none found in the range."
+    );
   }
   console.log(`NOTES_PATH=${target}`);
 }

--- a/tests/unit/compose-release-notes.test.ts
+++ b/tests/unit/compose-release-notes.test.ts
@@ -13,7 +13,12 @@ import {
   parseBullets,
   parseSections,
   prereleaseTagsFor,
+  contributorsBetween,
+  previousStableTag,
+  renderContributions,
   retitle,
+  classifySection,
+  TOP_SECTIONS,
 } from "../../scripts/compose-release-notes.mjs";
 import { processBody } from "../../scripts/release-headline.mjs";
 
@@ -334,8 +339,11 @@ describe("composeReleaseNotes", () => {
     expect(strippedBody).not.toContain("v1.2.0-beta");
     expect(strippedBody).toContain("The stable summary.");
 
+    const tops = [...strippedBody.matchAll(/^## (.+)$/gm)].map((m) => m[1]);
+    expect(tops).toEqual(["v1.2.0", "Features", "Fixes", "Mentions"]);
     const headings = [...strippedBody.matchAll(/^### (.+)$/gm)].map((m) => m[1]);
-    expect(headings).toEqual(["Multi-editor", "Bug fixes", "Internals", "Server"]);
+    // Grouped, not in merge order: the features lead, the internals trail.
+    expect(headings).toEqual(["Multi-editor", "Server", "Bug fixes", "Internals"]);
 
     // The reworded #820 bullet collapsed to the longer variant.
     expect(strippedBody).toContain("the stored count is verified (#820)");
@@ -343,10 +351,12 @@ describe("composeReleaseNotes", () => {
     expect(result.duplicates).toHaveLength(1);
   });
 
-  it("falls back to the newest prerelease summary and says so", () => {
+  it("writes no summary rather than inheriting a beta's", () => {
     const result = composeReleaseNotes({ version: "1.2.0", prereleases: [BETA, BETA2] });
-    expect(result.preambleFrom).toBe("v1.2.0-beta.2");
-    expect(processBody(result.body).strippedBody).toContain("The second beta summary.");
+    expect(result.preambleFrom).toBeNull();
+    const { strippedBody } = processBody(result.body);
+    expect(strippedBody).not.toContain("The second beta summary.");
+    expect(strippedBody).toContain("## v1.2.0");
   });
 
   it("passes a stable release with no prereleases straight through", () => {
@@ -435,5 +445,148 @@ describe("GitHub reads", () => {
     const found = fetchPrereleases("db-lyon/ue-mcp", "1.2.0", fakeGh({}));
     expect(found.map((r) => r.tag)).toEqual(["v1.2.0-beta.2", "v1.2.0-beta.10"]);
     expect(found[0].body).toBe("body of v1.2.0-beta.2");
+  });
+});
+
+describe("top-level section grouping", () => {
+  it("files a heading under features, fixes or mentions", () => {
+    expect(classifySection("landscape (20 new)")).toBe("Features");
+    expect(classifySection("Server")).toBe("Features");
+    expect(classifySection("Across every action")).toBe("Features");
+    expect(classifySection("Bug fixes")).toBe("Fixes");
+    expect(classifySection("Editor stability")).toBe("Fixes");
+    expect(classifySection("Correctness")).toBe("Fixes");
+    expect(classifySection("Breaking changes")).toBe("Mentions");
+    expect(classifySection("Internals")).toBe("Mentions");
+    expect(classifySection("The engine range")).toBe("Mentions");
+  });
+
+  it("reads 'Bug fixes' as a fix rather than a mention", () => {
+    // Both patterns could claim it; fixes are tested first on purpose.
+    expect(classifySection("Bug fixes")).toBe("Fixes");
+  });
+
+  it("prints features before fixes before mentions, whatever order they merged in", () => {
+    // The shape that broke v1.3.1: a late beta introduced a feature section, so
+    // merge order printed it after the internals of an earlier one.
+    const { body } = composeReleaseNotes({
+      version: "9.9.9",
+      prereleases: [
+        release("v9.9.9-beta.1", "## v9.9.9-beta.1\n\n### Internals\n\n- Groundwork.\n", ["First"]),
+        release("v9.9.9-beta.2", "## v9.9.9-beta.2\n\n### Server\n\n- A new action.\n", ["Second"]),
+      ],
+    });
+    const features = body.indexOf("## Features");
+    const mentions = body.indexOf("## Mentions");
+    expect(features).toBeGreaterThan(-1);
+    expect(mentions).toBeGreaterThan(-1);
+    expect(features).toBeLessThan(mentions);
+    expect(body.indexOf("### Server")).toBeLessThan(body.indexOf("### Internals"));
+    expect(TOP_SECTIONS).toEqual(["Features", "Fixes", "Mentions", "Contributions"]);
+  });
+});
+
+describe("the stable summary", () => {
+  it("never inherits the newest prerelease's summary", () => {
+    // v1.3.1 shipped "Three contract fixes ..." over a release of hundreds of
+    // changes, because the last beta's paragraph was carried forward.
+    const { body, preambleFrom } = composeReleaseNotes({
+      version: "9.9.9",
+      prereleases: [
+        release("v9.9.9-beta.1", "## v9.9.9-beta.1\n\nThree contract fixes.\n\n### Server\n\n- A.\n", ["First"]),
+      ],
+    });
+    expect(body).not.toContain("Three contract fixes");
+    expect(preambleFrom).toBeNull();
+    expect(body).toContain("## v9.9.9");
+  });
+
+  it("keeps a summary the local notes file supplies", () => {
+    const { body, preambleFrom } = composeReleaseNotes({
+      version: "9.9.9",
+      prereleases: [release("v9.9.9-beta.1", "## v9.9.9-beta.1\n\nBeta prose.\n\n### Server\n\n- A.\n", ["First"])],
+      localNotes: "## v9.9.9\n\nUnreal Engine 5.4 to 5.8.\n\n### Server\n\n- B.\n",
+    });
+    expect(body).toContain("Unreal Engine 5.4 to 5.8.");
+    expect(body).not.toContain("Beta prose");
+    expect(preambleFrom).toBe("local notes");
+  });
+});
+
+describe("contributions", () => {
+  it("names each contributor once, linked, with a counted noun", () => {
+    expect(renderContributions(["alexkenley"])).toBe(
+      "Thanks to 1 contributor: [@alexkenley](https://github.com/alexkenley).",
+    );
+    expect(renderContributions(["a", "b", "a"])).toBe(
+      "Thanks to 2 contributors: [@a](https://github.com/a), [@b](https://github.com/b).",
+    );
+  });
+
+  it("emits the section only when there are contributors", () => {
+    const withNone = composeReleaseNotes({
+      version: "9.9.9",
+      prereleases: [release("v9.9.9-beta.1", "## v9.9.9-beta.1\n\n### Server\n\n- A.\n", ["First"])],
+    });
+    expect(withNone.body).not.toContain("## Contributions");
+
+    const withOne = composeReleaseNotes({
+      version: "9.9.9",
+      prereleases: [release("v9.9.9-beta.1", "## v9.9.9-beta.1\n\n### Server\n\n- A.\n", ["First"])],
+      contributors: ["alexkenley"],
+    });
+    expect(withOne.body).toContain("## Contributions");
+    expect(withOne.body).toContain("[@alexkenley](https://github.com/alexkenley)");
+    // Last section in the body, per the documented order.
+    expect(withOne.body.trimEnd().indexOf("## Contributions")).toBeGreaterThan(
+      withOne.body.indexOf("## Features"),
+    );
+  });
+});
+
+describe("reading contributors off the range", () => {
+  const gh = (args: string[]) => {
+    if (args[0] === "release" && args[1] === "list") {
+      return JSON.stringify([
+        { tagName: "v1.3.0", isDraft: false },
+        { tagName: "v1.2.4", isDraft: false },
+        { tagName: "v1.3.1-beta.1", isDraft: false },
+        { tagName: "v9.0.0", isDraft: false },
+        { tagName: "v1.3.1", isDraft: true },
+      ]);
+    }
+    if (args[0] === "api") {
+      return JSON.stringify({
+        commits: [
+          { author: { login: "alexkenley" } },
+          { author: { login: "bing" } },
+          { author: { login: "AlexKenley" } },
+          { author: null },
+        ],
+      });
+    }
+    throw new Error(`unexpected gh ${args.join(" ")}`);
+  };
+
+  it("picks the newest stable below the version, ignoring prereleases and drafts", () => {
+    expect(previousStableTag("o/r", "1.3.1", gh)).toBe("v1.3.0");
+  });
+
+  it("returns null when nothing stable precedes it", () => {
+    const only = () => JSON.stringify([{ tagName: "v2.0.0", isDraft: false }]);
+    expect(previousStableTag("o/r", "1.0.0", only)).toBeNull();
+  });
+
+  it("dedupes case-insensitively, drops maintainers, and skips authorless commits", () => {
+    expect(contributorsBetween("o/r", "v1.3.0", "HEAD", { exclude: ["bing"], run: gh })).toEqual([
+      "alexkenley",
+    ]);
+  });
+
+  it("yields nobody rather than failing the cut when the API will not answer", () => {
+    const boom = () => {
+      throw new Error("network");
+    };
+    expect(contributorsBetween("o/r", "a", "b", { run: boom })).toEqual([]);
   });
 });

--- a/tests/unit/compose-release-notes.test.ts
+++ b/tests/unit/compose-release-notes.test.ts
@@ -15,6 +15,8 @@ import {
   prereleaseTagsFor,
   contributorsBetween,
   previousStableTag,
+  renderSection,
+  COLLAPSE_MIN_LINES,
   renderContributions,
   retitle,
   classifySection,
@@ -588,5 +590,54 @@ describe("reading contributors off the range", () => {
       throw new Error("network");
     };
     expect(contributorsBetween("o/r", "a", "b", { run: boom })).toEqual([]);
+  });
+});
+
+
+describe("collapsing the long feature tables", () => {
+  const rows = Array.from({ length: 20 }, (_, i) => `| a${i} | does a thing |`);
+  const long = { heading: "landscape (20 new)", lead: "", bullets: rows };
+  const short = { heading: "reflection (1 new)", lead: "", bullets: ["| x | one |"] };
+
+  it("puts a long feature section behind a disclosure, keeping its name visible", () => {
+    const out = renderSection(long, true);
+    expect(out[0]).toBe("<details>");
+    expect(out[1]).toBe("<summary><b>landscape (20 new)</b></summary>");
+    // GitHub renders markdown inside details only when a blank line follows
+    // the summary, so this one is load-bearing rather than cosmetic.
+    expect(out[2]).toBe("");
+    expect(out.at(-2)).toBe("</details>");
+  });
+
+  it("leaves a short section open, because collapsing it saves nothing", () => {
+    expect(renderSection(short, true)[0]).toBe("### reflection (1 new)");
+    expect(rows.length).toBeGreaterThanOrEqual(COLLAPSE_MIN_LINES);
+  });
+
+  it("never collapses fixes or mentions", () => {
+    expect(renderSection(long, false)[0]).toBe("### landscape (20 new)");
+  });
+
+  it("collapses inside Features and leaves the rest open end to end", () => {
+    const beta = [
+      "## v9.9.9-beta.1",
+      "",
+      "### landscape (20 new)",
+      "",
+      ...rows,
+      "",
+      "### Bug fixes",
+      "",
+      "- Fixed a thing.",
+      "",
+    ].join("\n");
+    const { body } = composeReleaseNotes({
+      version: "9.9.9",
+      prereleases: [release("v9.9.9-beta.1", beta, ["First"])],
+    });
+    expect(body).toContain("<summary><b>landscape (20 new)</b></summary>");
+    expect(body).toContain("### Bug fixes");
+    expect(body.indexOf("<details>")).toBeGreaterThan(body.indexOf("## Features"));
+    expect(body.indexOf("<details>")).toBeLessThan(body.indexOf("## Fixes"));
   });
 });


### PR DESCRIPTION
So the format is enforced rather than remembered.

## Composer

Three changes, each a defect the v1.3.1 cut hit:

- **Sections are grouped**, not printed in merge order. `classifySection` files each merged heading under Features, Fixes or Mentions. A section a late prerelease introduced used to land wherever the merge put it, which is why beta.5's new actions printed after an earlier beta's internals.
- **The summary is no longer inherited** from the newest prerelease. That text is written about one beta, so the stable cut opened on a sentence about three fixes over a release of hundreds of changes. With no local summary the version heading stands alone and the run says so.
- **Contributions are generated** from the compare API between the previous stable and HEAD, so handles come from the commit range rather than memory. An unresolvable tag or a failing API yields nobody instead of failing the cut.

## Readability

Feature sections of twelve lines or more render inside a `<details>` block with the category name in the summary. The v1.3.1 body is 460+ lines, nearly all per-category tables, so the fixes and breaking changes sat below a screen of scrolling. Short sections stay open; fixes and mentions are never collapsed.

## Written rules

`docs/release-notes-style.md` sets the structure, the opening shape and the things not to write. CLAUDE.md described the old flat structure and pointed at prior releases for the style, which is how each release got a new voice invented for it. Plus a PR template that collects the release line per PR, and a release skeleton matching what the composer emits.

## Engine range

README and the install step annotated the 5.4 to 5.8 range with which versions had been compiled and which were gated but unbuilt. That reads as a warning about our own product to someone deciding whether to install it. The range is stated plainly now, and the style guide says not to qualify it.

Verified: tsc clean, 1594 unit tests (53 in the composer suite, up from 43), em-dash / unity / docs / params audits clean. The live v1.3.1 notes are already updated to this format.