### PR TITLE
chore(release): 1.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ue-mcp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ue-mcp",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@db-lyon/flowkit": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ue-mcp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Unreal Engine MCP server - 24 tools, 1090+ actions for AI-driven editor control",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
+++ b/plugin/ue_mcp_bridge/UE_MCP_Bridge.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.3.1",
+	"VersionName": "1.3.2",
 	"FriendlyName": "UE MCP Bridge",
 	"Description": "C++ WebSocket bridge for UE-MCP, providing 1029+ editor actions over the MCP protocol",
 	"Category": "Developer Tools",


### PR DESCRIPTION
Ships the blocking-dialog gate (#1025).

Notes carry the full 1.3.1 body plus the gate, so nothing from 1.3.1 is buried by a thin follow-up release.

Verified on UE 5.8.1 against tests/ue_mcp with the plugin rebuilt from this tree:

- Plugin build succeeded
- Live tier: 223 passed, 0 failed, including three new tests that raise a real Save Content modal and assert every category is refused
- Smoke: 1039 handlers, 1035 success, 0 failure, 4 skipped as unsafe to sweep
- Unit: 1603 passed
- Audits: em-dash, unity collisions, docs coverage, param drift clean