### PR TITLE
Refuse to start on a task still named like a guard

### DIFF
--- a/src/flow/guards.ts
+++ b/src/flow/guards.ts
@@ -217,3 +217,49 @@ export async function buildGuards(
 
   return guards;
 }
+
+/** The dead naming convention: a task called `guard.<name>.<phase>`. */
+const LEGACY_GUARD_TASK = /^guard\.[^.]+\.(before|after)[A-Za-z0-9]*$/;
+
+/**
+ * Refuse to start when a task is still named like a guard.
+ *
+ * Before guards were declared, a task with this name WAS a guard. Under the
+ * declaration model nothing discovers it, so it becomes an ordinary task
+ * nobody calls: a source-control write guard would keep appearing in the
+ * config and stop gating anything, silently.
+ *
+ * That is the exact failure the declaration model exists to prevent, so the
+ * migration must not reintroduce it. A leftover name is fatal and says what to
+ * write instead.
+ */
+export function assertNoLegacyGuardTasks(
+  taskNames: string[],
+  source: GuardSource,
+): void {
+  const legacy = taskNames.filter((n) => LEGACY_GUARD_TASK.test(n));
+  if (legacy.length === 0) return;
+
+  const examples = legacy.slice(0, 3).map((name) => {
+    const [, guardName, phase] = /^guard\.([^.]+)\.(.+)$/.exec(name)!;
+    const scope = /Write$/.test(phase) ? "writes" : "all";
+    const hook = phase.startsWith("after") ? "after" : "before";
+    return (
+      `  ${name}\n`
+      + "    becomes:\n"
+      + "      guards:\n"
+      + `        ${guardName}:\n`
+      + `          scope: ${scope}\n`
+      + `          ${hook}:\n`
+      + "            class_path: <the class_path that task had>"
+    );
+  });
+
+  throw new Error(
+    `${source.label} declares ${legacy.length} task(s) named like a guard, which no longer makes `
+    + "them one. A guard is declared in a `guards:` section now, so these are ordinary tasks that "
+    + "nothing calls: whatever they were gating is ungated while the config still says it is "
+    + `guarded.\n\n${examples.join("\n\n")}\n\n`
+    + "See the guards documentation for the full shape, including order and the after hook.",
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ import { info, warn, debug } from "./log.js";
 import { startVersionCheck, consumeUpgradeNotice } from "./version-check.js";
 import { buildFlowRegistry } from "./flow/registry.js";
 import { GuardRegistry } from "./flow/guard.js";
-import { buildGuards } from "./flow/guards.js";
+import { assertNoLegacyGuardTasks, buildGuards } from "./flow/guards.js";
 import type { GuardDeclarations } from "./flow/guard-schema.js";
 import { loadFlowConfig } from "./flow/loader.js";
 import { createFlowTool } from "./flow/flow-tool.js";
@@ -515,6 +515,14 @@ async function main() {
       ...load.pluginLoad.guardsByPlugin.map((g) => ({ label: g.plugin, guards: g.guards })),
       { label: "ue-mcp.yml", guards: (projectConfig.guards ?? {}) as GuardDeclarations },
     ];
+
+    // A task still named like a guard is fatal, whoever declared it: under the
+    // declaration model nothing discovers it, so it would sit in the config
+    // gating nothing.
+    assertNoLegacyGuardTasks(Object.keys(projectConfig.tasks ?? {}), { label: "ue-mcp.yml" });
+    for (const { plugin, taskNames } of load.pluginLoad.taskNamesByPlugin) {
+      assertNoLegacyGuardTasks(taskNames, { label: plugin });
+    }
 
     let count = 0;
     for (const source of sources) {

--- a/src/plugin/loader.ts
+++ b/src/plugin/loader.ts
@@ -75,6 +75,8 @@ export interface PluginLoadResult {
    * distinguishable rather than one silently replacing the other.
    */
   guardsByPlugin: Array<{ plugin: string; guards: GuardDeclarations }>;
+  /** Task names per plugin, so a name that used to mean "guard" can be refused. */
+  taskNamesByPlugin: Array<{ plugin: string; taskNames: string[] }>;
   /** Per-category markdown to append to AI-facing docs. */
   knowledgeByCategory: Record<string, string[]>;
 }
@@ -87,6 +89,7 @@ const EMPTY_RESULT: PluginLoadResult = {
   taskDefs: {},
   flowDefs: {},
   guardsByPlugin: [],
+  taskNamesByPlugin: [],
   knowledgeByCategory: {},
 };
 
@@ -121,6 +124,7 @@ export async function loadPlugins(
   const taskDefs: Record<string, TaskDefinition> = {};
   const flowDefs: Record<string, FlowDefinition> = {};
   const guardsByPlugin: Array<{ plugin: string; guards: GuardDeclarations }> = [];
+  const taskNamesByPlugin: Array<{ plugin: string; taskNames: string[] }> = [];
   const knowledgeByCategory: Record<string, string[]> = {};
   // For each category, accumulate injection plans across all plugins.
   const plansByCategory = new Map<string, InjectionPlan[]>();
@@ -161,6 +165,7 @@ export async function loadPlugins(
     if (Object.keys(manifest.guards).length > 0) {
       guardsByPlugin.push({ plugin: pkg.name, guards: manifest.guards });
     }
+    taskNamesByPlugin.push({ plugin: pkg.name, taskNames: Object.keys(manifest.tasks) });
 
     // Merge plugin-supplied flows, filtered by the user's group toggles. A flow
     // whose group is disabled in `ue-mcp.pluginConfig.<slug>.groups` is dropped
@@ -336,6 +341,7 @@ export async function loadPlugins(
     taskDefs,
     flowDefs,
     guardsByPlugin,
+    taskNamesByPlugin,
     knowledgeByCategory,
   };
 }

--- a/tests/unit/guards.test.ts
+++ b/tests/unit/guards.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { BaseTask, TaskRegistry, type TaskResult, type TaskConstructor } from "@db-lyon/flowkit";
-import { buildGuards } from "../../src/flow/guards.js";
+import { assertNoLegacyGuardTasks, buildGuards } from "../../src/flow/guards.js";
 import { GuardsSchema } from "../../src/flow/guard-schema.js";
 import { GuardRegistry, makeCallContext, type CallContext } from "../../src/flow/guard.js";
 import { GuardedBridge } from "../../src/flow/guarded-bridge.js";
@@ -488,5 +488,54 @@ describe("through the bridge a call actually takes", () => {
 
     await expect(bridge.call("get_asset", { assetPath: "/Game/Foo" })).resolves.toEqual({ ok: true });
     expect(inner.calls).toEqual(["get_asset"]);
+  });
+});
+
+/**
+ * The migration must not reintroduce the failure the declaration model exists
+ * to prevent. A task still named like a guard is discovered by nothing, so it
+ * would sit in a config gating nothing while looking configured.
+ */
+describe("a task still named like a guard is fatal", () => {
+  it("refuses the old spelling and says what to write instead", () => {
+    expect(() =>
+      assertNoLegacyGuardTasks(["guard.sourcecontrol.beforeWrite", "deploy"], { label: "ue-mcp-perforce" }),
+    ).toThrow(/guards:/);
+  });
+
+  it("names the file or plugin that declared it", () => {
+    expect(() => assertNoLegacyGuardTasks(["guard.policy.before"], { label: "ue-mcp.yml" })).toThrow(
+      /ue-mcp\.yml/,
+    );
+  });
+
+  it("says what is at stake rather than only that it is wrong", () => {
+    expect(() => assertNoLegacyGuardTasks(["guard.policy.before"], { label: "x" })).toThrow(/ungated/);
+  });
+
+  it("translates the phase into the scope and hook it meant", () => {
+    let message = "";
+    try {
+      assertNoLegacyGuardTasks(["guard.sourcecontrol.beforeWrite"], { label: "x" });
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toContain("scope: writes");
+    expect(message).toContain("before:");
+
+    let after = "";
+    try {
+      assertNoLegacyGuardTasks(["guard.audit.after"], { label: "x" });
+    } catch (e) {
+      after = (e as Error).message;
+    }
+    expect(after).toContain("scope: all");
+    expect(after).toContain("after:");
+  });
+
+  it("says nothing about ordinary tasks", () => {
+    expect(() =>
+      assertNoLegacyGuardTasks(["deploy", "guardian", "guard_rail", "my.guard.helper"], { label: "x" }),
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
A task called `guard.<name>.<phase>` used to be a guard. Nothing discovers that name now, so it becomes an ordinary task nobody calls: whatever it gated is ungated while the config still says it is guarded, silently.

That is the failure the declaration model exists to prevent, so the migration must not reintroduce it. Fatal at boot, naming the plugin or config that holds it and printing the declaration to write instead.

## Notes line

A task still named like a guard fails at boot instead of silently gating nothing.

## Verification

146 files / 1864 unit tests, 32 multi-editor, prose clean.