### PR TITLE
Collapse every release notes section

### DIFF
--- a/docs/release-notes-style.md
+++ b/docs/release-notes-style.md
@@ -20,10 +20,12 @@ buckets by heading, so a section a late beta introduced cannot print after the
 internals. `classifySection` is the rule; extend its patterns rather than
 hand-sorting a composed body.
 
-Feature sections of twelve lines or more render inside a `<details>` block with
-the category name in the summary, so the fixes and the breaking changes stay
-above the fold instead of below four hundred lines of tables. Short sections
-stay open, and fixes and mentions are never collapsed.
+Every section renders inside a `<details>` block with its name in the summary.
+Folded, a release is its four headings and one line per section; a stable cut
+composed from six prereleases is otherwise 460 lines of tables with the
+breaking changes at the bottom. Nothing is left half open: a reader deciding
+what to expand should not have to work out which parts were judged worth
+hiding.
 
 ## The opening
 

--- a/scripts/compose-release-notes.mjs
+++ b/scripts/compose-release-notes.mjs
@@ -441,24 +441,18 @@ export function classifySection(heading) {
 }
 
 /**
- * A section long enough that leaving it open buries what follows it. Twelve
- * lines is about a screen of table once GitHub has rendered it.
+ * One section, behind a disclosure. Every section collapses: a body made of
+ * per-category action tables is unreadable open, and a reader who has to
+ * expand one thing should not have to guess which parts were worth hiding.
+ *
+ * GitHub renders markdown inside `<details>` only when a blank line follows
+ * the summary, so the blanks here are load-bearing.
  */
