### PR TITLE
The mutations scope fails closed

### DIFF
--- a/docs/plugins-guards.md
+++ b/docs/plugins-guards.md
@@ -30,6 +30,8 @@ Three scopes, from widest to narrowest:
 
 `mutations` and `writes` are different questions, and the difference matters. Spawning an actor, starting a play session or answering a dialog all change something and name no content path, so `writes` never sees them. A call that creates a new asset modifies nothing that exists yet, so `writes` does not see that either. If the rule is "nothing may change until X", the scope is `mutations`.
 
+`mutations` fails closed: a call counts unless its leading verb is a known read. A guard asked to stand in front of everything has to be exhaustive, and a list of mutating verbs is open-ended, so every verb missing from such a list would be a mutation nobody guarded. The read vocabulary is shared with asset locking, so the two cannot drift into disagreeing about what a read is.
+
 Both narrower scopes are computed lazily, so a read pays nothing and a pipeline of guards that all ask pays once.
 
 `before` may deny: returning `success: false`, or throwing, stops the call and the caller gets a `WRITE_BLOCKED` error carrying the message. `after` runs on a call that already happened, so it cannot deny; returning `data` replaces the result, and a failure or a throw is logged and the call stands.

--- a/src/flow/guard.ts
+++ b/src/flow/guard.ts
@@ -25,6 +25,7 @@ import type { IBridge } from "../bridge.js";
 import type { ProjectContext } from "../project.js";
 import type { EditorSession } from "../session.js";
 import { classifyWrite, type WriteClassification } from "./write-methods.js";
+import { READ_PREFIXES } from "../locking.js";
 
 /** Resolve a UE content path to an absolute on-disk file, or null if it does not exist. */
 export type ResolveExistingFile = (contentPath: string) => string | null;
@@ -64,17 +65,34 @@ export function writeScope(ctx: CallContext): boolean {
 }
 
 /**
- * Every call that changes editor state.
+ * Every call that is not provably a read.
  *
  * Wider than `writeScope`, and deliberately so. That one asks which existing
- * files a call modifies, which is the question a source-control guard has. A
- * guard told to stand in front of everything that mutates has a different
- * question: spawning an actor, starting a play session or pressing a dialog
- * button all change something and name no asset, so they are invisible to the
- * narrower scope while being exactly what "block every mutation" means.
+ * files a call modifies, which is the source-control question: it answers
+ * "no" whenever it cannot extract a content path, and a call with no asset
+ * path in its parameters is still a mutation of the editor.
+ *
+ * This one FAILS CLOSED. A guard told to stand in front of everything that
+ * mutates is asked to be exhaustive, so anything whose verb is not a known
+ * read counts. Listing mutating verbs instead was the wrong way round: the
+ * list is open-ended, and every verb missing from it was a mutation nobody
+ * guarded. The read lexicon is the same one asset locking uses, so the two
+ * cannot drift into disagreeing about what a read is.
  */
 export function mutationScope(ctx: CallContext): boolean {
-  return ctx.write().mutates;
+  return !isReadVerb(ctx.method);
+}
+
+/** Whether a method's leading verb is a known read. Shared with asset locking. */
+function isReadVerb(method: string): boolean {
+  const segments = String(method).toLowerCase().split(/[._]/);
+  let verb = segments[0] ?? "";
+  // "bulk" and "batch" describe the shape of a call, not what it does, so the
+  // verb after one is the answer: `bulk_read_properties` only looks.
+  if ((verb === "bulk" || verb === "batch") && segments.length > 1) {
+    verb = segments[1];
+  }
+  return (READ_PREFIXES as readonly string[]).includes(verb);
 }
 
 /** Build the per-call context, wiring the lazy write-enrichment helpers. */

--- a/src/flow/write-methods.ts
+++ b/src/flow/write-methods.ts
@@ -31,16 +31,6 @@ export interface WriteClassification {
    * anything".
    */
   writes: boolean;
-  /**
-   * Whether this call changes editor state at all.
-   *
-   * Separate from `writes` because most mutations are not asset writes: a call
-   * that spawns an actor, sets a live property or starts a play session
-   * changes the world and names no content path. A guard asked to stand in
-   * front of every mutation needs this one; a guard checking files out of
-   * source control needs `writes`.
-   */
-  mutates: boolean;
   /** UE content paths the call modifies. Empty when nothing is guardable. */
   contentPaths: string[];
 }
