### PR TITLE
Add orthographic viewport state and typed spline editing

### DIFF
--- a/plugin/ue_mcp_bridge/README_SplineHandlers.md
+++ b/plugin/ue_mcp_bridge/README_SplineHandlers.md
@@ -1,0 +1,30 @@
+# Native spline handlers
+
+`set_spline_points` updates an actor's `USplineComponent` through the native
+UE-MCP bridge. Existing `actorLabel` and `{x,y,z}` point callers remain valid.
+
+The optional `componentName` is an exact Unreal component name. If supplied,
+the handler fails unless that named component is a `USplineComponent`; it does
+not select a different spline.
+
+Each point may provide `pointType` (`Linear`, `Curve`, `CurveClamped`,
+`Constant`, or `CurveCustomTangent`). Custom-tangent points must provide finite
+`arriveTangent` and `leaveTangent` vectors. Coordinates and supplied tangents
+must be finite. Validation completes before the existing spline is cleared.
+
+Edits are recorded in an editor transaction, mark the actor/component package
+dirty, and expose prior positions, types, tangents, rotations, scales, input
+keys, and loop endpoint state for MCP rollback. Input keys must be increasing
+and distinct under Unreal's near-equality comparison. `loopPositionOverride`
+and `loopPosition` preserve an explicit closing key.
+
+Splines with subclass metadata require their specialized authoring APIs and are
+rejected before mutation. The response marks MCP rollback
+as potentially lossy for custom rotation/scale-curve interpolation. Standard
+Unreal Editor Undo records the complete component state and is preferred when
+those ancillary curve details matter.
+
+For older category schemas with an XYZ-only `points` array, pass the typed array
+through `level(action="set_spline_points", actorLabel="Route", input={"points":[...]})`.
+The `input` object also accepts componentName, closedLoop, loopPositionOverride,
+and loopPosition. Duplicate fields at both levels are rejected.