-export const COLLAPSE_MIN_LINES = 12;
-
-/**
- * One section, collapsed behind a disclosure when it is allowed to be and long
- * enough to be worth it. GitHub renders markdown inside `<details>` only when a
- * blank line follows the summary, so the blanks here are load-bearing.
- */
-export function renderSection(section, collapsible) {
+export function renderSection(section) {
   const inner = [];
   if (section.lead) inner.push(section.lead, "");
   for (const bullet of section.bullets) inner.push(bullet);
   const body = inner.join("\n").trim();
-  if (!collapsible || body.split("\n").length < COLLAPSE_MIN_LINES) {
-    return [`### ${section.heading}`, "", body, ""];
-  }
   return ["<details>", `<summary><b>${section.heading}</b></summary>`, "", body, "", "</details>", ""];
 }
 
@@ -488,10 +482,7 @@ export function renderBody({ version, headline, preamble, sections, contributors
     const inSection = grouped.get(name);
     if (inSection.length === 0) continue;
     out.push(`## ${name}`, "");
-    // Features carry the per-category action tables, which are most of the
-    // body's length and the least of its reading. Fixes and mentions stay
-    // open: they are short, and they are what a reader came to scan.
-    for (const section of inSection) out.push(...renderSection(section, name === "Features"));
+    for (const section of inSection) out.push(...renderSection(section));
   }
 
   if ((contributors ?? []).length > 0) {

--- a/tests/unit/compose-release-notes.test.ts
+++ b/tests/unit/compose-release-notes.test.ts
@@ -16,7 +16,6 @@ import {
   contributorsBetween,
   previousStableTag,
   renderSection,
-  COLLAPSE_MIN_LINES,
   renderContributions,
   retitle,
   classifySection,
@@ -343,7 +342,7 @@ describe("composeReleaseNotes", () => {
 
     const tops = [...strippedBody.matchAll(/^## (.+)$/gm)].map((m) => m[1]);
     expect(tops).toEqual(["v1.2.0", "Features", "Fixes", "Mentions"]);
-    const headings = [...strippedBody.matchAll(/^### (.+)$/gm)].map((m) => m[1]);
+    const headings = [...strippedBody.matchAll(/^<summary><b>(.+?)<\/b><\/summary>$/gm)].map((m) => m[1]);
     // Grouped, not in merge order: the features lead, the internals trail.
     expect(headings).toEqual(["Multi-editor", "Server", "Bug fixes", "Internals"]);
 
@@ -483,7 +482,7 @@ describe("top-level section grouping", () => {
     expect(features).toBeGreaterThan(-1);
     expect(mentions).toBeGreaterThan(-1);
     expect(features).toBeLessThan(mentions);
-    expect(body.indexOf("### Server")).toBeLessThan(body.indexOf("### Internals"));
+    expect(body.indexOf("<b>Server</b>")).toBeLessThan(body.indexOf("<b>Internals</b>"));
     expect(TOP_SECTIONS).toEqual(["Features", "Fixes", "Mentions", "Contributions"]);
   });
 });
@@ -594,13 +593,13 @@ describe("reading contributors off the range", () => {
 });
 
 
-describe("collapsing the long feature tables", () => {
+describe("collapsing sections", () => {
   const rows = Array.from({ length: 20 }, (_, i) => `| a${i} | does a thing |`);
   const long = { heading: "landscape (20 new)", lead: "", bullets: rows };
   const short = { heading: "reflection (1 new)", lead: "", bullets: ["| x | one |"] };
 
-  it("puts a long feature section behind a disclosure, keeping its name visible", () => {
-    const out = renderSection(long, true);
+  it("puts a section behind a disclosure, keeping its name visible", () => {
+    const out = renderSection(long);
     expect(out[0]).toBe("<details>");
     expect(out[1]).toBe("<summary><b>landscape (20 new)</b></summary>");
     // GitHub renders markdown inside details only when a blank line follows
@@ -609,16 +608,13 @@ describe("collapsing the long feature tables", () => {
     expect(out.at(-2)).toBe("</details>");
   });
 
-  it("leaves a short section open, because collapsing it saves nothing", () => {
-    expect(renderSection(short, true)[0]).toBe("### reflection (1 new)");
-    expect(rows.length).toBeGreaterThanOrEqual(COLLAPSE_MIN_LINES);
+  it("collapses a short section too, so nothing is left half open", () => {
+    const out = renderSection(short);
+    expect(out[0]).toBe("<details>");
+    expect(out[1]).toBe("<summary><b>reflection (1 new)</b></summary>");
   });
 
-  it("never collapses fixes or mentions", () => {
-    expect(renderSection(long, false)[0]).toBe("### landscape (20 new)");
-  });
-
-  it("collapses inside Features and leaves the rest open end to end", () => {
+  it("leaves no bare h3 anywhere in a composed body", () => {
     const beta = [
       "## v9.9.9-beta.1",
       "",
@@ -630,14 +626,24 @@ describe("collapsing the long feature tables", () => {
       "",
       "- Fixed a thing.",
       "",
+      "### Internals",
+      "",
+      "- Reworked a thing.",
+      "",
     ].join("\n");
     const { body } = composeReleaseNotes({
       version: "9.9.9",
       prereleases: [release("v9.9.9-beta.1", beta, ["First"])],
     });
-    expect(body).toContain("<summary><b>landscape (20 new)</b></summary>");
-    expect(body).toContain("### Bug fixes");
-    expect(body.indexOf("<details>")).toBeGreaterThan(body.indexOf("## Features"));
-    expect(body.indexOf("<details>")).toBeLessThan(body.indexOf("## Fixes"));
+    expect(body).not.toMatch(/^### /m);
+    expect(body.match(/<details>/g)).toHaveLength(3);
+    expect(body.match(/<\/details>/g)).toHaveLength(3);
+    // The four top-level headings stay open; only the sections fold.
+    expect([...body.matchAll(/^## (.+)$/gm)].map((m) => m[1])).toEqual([
+      "v9.9.9",
+      "Features",
+      "Fixes",
+      "Mentions",
+    ]);
   });
 });


### PR DESCRIPTION
Follow-up to #1023, which folded only feature sections over twelve lines and left short categories, all of Fixes and all of Mentions expanded. That read as half done.

Every section now renders inside a `<details>` block. The four top-level headings stay open, so a release page is its structure plus one line per section until a reader expands something. v1.3.1 goes from 467 lines to 30 folded.

The threshold and the features-only rule are gone, which also removes `COLLAPSE_MIN_LINES` and simplifies `renderSection` to one argument.

Verified: tsc clean, 1593 unit tests, composer suite asserts no bare h3 survives a composed body. The live v1.3.1 notes are already republished in this form: 25 sections, 25 closing tags, zero bare h3.