@@ -48,18 +38,6 @@ export interface WriteClassification {
 /** Method-name prefixes that denote a mutation. Read verbs are excluded. */
 const WRITE_VERB =
   /^(save|set|create|add|delete|remove|import|rename|move|duplicate|reparent|compile|apply|assign|modify|bake|generate|build)_/;
-
-/**
- * Verbs that change editor state without naming an asset.
- *
- * Spawning an actor, starting a play session, pressing a dialog button and
- * launching a build all change something somebody could care about, and none
- * of them writes a content path. A guard standing in front of "everything that
- * mutates" has to see these, which is why `mutates` is a wider question than
- * `writes`.
- */
-const MUTATING_VERB =
-  /^(spawn|destroy|attach|detach|possess|eject|start|stop|restart|launch|play|pause|resume|simulate|inject|press|respond|execute|run|trigger|invoke|arm|clear|reset|undo|redo|snap|nudge|align|focus|select|deselect|open|close|connect|disconnect|enable|disable|toggle|refresh|reload|deploy|sync|upload|download|install|uninstall|publish)_/;
 
 /** Single-value params that carry an asset content path. */
 const PATH_KEYS = ["assetPath", "sourcePath", "destinationPath", "packagePath", "path"];
@@ -152,20 +130,14 @@ const EXPLICIT: Record<string, Extractor> = {
  * `writes: false` when the call is not a guardable write.
  */
 export function classifyWrite(method: string, params: Record<string, unknown>): WriteClassification {
-  // A method is a mutation because of what it does, not because of whether it
-  // happened to name a path this call can resolve.
-  const mutates = EXPLICIT[method] !== undefined
-    || WRITE_VERB.test(method)
-    || MUTATING_VERB.test(method);
-
   const explicit = EXPLICIT[method];
   if (explicit) {
     const contentPaths = dedupe(explicit(params));
-    return { writes: contentPaths.length > 0, mutates, contentPaths };
+    return { writes: contentPaths.length > 0, contentPaths };
   }
 
   if (!WRITE_VERB.test(method)) {
-    return { writes: false, mutates, contentPaths: [] };
+    return { writes: false, contentPaths: [] };
   }
 
   const contentPaths: string[] = [];
@@ -178,7 +150,7 @@ export function classifyWrite(method: string, params: Record<string, unknown>): 
   }
 
   const deduped = dedupe(contentPaths);
-  return { writes: deduped.length > 0, mutates, contentPaths: deduped };
+  return { writes: deduped.length > 0, contentPaths: deduped };
 }
 
 function dedupe(xs: string[]): string[] {

--- a/tests/unit/guards.test.ts
+++ b/tests/unit/guards.test.ts
@@ -206,20 +206,50 @@ describe("standing in front of every mutation", () => {
     );
 
     for (const m of [
-      "spawn_actor",
-      "destroy_actor",
-      "save_asset",
-      "delete_asset",
-      "set_actor_property",
-      "start_pie",
-      "stop_editor",
-      "execute_python",
-      "respond_to_dialog",
-      "import_fbx",
-      "compile_blueprint",
+      // Named-asset writes.
+      "save_asset", "delete_asset", "import_fbx", "compile_blueprint",
+      // Mutations that name no asset, which the writes scope cannot see.
+      "spawn_actor", "destroy_actor", "set_actor_property", "start_pie",
+      "stop_editor", "execute_python", "respond_to_dialog",
+      // Bare verbs. A rule matching a trailing underscore missed every one.
+      "save", "create", "compile", "duplicate", "load", "sculpt",
+      // Verbs a hand-written list did not think of.
+      "write_cpp_file", "write_source_file", "build", "use_editor",
+      "drop_editor", "bulk_rename", "batch_translate", "edit_user_defined_enum",
+      "reorder_enum_values", "metasound_author", "place_actor", "unlock",
+      "force_reload", "update_datatable_row", "reimport", "request_editor_shutdown",
     ]) {
       expect(await guard.appliesTo!(callCtx(m, {})), m).toBe(true);
     }
+  });
+
+  it("fails closed on a verb nobody has seen before", async () => {
+    // The point of the scope is to be exhaustive. Listing mutating verbs was
+    // the wrong way round: the list is open-ended, and every verb missing from
+    // it was a mutation nobody guarded.
+    const registry = registryWith({ check: ALLOW });
+    const [guard] = await buildGuards(
+      declare({ freeze: { scope: "mutations", before: { class_path: "check" } } }),
+      deps(registry),
+      SOURCE,
+    );
+
+    for (const m of ["frobnicate_widget", "teleport_pawn", "zzz_unknown_operation"]) {
+      expect(await guard.appliesTo!(callCtx(m, {})), m).toBe(true);
+    }
+  });
+
+  it("still lets a shaped read through", async () => {
+    const registry = registryWith({ check: ALLOW });
+    const [guard] = await buildGuards(
+      declare({ freeze: { scope: "mutations", before: { class_path: "check" } } }),
+      deps(registry),
+      SOURCE,
+    );
+
+    // "bulk" and "batch" describe the shape of a call, not what it does.
+    expect(await guard.appliesTo!(callCtx("bulk_read_properties", {}))).toBe(false);
+    expect(await guard.appliesTo!(callCtx("batch_get_actors", {}))).toBe(false);
   });
 
   it("blocks one end to end, through the bridge a call actually takes", async () => {

--- a/tests/unit/write-methods.test.ts
+++ b/tests/unit/write-methods.test.ts
@@ -124,9 +124,6 @@ describe("classifyWrite", () => {
     for (const [method, params, expectedPath] of cases) {
       expect(classifyWrite(method, params), method).toEqual({
         writes: true,
-        // Every one of these is also a mutation, which is the wider question a
-        // guard scoped to mutations asks.
-        mutates: true,
         contentPaths: [expectedPath],
       });
     }


### PR DESCRIPTION
A guard scoped to `mutations` saw 542 of 1090 actions. It now sees 774, and nothing that mutates is treated as a read.

The scope asked a hand-written list of mutating verbs, which is the wrong way round twice over. The list is open-ended, so every verb missing from it was a mutation nobody guarded: `write_cpp_file`, `build`, `sculpt`, `place_actor`, `bulk_rename`, `metasound_author` and twenty more. And its verbs were matched as prefixes with a trailing underscore, so bare forms escaped too: `save`, `create`, `compile`, `duplicate`, `load`.

A guard told to stand in front of everything has to be exhaustive, so the question is inverted: a call counts unless its leading verb is a known read. The read vocabulary is the one asset locking already uses rather than a second copy.

The `mutates` field on the write classifier is removed with it. That classifier answers which content paths a call writes and returns false whenever it cannot find one, which is right for source control and wrong for this question.

## Notes line

A guard scoped to mutations now fails closed, covering every call that is not provably a read.

## Verification

146 files / 1872 unit tests, 32 multi-editor, including the bare verbs, the verbs no list held, an unknown verb, and the shaped reads that must still pass.