--- a/plugin/ue_mcp_bridge/README_VIEWPORT_CAMERA.md
+++ b/plugin/ue_mcp_bridge/README_VIEWPORT_CAMERA.md
@@ -1,0 +1,22 @@
+# Viewport camera control
+
+The native `set_viewport_camera` command (`editor` action `set_viewport`) preserves its original optional `location` and
+`rotation` fields and now also accepts:
+
+- `projection` or `viewportType`: `perspective`, `top`, `bottom`, `left`,
+  `right`, `front`, `back`, or `orthoFreelook`.
+- `orthoZoom`: a finite Unreal-unit value within the engine's minimum/maximum
+  orthographic zoom bounds. In perspective mode it updates the stored
+  orthographic zoom, allowing complete camera-state rollback across view modes.
+
+The handler validates all supplied values before changing the viewport, marks
+the viewport for redraw, and returns the resulting location, rotation,
+projection/type, and orthographic zoom. Calls with no setters are therefore a
+state readback. `projection` and `viewportType` may not disagree.
+
+Invalid projection names, malformed numeric objects, non-finite values, and
+non-positive orthographic zooms are errors and leave the viewport unchanged.
+
+Older category schemas can forward these fields through their generic `args`
+object: `editor(action="set_viewport", args={"projection":"top","orthoZoom":100000})`.
+Supplying the same field both at the top level and inside `args` is rejected.

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EditorHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/EditorHandlers.cpp
@@ -2075,6 +2075,24 @@ TSharedPtr<FJsonValue> FEditorHandlers::CaptureScreenshot(const TSharedPtr<FJson
 
 TSharedPtr<FJsonValue> FEditorHandlers::SetViewportCamera(const TSharedPtr<FJsonObject>& Params)
 {
+	// Older category schemas expose a generic args object. Accept the same
+	// native parameters there so clients can use the extension without Python.
+	if (Params->HasField(TEXT("args")))
+	{
+		const TSharedPtr<FJsonObject>* Extra = nullptr;
+		if (!Params->TryGetObjectField(TEXT("args"), Extra)) return MCPError(TEXT("args must be an object"));
+		auto Expanded = MakeShared<FJsonObject>();
+		Expanded->Values = Params->Values;
+		Expanded->RemoveField(TEXT("args"));
+		for (const auto& Pair : (*Extra)->Values)
+		{
+			if (Pair.Key != TEXT("projection") && Pair.Key != TEXT("viewportType") && Pair.Key != TEXT("orthoZoom") && Pair.Key != TEXT("location") && Pair.Key != TEXT("rotation"))
+				return MCPError(TEXT("Unsupported field inside viewport args"));
+			if (Expanded->HasField(Pair.Key)) return MCPError(TEXT("Viewport field supplied both at top level and inside args"));
+			Expanded->SetField(Pair.Key, Pair.Value);
+		}
+		return SetViewportCamera(Expanded);
+	}
 	if (!GEditor)
 	{
 		return MCPError(TEXT("Editor not available"));
@@ -2095,19 +2113,128 @@ TSharedPtr<FJsonValue> FEditorHandlers::SetViewportCamera(const TSharedPtr<FJson
 		return MCPError(TEXT("No viewport client available"));
 	}
 
-	// Read the camera that is about to be replaced. This is the only state an
-	// inverse call could restore, and it is unreadable once the write lands.
-	const FVector PreviousLocation = ViewportClient->GetViewLocation();
-	const FRotator PreviousRotation = ViewportClient->GetViewRotation();
+        // Validate every supplied value before touching the viewport. OptionalVec3
+        // intentionally supplies defaults for older callers, but silently turning a
+        // malformed new projection/zoom value into a camera write is unsafe.
+        auto ValidateFiniteObjectFields = [&](const TCHAR* Key, const TArray<FString>& FieldNames) -> TSharedPtr<FJsonValue>
+        {
+                if (!Params->HasField(Key)) return nullptr;
+                const TSharedPtr<FJsonObject>* Object = nullptr;
+                if (!Params->TryGetObjectField(Key, Object) || !Object || !Object->IsValid())
+                {
+                        return MCPError(FString::Printf(TEXT("'%s' must be an object"), Key));
+                }
+                for (const FString& FieldName : FieldNames)
+                {
+                        if (!(*Object)->HasField(FieldName)) continue;
+                        double Number = 0.0;
+                        if (!(*Object)->TryGetNumberField(FieldName, Number) || !FMath::IsFinite(Number))
+                        {
+                                return MCPError(FString::Printf(TEXT("'%s.%s' must be a finite number"), Key, *FieldName));
+                        }
+                }
+                return nullptr;
+        };
+        auto ViewportTypeName = [](ELevelViewportType Type) -> const TCHAR*
+        {
+                switch (Type)
+                {
+                        case LVT_Perspective: return TEXT("perspective");
+                        case LVT_OrthoXY: return TEXT("top");
+                        case LVT_OrthoNegativeXY: return TEXT("bottom");
+                        case LVT_OrthoXZ: return TEXT("left");
+                        case LVT_OrthoNegativeXZ: return TEXT("right");
+                        case LVT_OrthoNegativeYZ: return TEXT("front");
+                        case LVT_OrthoYZ: return TEXT("back");
+                        case LVT_OrthoFreelook: return TEXT("orthoFreelook");
+                        default: return TEXT("unknown");
+                }
+        };
+        if (TSharedPtr<FJsonValue> Error = ValidateFiniteObjectFields(TEXT("location"), { TEXT("x"), TEXT("y"), TEXT("z") })) return Error;
+        if (TSharedPtr<FJsonValue> Error = ValidateFiniteObjectFields(TEXT("rotation"), { TEXT("pitch"), TEXT("yaw"), TEXT("roll") })) return Error;
 
+        FString RequestedProjection;
+        FString RequestedViewportType;
+        const bool bHasProjection = Params->HasField(TEXT("projection"));
+        const bool bHasViewportType = Params->HasField(TEXT("viewportType"));
+        if (bHasProjection && !Params->TryGetStringField(TEXT("projection"), RequestedProjection))
+        {
+                return MCPError(TEXT("'projection' must be a string such as 'perspective' or 'top'"));
+        }
+        if (bHasViewportType && !Params->TryGetStringField(TEXT("viewportType"), RequestedViewportType))
+        {
+                return MCPError(TEXT("'viewportType' must be a string such as 'perspective' or 'top'"));
+        }
+        if (bHasProjection && bHasViewportType && !RequestedProjection.Equals(RequestedViewportType, ESearchCase::IgnoreCase))
+        {
+                return MCPError(TEXT("'projection' and 'viewportType' disagree; provide only one or use the same value"));
+        }
+
+        FString Projection = bHasProjection ? RequestedProjection : RequestedViewportType;
+        Projection.TrimStartAndEndInline();
+        ELevelViewportType NewViewportType = ViewportClient->GetViewportType();
+        if (bHasProjection || bHasViewportType)
+        {
+                const struct FProjectionName { const TCHAR* Name; ELevelViewportType Type; } Names[] =
+                {
+                        { TEXT("perspective"), LVT_Perspective },
+                        { TEXT("top"), LVT_OrthoXY }, { TEXT("bottom"), LVT_OrthoNegativeXY },
+                        { TEXT("left"), LVT_OrthoXZ }, { TEXT("right"), LVT_OrthoNegativeXZ },
+                        { TEXT("front"), LVT_OrthoNegativeYZ }, { TEXT("back"), LVT_OrthoYZ },
+                        { TEXT("orthofreelook"), LVT_OrthoFreelook }
+                };
+                bool bFound = false;
+                for (const FProjectionName& Name : Names)
+                {
+                        if (Projection.Equals(Name.Name, ESearchCase::IgnoreCase))
+                        {
+                                NewViewportType = Name.Type;
+                                bFound = true;
+                                break;
+                        }
+                }
+                if (!bFound)
+                {
+                        return MCPError(TEXT("Unknown viewport projection/type. Valid values are perspective, top, bottom, left, right, front, back, and orthoFreelook"));
+                }
+        }
+
+        const bool bHasOrthoZoom = Params->HasField(TEXT("orthoZoom"));
+        double RequestedOrthoZoom = 0.0;
+        if (bHasOrthoZoom)
+        {
+                if (!Params->TryGetNumberField(TEXT("orthoZoom"), RequestedOrthoZoom) || !FMath::IsFinite(RequestedOrthoZoom)
+                    || RequestedOrthoZoom < MIN_ORTHOZOOM || RequestedOrthoZoom > MAX_ORTHOZOOM)
+                {
+                        return MCPError(TEXT("'orthoZoom' must be finite and within the engine MIN_ORTHOZOOM/MAX_ORTHOZOOM bounds"));
+                }
+        }
+
+        // Read the camera that is about to be replaced. This is the only state an
+	// inverse call could restore, and it is unreadable once the write lands.
+        const FVector PreviousLocation = ViewportClient->GetViewLocation();
+        const FRotator PreviousRotation = ViewportClient->GetViewRotation();
+        const ELevelViewportType PreviousViewportType = ViewportClient->GetViewportType();
+        const float PreviousOrthoZoom = ViewportClient->GetOrthoZoom();
+
+	// Viewport type selects a distinct transform cache. Select it before pose writes.
+	if (bHasProjection || bHasViewportType)
+	{
+		ViewportClient->SetViewportType(NewViewportType);
+	}
 	if (Params->HasField(TEXT("location")))
 	{
 		ViewportClient->SetViewLocation(OptionalVec3(Params, TEXT("location")));
 	}
-	if (Params->HasField(TEXT("rotation")))
-	{
-		ViewportClient->SetViewRotation(OptionalRotator(Params, TEXT("rotation")));
-	}
+        if (Params->HasField(TEXT("rotation")))
+        {
+                ViewportClient->SetViewRotation(OptionalRotator(Params, TEXT("rotation")));
+        }
+        if (bHasOrthoZoom)
+        {
+                ViewportClient->SetOrthoZoom(static_cast<float>(RequestedOrthoZoom));
+        }
+        ViewportClient->Invalidate();
 
 	auto Result = MCPSuccess();
 	const FVector CurrentLocation = ViewportClient->GetViewLocation();
@@ -2122,14 +2249,27 @@ TSharedPtr<FJsonValue> FEditorHandlers::SetViewportCamera(const TSharedPtr<FJson
 	PrevRot->SetNumberField(TEXT("roll"), PreviousRotation.Roll);
 	Result->SetObjectField(TEXT("previousLocation"), PrevLoc);
 	Result->SetObjectField(TEXT("previousRotation"), PrevRot);
-	Result->SetBoolField(TEXT("changed"),
-		!CurrentLocation.Equals(PreviousLocation) || !CurrentRotation.Equals(PreviousRotation));
+        Result->SetBoolField(TEXT("changed"),
+                !CurrentLocation.Equals(PreviousLocation) || !CurrentRotation.Equals(PreviousRotation)
+                || ViewportClient->GetViewportType() != PreviousViewportType
+                || !FMath::IsNearlyEqual(ViewportClient->GetOrthoZoom(), PreviousOrthoZoom));
+        Result->SetStringField(TEXT("projection"), ViewportTypeName(ViewportClient->GetViewportType()));
+        Result->SetStringField(TEXT("viewportType"), ViewportTypeName(ViewportClient->GetViewportType()));
+        Result->SetNumberField(TEXT("orthoZoom"), ViewportClient->GetOrthoZoom());
+        Result->SetObjectField(TEXT("location"), MCPVec3ToJsonObject(CurrentLocation));
+        auto CurrentRot = MakeShared<FJsonObject>();
+        CurrentRot->SetNumberField(TEXT("pitch"), CurrentRotation.Pitch);
+        CurrentRot->SetNumberField(TEXT("yaw"), CurrentRotation.Yaw);
+        CurrentRot->SetNumberField(TEXT("roll"), CurrentRotation.Roll);
+        Result->SetObjectField(TEXT("rotation"), CurrentRot);
 
 	// Self-inverse: the same handler with the camera this call replaced. Both
 	// halves are sent, so a location-only write still restores the whole pose.
 	TSharedPtr<FJsonObject> Payload = MakeShared<FJsonObject>();
 	Payload->SetObjectField(TEXT("location"), PrevLoc);
-	Payload->SetObjectField(TEXT("rotation"), PrevRot);
+        Payload->SetObjectField(TEXT("rotation"), PrevRot);
+        Payload->SetStringField(TEXT("projection"), ViewportTypeName(PreviousViewportType));
+        Payload->SetNumberField(TEXT("orthoZoom"), PreviousOrthoZoom);
 	MCPSetRollback(Result, TEXT("set_viewport_camera"), Payload);
 	Result->SetBoolField(TEXT("rollbackLossy"), false);
 	Result->SetStringField(TEXT("rollbackNote"),

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/SplineHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/SplineHandlers.cpp
@@ -9,6 +9,56 @@
 #include "EngineUtils.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
+#include "ScopedTransaction.h"
+#include "UObject/UnrealType.h"
+
+namespace
+{
+	static bool ReadFiniteNumber(const TSharedPtr<FJsonObject>& Object, const TCHAR* Field, double& OutValue)
+	{
+		return Object.IsValid() && Object->TryGetNumberField(Field, OutValue) && FMath::IsFinite(OutValue);
+	}
+
+	static bool ReadPointVector(const TSharedPtr<FJsonObject>& Object, const TCHAR* Field, FVector& OutValue)
+	{
+		const TSharedPtr<FJsonObject>* VectorObject = nullptr;
+		if (!Object.IsValid() || !Object->TryGetObjectField(Field, VectorObject) || !VectorObject || !VectorObject->IsValid())
+		{
+			return false;
+		}
+		double X = 0.0, Y = 0.0, Z = 0.0;
+		if (!ReadFiniteNumber(*VectorObject, TEXT("x"), X) || !ReadFiniteNumber(*VectorObject, TEXT("y"), Y) || !ReadFiniteNumber(*VectorObject, TEXT("z"), Z))
+		{
+			return false;
+		}
+		OutValue = FVector(X, Y, Z);
+		return !OutValue.ContainsNaN();
+	}
+
+	static bool ParseSplinePointType(const FString& TypeName, ESplinePointType::Type& OutType)
+	{
+		if (TypeName == TEXT("Linear")) OutType = ESplinePointType::Linear;
+		else if (TypeName == TEXT("Curve")) OutType = ESplinePointType::Curve;
+		else if (TypeName == TEXT("CurveClamped")) OutType = ESplinePointType::CurveClamped;
+		else if (TypeName == TEXT("Constant")) OutType = ESplinePointType::Constant;
+		else if (TypeName == TEXT("CurveCustomTangent")) OutType = ESplinePointType::CurveCustomTangent;
+		else return false;
+		return true;
+	}
+
+	static FString SplinePointTypeName(ESplinePointType::Type Type)
+	{
+		switch (Type)
+		{
+		case ESplinePointType::Linear: return TEXT("Linear");
+		case ESplinePointType::Curve: return TEXT("Curve");
+		case ESplinePointType::CurveClamped: return TEXT("CurveClamped");
+		case ESplinePointType::Constant: return TEXT("Constant");
+		case ESplinePointType::CurveCustomTangent: return TEXT("CurveCustomTangent");
+		default: return TEXT("Unknown");
+		}
+	}
+}
 
 void FSplineHandlers::RegisterHandlers(FMCPHandlerRegistry& Registry)
 {
@@ -145,6 +195,21 @@ TSharedPtr<FJsonValue> FSplineHandlers::ReadSpline(const TSharedPtr<FJsonObject>
 
 TSharedPtr<FJsonValue> FSplineHandlers::SetSplinePoints(const TSharedPtr<FJsonObject>& Params)
 {
+	// Preserve typed point fields through older category schemas that expose input.
+	if (Params->HasField(TEXT("input")))
+	{
+		const TSharedPtr<FJsonObject>* Extra = nullptr;
+		if (!Params->TryGetObjectField(TEXT("input"), Extra)) return MCPError(TEXT("input must be an object"));
+		auto Expanded = MakeShared<FJsonObject>(); Expanded->Values = Params->Values; Expanded->RemoveField(TEXT("input"));
+		for (const auto& Pair : (*Extra)->Values)
+		{
+			if (Pair.Key != TEXT("points") && Pair.Key != TEXT("componentName") && Pair.Key != TEXT("closedLoop") && Pair.Key != TEXT("loopPositionOverride") && Pair.Key != TEXT("loopPosition"))
+				return MCPError(TEXT("Unsupported field inside spline input"));
+			if (Expanded->HasField(Pair.Key)) return MCPError(TEXT("Spline field supplied both at top level and inside input"));
+			Expanded->SetField(Pair.Key, Pair.Value);
+		}
+		return SetSplinePoints(Expanded);
+	}
 	FString ActorLabel;
 	if (auto Err = RequireStringAlt(Params, TEXT("actorLabel"), TEXT("actorPath"), ActorLabel)) return Err;
 
@@ -155,21 +220,156 @@ TSharedPtr<FJsonValue> FSplineHandlers::SetSplinePoints(const TSharedPtr<FJsonOb
 	}
 
 	REQUIRE_EDITOR_WORLD(World);
+	if (Params->HasField(TEXT("componentName")) && (!Params->TryGetField(TEXT("componentName")).IsValid() || Params->TryGetField(TEXT("componentName"))->Type != EJson::String))
+		return MCPError(TEXT("componentName must be a string"));
 
 	TSharedPtr<FJsonValue> ActorErr;
 	AActor* Actor = MCPResolveActor(World, Params, ActorErr);
 	if (!Actor) return ActorErr;
 	ActorLabel = Actor->GetActorLabel();
 
-	// Find spline component
-	USplineComponent* SplineComp = Actor->FindComponentByClass<USplineComponent>();
+	// A named component is an exact component-name lookup; never silently fall back
+	// to another spline when the caller has identified one.
+	USplineComponent* SplineComp = nullptr;
+	const FString ComponentName = OptionalString(Params, TEXT("componentName"));
+	if (Params->HasField(TEXT("componentName")) && ComponentName.IsEmpty()) return MCPError(TEXT("componentName cannot be empty"));
+	if (!ComponentName.IsEmpty())
+	{
+		TArray<USplineComponent*> Components;
+		Actor->GetComponents<USplineComponent>(Components);
+		for (USplineComponent* Candidate : Components)
+		{
+			if (Candidate && Candidate->GetName() == ComponentName) { SplineComp = Candidate; break; }
+		}
+	}
+	else
+	{
+		SplineComp = Actor->FindComponentByClass<USplineComponent>();
+	}
 	if (!SplineComp)
 	{
-		return MCPError(FString::Printf(TEXT("Actor '%s' does not have a SplineComponent"), *ActorLabel));
+		return MCPError(FString::Printf(TEXT("Actor '%s' has no matching SplineComponent%s"), *ActorLabel,
+			ComponentName.IsEmpty() ? TEXT("") : *FString::Printf(TEXT(" named '%s'"), *ComponentName)));
+	}
+	if (SplineComp->GetSplinePointsMetadata())
+		return MCPError(TEXT("This spline has subclass metadata and requires its specialized authoring API"));
+
+	struct FValidatedPoint
+	{
+		FVector Location = FVector::ZeroVector;
+		FVector ArriveTangent = FVector::ZeroVector;
+		FVector LeaveTangent = FVector::ZeroVector;
+		FRotator Rotation = FRotator::ZeroRotator;
+		FVector Scale = FVector::OneVector;
+		float InputKey = 0.0f;
+		bool bHasInputKey = false;
+		bool bHasRotation = false;
+		bool bHasTangents = false;
+		ESplinePointType::Type Type = ESplinePointType::Curve;
+	};
+	TArray<FValidatedPoint> NewPoints;
+	NewPoints.Reserve(PointsArray->Num());
+	for (int32 Index = 0; Index < PointsArray->Num(); ++Index)
+	{
+		const TSharedPtr<FJsonObject>* PointObject = nullptr;
+		if (!(*PointsArray)[Index].IsValid() || !(*PointsArray)[Index]->TryGetObject(PointObject) || !PointObject || !PointObject->IsValid())
+		{
+			return MCPError(FString::Printf(TEXT("points[%d] must be an object with finite x, y, z"), Index));
+		}
+		FValidatedPoint Point;
+		int32 CoordinateForms = 0;
+		for (const TCHAR* Form : { TEXT("location"), TEXT("position"), TEXT("worldLocation") })
+		{
+			if (!(*PointObject)->HasField(Form)) continue;
+			++CoordinateForms; FVector Checked;
+			if (!ReadPointVector(*PointObject, Form, Checked)) return MCPError(FString::Printf(TEXT("points[%d] has malformed coordinate object"), Index));
+		}
+		if (CoordinateForms > 1 || (CoordinateForms && ((*PointObject)->HasField(TEXT("x")) || (*PointObject)->HasField(TEXT("y")) || (*PointObject)->HasField(TEXT("z")))))
+			return MCPError(FString::Printf(TEXT("points[%d] must use one coordinate representation"), Index));
+		if (!ReadPointVector(*PointObject, TEXT("location"), Point.Location))
+		{
+			if (!ReadPointVector(*PointObject, TEXT("position"), Point.Location) && !ReadPointVector(*PointObject, TEXT("worldLocation"), Point.Location))
+			{
+				double X = 0.0, Y = 0.0, Z = 0.0;
+				if (!ReadFiniteNumber(*PointObject, TEXT("x"), X) || !ReadFiniteNumber(*PointObject, TEXT("y"), Y) || !ReadFiniteNumber(*PointObject, TEXT("z"), Z))
+					return MCPError(FString::Printf(TEXT("points[%d] must contain finite x, y, z"), Index));
+				Point.Location = FVector(X, Y, Z);
+				if (Point.Location.ContainsNaN())
+					return MCPError(FString::Printf(TEXT("points[%d] coordinates are outside the finite float range"), Index));
+			}
+		}
+		double InputKey = 0.0;
+		if ((*PointObject)->HasField(TEXT("inputKey")))
+		{
+			if (!ReadFiniteNumber(*PointObject, TEXT("inputKey"), InputKey) || !FMath::IsFinite(static_cast<float>(InputKey)))
+				return MCPError(FString::Printf(TEXT("points[%d] inputKey must be finite"), Index));
+			Point.InputKey = static_cast<float>(InputKey);
+			Point.bHasInputKey = true;
+		}
+		FVector RotationVector;
+		if ((*PointObject)->HasField(TEXT("rotation")))
+		{
+			Point.bHasRotation = true;
+			if (!ReadPointVector(*PointObject, TEXT("rotation"), RotationVector))
+				return MCPError(FString::Printf(TEXT("points[%d] rotation must contain finite x, y, z"), Index));
+			Point.Rotation = FRotator(RotationVector.X, RotationVector.Y, RotationVector.Z);
+		}
+		if ((*PointObject)->HasField(TEXT("scale")) && !ReadPointVector(*PointObject, TEXT("scale"), Point.Scale))
+			return MCPError(FString::Printf(TEXT("points[%d] scale must contain finite x, y, z"), Index));
+		FString TypeName = TEXT("Curve");
+		if ((*PointObject)->HasField(TEXT("pointType")) && (!(*PointObject)->TryGetField(TEXT("pointType")).IsValid() || (*PointObject)->TryGetField(TEXT("pointType"))->Type != EJson::String))
+			return MCPError(FString::Printf(TEXT("points[%d] pointType must be a string"), Index));
+		(*PointObject)->TryGetStringField(TEXT("pointType"), TypeName);
+		if (!ParseSplinePointType(TypeName, Point.Type))
+			return MCPError(FString::Printf(TEXT("points[%d] has unsupported pointType '%s'"), Index, *TypeName));
+		const bool bHasArrive = ReadPointVector(*PointObject, TEXT("arriveTangent"), Point.ArriveTangent);
+		const bool bHasLeave = ReadPointVector(*PointObject, TEXT("leaveTangent"), Point.LeaveTangent);
+		if ((*PointObject)->HasField(TEXT("arriveTangent")) != (*PointObject)->HasField(TEXT("leaveTangent")))
+			return MCPError(FString::Printf(TEXT("points[%d] must provide both arriveTangent and leaveTangent"), Index));
+		if (((*PointObject)->HasField(TEXT("arriveTangent")) && !bHasArrive) || ((*PointObject)->HasField(TEXT("leaveTangent")) && !bHasLeave))
+			return MCPError(FString::Printf(TEXT("points[%d] tangents must contain finite x, y, z"), Index));
+		Point.bHasTangents = bHasArrive && bHasLeave;
+		if (Point.Type == ESplinePointType::CurveCustomTangent && (!bHasArrive || !bHasLeave))
+			return MCPError(FString::Printf(TEXT("points[%d] CurveCustomTangent requires arriveTangent and leaveTangent"), Index));
+		NewPoints.Add(Point);
+	}
+	bool bClosedLoop = false;
+	const bool bHasClosedLoop = Params->HasField(TEXT("closedLoop"));
+	if (bHasClosedLoop)
+	{
+		if (!Params->TryGetField(TEXT("closedLoop")).IsValid() || Params->TryGetField(TEXT("closedLoop"))->Type != EJson::Boolean)
+			return MCPError(TEXT("closedLoop must be a boolean"));
+		Params->TryGetBoolField(TEXT("closedLoop"), bClosedLoop);
+	}
+	float PreviousInputKey = -TNumericLimits<float>::Max();
+	for (int32 Index = 0; Index < NewPoints.Num(); ++Index)
+	{
+		const float EffectiveInputKey = NewPoints[Index].bHasInputKey ? NewPoints[Index].InputKey : static_cast<float>(Index);
+		if (!FMath::IsFinite(EffectiveInputKey) || (Index > 0 && (EffectiveInputKey <= PreviousInputKey || FMath::IsNearlyEqual(EffectiveInputKey, PreviousInputKey))))
+			return MCPError(FString::Printf(TEXT("points[%d] inputKey values must be finite and strictly increasing"), Index));
+		PreviousInputKey = EffectiveInputKey;
 	}
 
-	// Capture previous spline points for rollback
+	const FBoolProperty* LoopOverrideProperty = FindFProperty<FBoolProperty>(USplineComponent::StaticClass(), TEXT("bLoopPositionOverride"));
+	const FFloatProperty* LoopPositionProperty = FindFProperty<FFloatProperty>(USplineComponent::StaticClass(), TEXT("LoopPosition"));
+	const bool PreviousLoopOverride = LoopOverrideProperty && LoopOverrideProperty->GetPropertyValue_InContainer(SplineComp);
+	const float PreviousLoopPosition = LoopPositionProperty ? LoopPositionProperty->GetPropertyValue_InContainer(SplineComp) : 0.f;
+	bool RequestedLoopOverride = bHasClosedLoop ? false : PreviousLoopOverride;
+	double RequestedLoopPosition = PreviousLoopPosition;
+	if (Params->HasField(TEXT("loopPositionOverride")) && !Params->TryGetBoolField(TEXT("loopPositionOverride"), RequestedLoopOverride))
+		return MCPError(TEXT("loopPositionOverride must be a boolean"));
+	if (Params->HasField(TEXT("loopPosition")) && (!Params->TryGetNumberField(TEXT("loopPosition"), RequestedLoopPosition) || !FMath::IsFinite(RequestedLoopPosition) || !FMath::IsFinite(static_cast<float>(RequestedLoopPosition))))
+		return MCPError(TEXT("loopPosition must be a finite float"));
+	if (RequestedLoopOverride && (!((bHasClosedLoop && bClosedLoop) || (!bHasClosedLoop && SplineComp->IsClosedLoop())) || NewPoints.IsEmpty() || static_cast<float>(RequestedLoopPosition) <= PreviousInputKey || FMath::IsNearlyEqual(static_cast<float>(RequestedLoopPosition), PreviousInputKey)))
+		return MCPError(TEXT("An overridden loop position requires a closed nonempty spline and a key after the final point"));
+
+	// Point state is portable through MCP; Undo additionally captures complete component state.
 	TArray<TSharedPtr<FJsonValue>> PrevPoints;
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+	const FSplineCurves PreviousCurves = SplineComp->GetSplineCurves();
+#else
+	const FSplineCurves PreviousCurves = SplineComp->SplineCurves;
+#endif
 	for (int32 i = 0; i < SplineComp->GetNumberOfSplinePoints(); ++i)
 	{
 		FVector P = SplineComp->GetLocationAtSplinePoint(i, ESplineCoordinateSpace::World);
@@ -177,39 +377,58 @@ TSharedPtr<FJsonValue> FSplineHandlers::SetSplinePoints(const TSharedPtr<FJsonOb
 		PObj->SetNumberField(TEXT("x"), P.X);
 		PObj->SetNumberField(TEXT("y"), P.Y);
 		PObj->SetNumberField(TEXT("z"), P.Z);
+		PObj->SetObjectField(TEXT("arriveTangent"), MCPVec3ToJsonObject(SplineComp->GetArriveTangentAtSplinePoint(i, ESplineCoordinateSpace::World)));
+		PObj->SetObjectField(TEXT("leaveTangent"), MCPVec3ToJsonObject(SplineComp->GetLeaveTangentAtSplinePoint(i, ESplineCoordinateSpace::World)));
+		PObj->SetStringField(TEXT("pointType"), SplinePointTypeName(SplineComp->GetSplinePointType(i)));
+		PObj->SetNumberField(TEXT("inputKey"), PreviousCurves.Position.Points[i].InVal);
+		const FRotator StoredWorldRotation = (SplineComp->GetComponentQuat() * PreviousCurves.Rotation.Points[i].OutVal).Rotator();
+		PObj->SetObjectField(TEXT("rotation"), MCPVec3ToJsonObject(FVector(StoredWorldRotation.Pitch, StoredWorldRotation.Yaw, StoredWorldRotation.Roll)));
+		PObj->SetObjectField(TEXT("scale"), MCPVec3ToJsonObject(PreviousCurves.Scale.Points[i].OutVal));
 		PrevPoints.Add(MakeShared<FJsonValueObject>(PObj));
 	}
 	const bool bPrevClosedLoop = SplineComp->IsClosedLoop();
 
-	// Clear existing points and add new ones
+	FScopedTransaction Transaction(FText::FromString(TEXT("Set Spline Points")));
+	Actor->SetFlags(RF_Transactional);
+	SplineComp->SetFlags(RF_Transactional);
+	Actor->Modify();
+	SplineComp->Modify();
 	SplineComp->ClearSplinePoints(false);
-
-	for (int32 i = 0; i < PointsArray->Num(); ++i)
+	for (int32 i = 0; i < NewPoints.Num(); ++i)
 	{
-		const TSharedPtr<FJsonObject>* PointObj = nullptr;
-		if ((*PointsArray)[i]->TryGetObject(PointObj))
-		{
-			FVector Point = FVector::ZeroVector;
-			(*PointObj)->TryGetNumberField(TEXT("x"), Point.X);
-			(*PointObj)->TryGetNumberField(TEXT("y"), Point.Y);
-			(*PointObj)->TryGetNumberField(TEXT("z"), Point.Z);
-			SplineComp->AddSplinePoint(Point, ESplineCoordinateSpace::World, false);
-		}
+		const FTransform ComponentTransform = SplineComp->GetComponentTransform();
+		const FVector LocalLocation = ComponentTransform.InverseTransformPosition(NewPoints[i].Location);
+		const FVector LocalArrive = ComponentTransform.InverseTransformVector(NewPoints[i].ArriveTangent);
+		const FVector LocalLeave = ComponentTransform.InverseTransformVector(NewPoints[i].LeaveTangent);
+		const FQuat LocalRotationQuat = NewPoints[i].bHasRotation ? ComponentTransform.GetRotation().Inverse() * NewPoints[i].Rotation.Quaternion() : FQuat::Identity;
+		FSplinePoint NewPoint(NewPoints[i].bHasInputKey ? NewPoints[i].InputKey : static_cast<float>(i), LocalLocation,
+			LocalArrive, LocalLeave, LocalRotationQuat.Rotator(), NewPoints[i].Scale, NewPoints[i].Type);
+		SplineComp->AddPoint(NewPoint, false);
+		if (NewPoints[i].bHasTangents)
+			SplineComp->SetTangentsAtSplinePoint(i, NewPoints[i].ArriveTangent, NewPoints[i].LeaveTangent, ESplineCoordinateSpace::World, false);
+		// SetTangentsAtSplinePoint promotes the point to CurveCustomTangent;
+		// apply the requested type last so the public result is exact.
+		SplineComp->SetSplinePointType(i, NewPoints[i].Type, false);
 	}
 
 	// Optionally set closed loop
-	bool bClosedLoop = false;
-	if (Params->TryGetBoolField(TEXT("closedLoop"), bClosedLoop))
+	if (RequestedLoopOverride)
 	{
-		SplineComp->SetClosedLoop(bClosedLoop);
+		SplineComp->SetClosedLoopAtPosition(true, static_cast<float>(RequestedLoopPosition), false);
+	}
+	else if (bHasClosedLoop || Params->HasField(TEXT("loopPositionOverride")))
+	{
+		SplineComp->SetClosedLoop(bHasClosedLoop ? bClosedLoop : bPrevClosedLoop, false);
 	}
 
 	SplineComp->UpdateSpline();
+	SplineComp->GetPackage()->MarkPackageDirty();
 
 	auto Result = MCPSuccess();
 	MCPSetUpdated(Result);
 	Result->SetStringField(TEXT("actorLabel"), ActorLabel);
 	Result->SetStringField(TEXT("actorPath"), Actor->GetPathName());
+	Result->SetStringField(TEXT("componentName"), SplineComp->GetName());
 	Result->SetNumberField(TEXT("splinePointCount"), SplineComp->GetNumberOfSplinePoints());
 	Result->SetBoolField(TEXT("closedLoop"), SplineComp->IsClosedLoop());
 	Result->SetNumberField(TEXT("splineLength"), SplineComp->GetSplineLength());
@@ -219,7 +438,12 @@ TSharedPtr<FJsonValue> FSplineHandlers::SetSplinePoints(const TSharedPtr<FJsonOb
 	Payload->SetStringField(TEXT("actorPath"), Actor->GetPathName());
 	Payload->SetArrayField(TEXT("points"), PrevPoints);
 	Payload->SetBoolField(TEXT("closedLoop"), bPrevClosedLoop);
+	Payload->SetBoolField(TEXT("loopPositionOverride"), PreviousLoopOverride);
+	Payload->SetNumberField(TEXT("loopPosition"), PreviousLoopPosition);
+	Payload->SetStringField(TEXT("componentName"), SplineComp->GetName());
 	MCPSetRollback(Result, TEXT("set_spline_points"), Payload);
+	Result->SetBoolField(TEXT("rollbackLossy"), true);
+	Result->SetStringField(TEXT("rollbackNote"), TEXT("MCP rollback preserves authored point positions, types, tangents, rotations, scales, keys and loop endpoint. Use editor Undo to restore any custom rotation/scale-curve interpolation and ancillary component state."));
 
 	return MCPResult(Result);
 }

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/SplineHandlersTests.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/SplineHandlersTests.cpp
@@ -1,0 +1,92 @@
+// Focused native coverage for exact component targeting and validate-before-mutate.
+#if WITH_DEV_AUTOMATION_TESTS
+#include "HandlerRegistry.h"
+#include "Handlers/SplineHandlers.h"
+#include "Components/SplineComponent.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "Misc/AutomationTest.h"
+#include "UObject/Package.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMCPNativeSplineAuthoringTest, "UE.MCP.Spline.NativeAuthoringContract", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMCPNativeSplineAuthoringTest::RunTest(const FString& Parameters)
+{
+	if (!TestTrue(TEXT("an editor world is available"), GEditor != nullptr)) return false;
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!TestTrue(TEXT("the editor world is valid"), World != nullptr)) return false;
+	const bool WasDirty = World->GetOutermost()->IsDirty();
+	FActorSpawnParameters SpawnParams; SpawnParams.ObjectFlags = RF_Transient | RF_Transactional;
+	AActor* Actor = World->SpawnActor<AActor>(AActor::StaticClass(), FVector::ZeroVector, FRotator::ZeroRotator, SpawnParams);
+	if (!TestTrue(TEXT("a transient actor can be spawned"), Actor != nullptr)) return false;
+	Actor->SetActorLabel(TEXT("MCP_SplineContractTest"));
+	USplineComponent* First = NewObject<USplineComponent>(Actor, TEXT("PrimarySpline"));
+	USplineComponent* Second = NewObject<USplineComponent>(Actor, TEXT("SecondarySpline"));
+	Actor->AddInstanceComponent(First); Actor->AddInstanceComponent(Second);
+	Actor->SetRootComponent(First);
+	Second->SetupAttachment(First);
+	First->RegisterComponent(); Second->RegisterComponent();
+	Actor->SetActorTransform(FTransform(FRotator(0.0, 45.0, 0.0), FVector(100.0, 200.0, 50.0), FVector(2.0, 3.0, 1.5)));
+	TestFalse(TEXT("component transform is nonidentity"), Second->GetComponentTransform().Equals(FTransform::Identity));
+	First->AddSplinePoint(FVector(10.0, 0.0, 0.0), ESplineCoordinateSpace::World, false);
+	Second->AddSplinePoint(FVector(20.0, 0.0, 0.0), ESplineCoordinateSpace::World, false);
+	First->UpdateSpline(); Second->UpdateSpline();
+	Second->SetRotationAtSplinePoint(0, FRotator(12,31,7), ESplineCoordinateSpace::Local, false);
+	Second->SetScaleAtSplinePoint(1, FVector(1.2,.8,2.1), false);
+	Second->SetClosedLoopAtPosition(true, 5.f);
+	const FVector OriginalPoint = Second->GetLocationAtSplinePoint(0, ESplineCoordinateSpace::World);
+	const FQuat OriginalRotation = Second->GetSplinePointsRotation().Points[0].OutVal;
+	const FVector OriginalScale = Second->GetScaleAtSplinePoint(1);
+	const float OriginalLength = Second->GetSplineLength();
+	const int32 OriginalCount = Second->GetNumberOfSplinePoints();
+
+	FMCPHandlerRegistry Registry; FSplineHandlers::RegisterHandlers(Registry);
+	TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
+	Params->SetStringField(TEXT("actorLabel"), TEXT("MCP_SplineContractTest"));
+	Params->SetStringField(TEXT("componentName"), TEXT("SecondarySpline"));
+	TArray<TSharedPtr<FJsonValue>> Points;
+	TSharedPtr<FJsonObject> Linear = MakeShared<FJsonObject>();
+	Linear->SetNumberField(TEXT("x"), 30.0); Linear->SetNumberField(TEXT("y"), 0.0); Linear->SetNumberField(TEXT("z"), 0.0); Linear->SetStringField(TEXT("pointType"), TEXT("Linear"));
+	Points.Add(MakeShared<FJsonValueObject>(Linear));
+	TSharedPtr<FJsonObject> Custom = MakeShared<FJsonObject>();
+	Custom->SetNumberField(TEXT("x"), 40.0); Custom->SetNumberField(TEXT("y"), 0.0); Custom->SetNumberField(TEXT("z"), 0.0); Custom->SetStringField(TEXT("pointType"), TEXT("CurveCustomTangent"));
+	for (const TCHAR* Name : {TEXT("arriveTangent"), TEXT("leaveTangent")}) { TSharedPtr<FJsonObject> Tangent = MakeShared<FJsonObject>(); Tangent->SetNumberField(TEXT("x"), Name[0] == 'a' ? 1.0 : 2.0); Tangent->SetNumberField(TEXT("y"), 0.0); Tangent->SetNumberField(TEXT("z"), 0.0); Custom->SetObjectField(Name, Tangent); }
+	Points.Add(MakeShared<FJsonValueObject>(Custom)); Params->SetArrayField(TEXT("points"), Points);
+	const int32 FirstBefore = First->GetNumberOfSplinePoints();
+	const TSharedPtr<FJsonValue> Response = Registry.ExecuteHandler(TEXT("set_spline_points"), Params);
+	TestTrue(TEXT("named spline update succeeds"), Response.IsValid() && Response->AsObject()->GetBoolField(TEXT("success")));
+	TestEqual(TEXT("only the exact named component is changed"), First->GetNumberOfSplinePoints(), FirstBefore);
+	TestEqual(TEXT("the target receives both typed points"), Second->GetNumberOfSplinePoints(), 2);
+	TestEqual(TEXT("the first target point is linear"), Second->GetSplinePointType(0), ESplinePointType::Linear);
+	TestEqual(TEXT("the custom tangent point keeps its type"), Second->GetSplinePointType(1), ESplinePointType::CurveCustomTangent);
+	TestTrue(TEXT("world-space input is not transformed twice"), Second->GetLocationAtSplinePoint(0, ESplineCoordinateSpace::World).Equals(FVector(30.0, 0.0, 0.0), 0.01));
+
+	const FVector BeforeMalformed = Second->GetLocationAtSplinePoint(0, ESplineCoordinateSpace::World);
+	TSharedPtr<FJsonObject> Malformed = MakeShared<FJsonObject>(); Malformed->SetStringField(TEXT("actorLabel"), TEXT("MCP_SplineContractTest")); Malformed->SetStringField(TEXT("componentName"), TEXT("SecondarySpline"));
+	TArray<TSharedPtr<FJsonValue>> BadPoints; BadPoints.Add(MakeShared<FJsonValueString>(TEXT("not-a-point"))); Malformed->SetArrayField(TEXT("points"), BadPoints);
+	const TSharedPtr<FJsonValue> MalformedResponse = Registry.ExecuteHandler(TEXT("set_spline_points"), Malformed);
+	TestFalse(TEXT("malformed input is rejected"), MalformedResponse.IsValid() && MalformedResponse->AsObject()->GetBoolField(TEXT("success")));
+	TestEqual(TEXT("rejected input leaves spline unchanged"), Second->GetLocationAtSplinePoint(0, ESplineCoordinateSpace::World), BeforeMalformed);
+	Linear->SetNumberField(TEXT("inputKey"), 0); Custom->SetNumberField(TEXT("inputKey"), 1e-9);
+	const auto NearKeys = Registry.ExecuteHandler(TEXT("set_spline_points"), Params);
+	TestFalse(TEXT("engine-near-equal keys are rejected"), NearKeys->AsObject()->GetBoolField(TEXT("success")));
+	TestEqual(TEXT("near-equal keys leave points intact"), Second->GetNumberOfSplinePoints(), 2);
+	const auto Rollback = Response->AsObject()->GetObjectField(TEXT("rollback"))->GetObjectField(TEXT("payload"));
+	const auto Restored = Registry.ExecuteHandler(TEXT("set_spline_points"), Rollback);
+	TestTrue(TEXT("MCP rollback succeeds"), Restored->AsObject()->GetBoolField(TEXT("success")));
+	TestEqual(TEXT("rollback restores count"), Second->GetNumberOfSplinePoints(), OriginalCount);
+	TestTrue(TEXT("rollback restores world position"), Second->GetLocationAtSplinePoint(0, ESplineCoordinateSpace::World).Equals(OriginalPoint,.01));
+	TestTrue(TEXT("rollback restores stored rotation"), Second->GetSplinePointsRotation().Points[0].OutVal.Equals(OriginalRotation,1e-5));
+	TestTrue(TEXT("rollback restores scale"), Second->GetScaleAtSplinePoint(1).Equals(OriginalScale,1e-5));
+	TestTrue(TEXT("rollback restores loop parameterization"), FMath::IsNearlyEqual(Second->GetSplineLength(),OriginalLength,.01f));
+	TestTrue(TEXT("successful mutation marks package dirty"), World->GetOutermost()->IsDirty());
+	GEditor->UndoTransaction();
+	TestEqual(TEXT("Undo restores the state before rollback"), Second->GetNumberOfSplinePoints(), 2);
+	GEditor->RedoTransaction();
+	TestEqual(TEXT("Redo restores original point count"), Second->GetNumberOfSplinePoints(), OriginalCount);
+	Actor->Destroy();
+	World->GetOutermost()->SetDirtyFlag(WasDirty);
+	return true;
+}
+#endif

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/ViewportCameraHandlerTests.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Tests/ViewportCameraHandlerTests.cpp
@@ -1,0 +1,114 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Handlers/EditorHandlers.h"
+#include "HandlerRegistry.h"
+
+#include "Editor.h"
+#include "LevelEditorViewport.h"
+#include "EditorViewportClient.h"
+#include "Misc/AutomationTest.h"
+
+namespace
+{
+TSharedPtr<FJsonValue> ViewportCall(FMCPHandlerRegistry& Registry, const TCHAR* Projection, double OrthoZoom = 0.0, bool bIncludeZoom = false)
+{
+	TSharedPtr<FJsonObject> Params = MakeShared<FJsonObject>();
+	if (Projection) Params->SetStringField(TEXT("projection"), Projection);
+	if (bIncludeZoom) Params->SetNumberField(TEXT("orthoZoom"), OrthoZoom);
+	return Registry.ExecuteHandler(TEXT("set_viewport_camera"), Params);
+}
+
+bool IsFailure(const TSharedPtr<FJsonValue>& Response)
+{
+	return Response.IsValid() && Response->Type == EJson::Object
+		&& !Response->AsObject()->GetBoolField(TEXT("success"));
+}
+}
+
+/** The camera setter must reject bad projection/zoom values before changing the
+ * viewport, and valid orthographic/perspective writes must be observable in the
+ * response. This is intentionally a focused editor test; no project content is
+ * opened or modified. */
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FViewportCameraProjectionTest,
+	"UE.MCP.Editor.ViewportCamera.ProjectionAndZoom",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FViewportCameraProjectionTest::RunTest(const FString& Parameters)
+{
+	if (!GEditor || GEditor->GetLevelViewportClients().Num() == 0)
+	{
+		AddInfo(TEXT("Skipped: no level editor viewport client is available in this editor session."));
+		return true;
+	}
+
+	FMCPHandlerRegistry Registry;
+	FEditorHandlers::RegisterHandlers(Registry);
+	FLevelEditorViewportClient* Client = GCurrentLevelEditingViewportClient
+		? GCurrentLevelEditingViewportClient : GEditor->GetLevelViewportClients()[0];
+	const ELevelViewportType OriginalType = Client->GetViewportType();
+	const float OriginalZoom = Client->GetOrthoZoom();
+	const FVector OriginalLocation = Client->GetViewLocation();
+	const FRotator OriginalRotation = Client->GetViewRotation();
+
+	const TSharedPtr<FJsonValue> BadProjection = ViewportCall(Registry, TEXT("not-a-view"));
+	TestTrue(TEXT("invalid projection is rejected"), IsFailure(BadProjection));
+	TestEqual(TEXT("invalid projection leaves viewport type unchanged"), static_cast<int32>(Client->GetViewportType()), static_cast<int32>(OriginalType));
+
+	const TSharedPtr<FJsonValue> BadZoom = ViewportCall(Registry, TEXT("top"), 0.0, true);
+	TestTrue(TEXT("zero orthographic zoom is rejected"), IsFailure(BadZoom));
+	TestEqual(TEXT("invalid zoom leaves viewport type unchanged"), static_cast<int32>(Client->GetViewportType()), static_cast<int32>(OriginalType));
+	TestEqual(TEXT("invalid zoom leaves orthographic zoom unchanged"), Client->GetOrthoZoom(), OriginalZoom);
+	for (double Extreme : { 1e-300, 1e300, -1.0 })
+	{
+		TestTrue(TEXT("unrepresentable/out-of-range zoom is rejected"), IsFailure(ViewportCall(Registry, TEXT("top"), Extreme, true)));
+		TestEqual(TEXT("bad zoom preserves projection"), static_cast<int32>(Client->GetViewportType()), static_cast<int32>(OriginalType));
+		TestEqual(TEXT("bad zoom preserves zoom"), Client->GetOrthoZoom(), OriginalZoom);
+	}
+
+	const TSharedPtr<FJsonValue> Top = ViewportCall(Registry, TEXT("top"), 1000.0, true);
+	TestFalse(TEXT("top orthographic projection succeeds"), IsFailure(Top));
+	TestEqual(TEXT("top projection is applied"), static_cast<int32>(Client->GetViewportType()), static_cast<int32>(LVT_OrthoXY));
+	TestTrue(TEXT("top zoom is applied"), FMath::IsNearlyEqual(Client->GetOrthoZoom(), 1000.0f));
+	if (Top.IsValid() && Top->Type == EJson::Object)
+	{
+		TestTrue(TEXT("response includes current location"), Top->AsObject()->HasField(TEXT("location")));
+		TestTrue(TEXT("response includes current rotation"), Top->AsObject()->HasField(TEXT("rotation")));
+		TestEqual(TEXT("response includes top projection"), Top->AsObject()->GetStringField(TEXT("projection")), FString(TEXT("top")));
+	}
+
+	const TSharedPtr<FJsonValue> Perspective = ViewportCall(Registry, TEXT("perspective"));
+	TestFalse(TEXT("perspective projection succeeds"), IsFailure(Perspective));
+	TestEqual(TEXT("perspective projection is applied"), static_cast<int32>(Client->GetViewportType()), static_cast<int32>(LVT_Perspective));
+	const FVector BeforeCrossLocation = Client->GetViewLocation();
+	const FRotator BeforeCrossRotation = Client->GetViewRotation();
+	auto CrossParams = MakeShared<FJsonObject>();
+	auto CrossArgs = MakeShared<FJsonObject>();
+	CrossArgs->SetStringField(TEXT("projection"), TEXT("top"));
+	CrossArgs->SetNumberField(TEXT("orthoZoom"), 4000.0);
+	auto CrossLocation = MakeShared<FJsonObject>();
+	CrossLocation->SetNumberField(TEXT("x"), 12345.0); CrossLocation->SetNumberField(TEXT("y"), -6789.0); CrossLocation->SetNumberField(TEXT("z"), 10000.0);
+	CrossArgs->SetObjectField(TEXT("location"), CrossLocation);
+	CrossParams->SetObjectField(TEXT("args"), CrossArgs);
+	const auto Cross = Registry.ExecuteHandler(TEXT("set_viewport_camera"), CrossParams);
+	TestFalse(TEXT("combined nested projection and pose succeeds"), IsFailure(Cross));
+	TestTrue(TEXT("pose applies to the requested projection cache"), Client->GetViewLocation().Equals(FVector(12345,-6789,10000),.01));
+	if (Cross && Cross->Type == EJson::Object && Cross->AsObject()->HasField(TEXT("rollback")))
+	{
+		const auto Payload = Cross->AsObject()->GetObjectField(TEXT("rollback"))->GetObjectField(TEXT("payload"));
+		TestFalse(TEXT("cross-mode rollback succeeds"), IsFailure(Registry.ExecuteHandler(TEXT("set_viewport_camera"),Payload)));
+		TestEqual(TEXT("rollback restores perspective"), static_cast<int32>(Client->GetViewportType()), static_cast<int32>(LVT_Perspective));
+		TestTrue(TEXT("rollback restores the previous active location"), Client->GetViewLocation().Equals(BeforeCrossLocation,.01));
+		TestTrue(TEXT("rollback restores the previous active rotation"), Client->GetViewRotation().Equals(BeforeCrossRotation,.001));
+	}
+
+	// Restore only the viewport state this test touched.
+	Client->SetViewportType(OriginalType);
+	Client->SetOrthoZoom(OriginalZoom);
+	Client->SetViewLocation(OriginalLocation);
+	Client->SetViewRotation(OriginalRotation);
+	Client->Invalidate();
+	return true;
+}
+
+#endif


### PR DESCRIPTION
## What changed

Extended native viewport camera control with orthographic projections, bounded zoom, state readback, and cross-mode rollback. Extended native spline editing with exact component selection, typed points, strict prevalidation, editor Undo, and portable point/loop rollback data.

## Why

Calibrated top-down editor workflows need a reliable projection switch and exact spline boundaries. The camera setter now switches its transform cache before applying a requested pose. Spline requests reject malformed input before clearing existing geometry and retain point keys, interpolation types, tangents, rotations, scales, and explicit loop endpoints.

Older MCP category schemas can pass additional viewport fields through `args` and typed spline points through `input`, avoiding a Python workaround. Metadata-bearing spline subclasses return a clear error directing callers to their specialized API. MCP rollback is explicitly marked potentially lossy for ancillary rotation/scale-curve interpolation; editor Undo records the full component state.

## Verification

- `git diff --check` passed.
- Compiled the modified handlers and editor automation-test sources against Unreal Engine 5.8 using a guarded, module-scoped `-NoLink` build.
- Added coverage for invalid and extreme zoom values, combined projection/pose changes, cross-mode rollback, named spline targeting, transformed components, malformed and near-equal keys, point-state rollback, and Undo/Redo.

Full test-project linking and live editor automation have not been run. This PR remains a draft until those checks are completed. No TypeScript files or project-specific content are changed.

## Notes for the release

Added native orthographic viewport controls and transactional typed spline editing with strict input validation.
