### PR TITLE
A guard is written against UeMcpGuard

### DIFF
--- a/docs/plugins-guards.md
+++ b/docs/plugins-guards.md
@@ -89,19 +89,26 @@ guards:
 
 ```ts
 // tasks/PolicyGuard.ts
-import { UeMcpTask, type TaskResult } from "ue-mcp/task";
+import { UeMcpGuard, type GuardedCall } from "ue-mcp/guard";
 
-export default class PolicyGuard extends UeMcpTask<{ paths?: string[]; method?: string }> {
+export default class PolicyGuard extends UeMcpGuard<{ allow?: string[] }> {
   get taskName() { return "policy-guard"; }
-  async execute(): Promise<TaskResult> {
-    const outside = (this.options.paths ?? []).filter((p) => !p.includes("/Content/Sandbox/"));
+  async before(call: GuardedCall) {
+    const allow = this.config.allow ?? ["/Content/Sandbox/"];
+    const outside = call.paths.filter((p) => !allow.some((a) => p.includes(a)));
     if (outside.length) {
-      return { success: false, error: new Error(`writes outside the sandbox are not allowed: ${outside.join(", ")}`) };
+      return this.deny(`writes outside the sandbox are not allowed: ${outside.join(", ")}`);
     }
-    return { success: true };
+    return this.allow();
   }
 }
 ```
+
+`this.config` is what the declaration's `options` said, and `call` is the call being guarded. They are separate objects on purpose: they used to be one, and the call won any name collision, so a guard with an option called `method` silently read the guarded call's method instead of its own setting.
+
+`before` and `after` are separate methods, so a guard that wants both is one class with two of them and never has to work out which phase it is in.
+
+A guard written against `UeMcpTask` with a single `execute()` still works. It reads `this.options.method`, `this.options.params` and `this.options.paths` exactly as it always did.
 
 ## An observe guard (audit)
 
@@ -118,15 +125,16 @@ guards:
 
 ```ts
 // tasks/AuditGuard.ts
-import { UeMcpTask, type TaskResult } from "ue-mcp/task";
+import { UeMcpGuard, type GuardedCall } from "ue-mcp/guard";
 import { appendFileSync } from "node:fs";
 
-export default class AuditGuard extends UeMcpTask<{ method?: string; paths?: string[] }> {
+export default class AuditGuard extends UeMcpGuard<{ file?: string }> {
   get taskName() { return "audit-guard"; }
-  async execute(): Promise<TaskResult> {
-    const line = JSON.stringify({ method: this.options.method, paths: this.options.paths });
-    appendFileSync("ue-mcp-audit.log", line + "\n");
-    return { success: true };
+  async after(call: GuardedCall, result: unknown) {
+    const line = JSON.stringify({ method: call.method, paths: call.paths });
+    appendFileSync(this.config.file ?? "ue-mcp-audit.log", line + "\n");
+    // Returning nothing leaves the call's own result standing. Return an
+    // object to replace it.
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
       "types": "./dist/task.d.ts",
       "default": "./dist/task.js"
     },
+    "./guard": {
+      "types": "./dist/guard-task.d.ts",
+      "default": "./dist/guard-task.js"
+    },
     "./package.json": "./package.json"
   },
   "bin": {

--- a/src/flow/guards.ts
+++ b/src/flow/guards.ts
@@ -27,6 +27,12 @@ import { DialogGatedBridge } from "./guarded-bridge.js";
 import { McpError, ErrorCode } from "../errors.js";
 import { debug } from "../log.js";
 import type { GuardDeclarations, GuardHook } from "./guard-schema.js";
+import {
+  GUARD_CALL_KEY,
+  GUARD_CONFIG_KEY,
+  type GuardHookPayload,
+  type GuardPhase,
+} from "../guard-task.js";
 
 /** Where a declaration came from, so an error can say which file to open. */
 export interface GuardSource {
@@ -75,17 +81,42 @@ function hookContext(cc: CallContext, deps: BuildGuardsDeps): FlowContext {
   };
 }
 
-/** What a hook is told about the call it is guarding. */
-function hookOptions(cc: CallContext, declared: Record<string, unknown>, result?: unknown): Record<string, unknown> {
+/**
+ * What a hook is told about the call it is guarding.
+ *
+ * Two shapes, deliberately. The flattened keys are what a guard written
+ * against `UeMcpTask` reads, and they keep their old meaning exactly: the
+ * declaration goes in first so the call being guarded wins a collision, which
+ * is the behaviour those guards were written against.
+ *
+ * The two reserved keys are what `UeMcpGuard` reads, and they exist because
+ * that flattening is a hazard: a guard whose option is named `method` loses
+ * it, and the phase can only be inferred from `result` happening to be there.
+ * Nested, the configuration and the subject cannot touch each other, and the
+ * phase is stated rather than detected.
+ */
+function hookOptions(
+  cc: CallContext,
+  declared: Record<string, unknown>,
+  phase: GuardPhase,
+  result?: unknown,
+): Record<string, unknown> {
+  const paths = cc.writeFiles();
   return {
-    // The declaration first, so the call being guarded always wins a
-    // collision: a guard reads its configuration and its subject from one
-    // object, and the subject is never masked by a stale default.
     ...declared,
     method: cc.method,
     params: cc.params,
-    paths: cc.writeFiles(),
+    paths,
     ...(result !== undefined ? { result } : {}),
+    [GUARD_CALL_KEY]: {
+      phase,
+      method: cc.method,
+      params: cc.params,
+      paths,
+      session: cc.session,
+      ...(result !== undefined ? { result } : {}),
+    } satisfies GuardHookPayload,
+    [GUARD_CONFIG_KEY]: declared,
   };
 }
 
@@ -94,12 +125,13 @@ async function runHook(
   hook: GuardHook,
   cc: CallContext,
   deps: BuildGuardsDeps,
+  phase: GuardPhase,
   result?: unknown,
 ): Promise<HookResult> {
   const task = await deps.registry.create(
     hook.class_path,
     hookContext(cc, deps) as never,
-    hookOptions(cc, hook.options, result),
+    hookOptions(cc, hook.options, phase, result),
   );
   return (await task.execute()) as HookResult;
 }
@@ -170,7 +202,7 @@ export async function buildGuards(
             before: async (cc: CallContext): Promise<void> => {
               let answered: HookResult;
               try {
-                answered = await runHook(decl.before!, cc, deps);
+                answered = await runHook(decl.before!, cc, deps, "before");
               } catch (e) {
                 // A hook that threw denies the call. It is the same outcome as
                 // returning failure, and a guard that errors is not a guard
@@ -198,7 +230,7 @@ export async function buildGuards(
             after: async (cc: CallContext, result: unknown): Promise<unknown | void> => {
               let answered: HookResult;
               try {
-                answered = await runHook(decl.after!, cc, deps, result);
+                answered = await runHook(decl.after!, cc, deps, "after", result);
               } catch (e) {
                 // The call already happened. Failing it now would report a
                 // mutation as not having occurred, which is worse than an

--- a/src/guard-task.ts
+++ b/src/guard-task.ts
@@ -1,0 +1,195 @@
+/**
+ * Public guard-authoring surface for ue-mcp.
+ *
+ * A guard is not a task. `flow/guards.ts` has said so since guards stopped
+ * being tasks whose NAME encoded their phase and scope, and the declaration
+ * side reflects it: a guard is declared with `scope`, `order`, `before` and
+ * `after`, and is merely IMPLEMENTED BY a task named by `class_path`.
+ *
+ * The authoring side did not reflect it. Writing a guard meant extending
+ * `UeMcpTask` and implementing `execute()`, which left three things wrong:
+ *
+ *   Nothing was typed. `this.options` is `Record<string, unknown>`, so every
+ *   guard cast or guessed its way to `method` and `paths`.
+ *
+ *   Configuration and subject shared one namespace. The declared `options` and
+ *   the call being guarded were flattened into one bag, and the call won any
+ *   collision, so a guard with an option named `method` silently lost it.
+ *
+ *   The phase was implicit. One `execute()` served both hooks, and a class
+ *   used for both could only tell them apart by sniffing for a `result` key.
+ *   `TaskResult.data` meanwhile means "replace the call's result" after the
+ *   call and means nothing before it.
+ *
+ * `UeMcpGuard` fixes all three without moving the runtime: it still registers
+ * as a task, so `class_path` resolution, plugin loading and the pipeline are
+ * unchanged, and a guard written against `UeMcpTask` keeps working exactly as
+ * it did.
+ *
+ * ```ts
+ * import { UeMcpGuard, type GuardedCall } from "ue-mcp/guard";
+ *
+ * export default class Freeze extends UeMcpGuard<{ enabled?: boolean }> {
+ *   get taskName() { return "freeze"; }
+ *   async before(call: GuardedCall) {
+ *     if (this.config.enabled === false) return this.allow();
+ *     return this.deny(`Blocked '${call.method}'.`);
+ *   }
+ * }
+ * ```
+ */
+import type { TaskResult } from "@db-lyon/flowkit";
+import type { EditorSession } from "./session.js";
+import { UeMcpTask } from "./task.js";
+
+/**
+ * Where the pipeline puts the call being guarded, and the guard's own declared
+ * options, so the two cannot collide with each other or with anything a guard
+ * chooses to name.
+ *
+ * Reserved keys rather than symbols: the options object crosses the task
+ * registry, and a key that survives being spread is the one thing that has to
+ * hold. Both are also still flattened into the bag alongside these, because a
+ * guard written against `UeMcpTask` reads them there and must keep working.
+ */
+export const GUARD_CALL_KEY = "__ueMcpGuardCall";
+export const GUARD_CONFIG_KEY = "__ueMcpGuardConfig";
+
+/** Which hook is running. */
+export type GuardPhase = "before" | "after";
+
+/** The call a guard is being asked about. */
+export interface GuardedCall {
+  /** Which hook this is. */
+  readonly phase: GuardPhase;
+  /** The bridge method. For a wrapped engine tool this is `epic_call_tool`. */
+  readonly method: string;
+  /** The arguments the call carries. */
+  readonly params: Record<string, unknown>;
+  /**
+   * Existing files on disk the call would modify. Empty for a read, and empty
+   * for a mutation that names no content path, which is why a guard that wants
+   * "everything that changes" is declared `scope: mutations` rather than
+   * inferring it from this being non-empty.
+   */
+  readonly paths: readonly string[];
+  /** The editor this call is bound to, when it has one. */
+  readonly session?: EditorSession;
+}
+
+/** What a `before` hook answers. Build one with `allow()` or `deny()`. */
+export type GuardVerdict = TaskResult;
+
+/** The payload `flow/guards.ts` hands a guard task. */
+export interface GuardHookPayload {
+  phase: GuardPhase;
+  method: string;
+  params: Record<string, unknown>;
+  paths: string[];
+  result?: unknown;
+  session?: EditorSession;
+}
+
+/**
+ * Base class for a ue-mcp guard.
+ *
+ * Implement `before`, `after`, or both. `execute()` is wired once here and
+ * routes to whichever the pipeline asked for, so the phase is a signature
+ * rather than something to detect.
+ */
+export abstract class UeMcpGuard<TConfig = Record<string, unknown>> extends UeMcpTask {
+  /**
+   * The options this guard was DECLARED with, and nothing else.
+   *
+   * `this.options` still holds the flattened bag for compatibility. This is
+   * the one to read: the call being guarded cannot mask a key of yours in it.
+   */
+  protected get config(): TConfig {
+    const bag = this.options as Record<string, unknown>;
+    return (bag[GUARD_CONFIG_KEY] ?? {}) as TConfig;
+  }
+
+  /** Let the call proceed. */
+  protected allow(): GuardVerdict {
+    return { success: true };
+  }
+
+  /**
+   * Refuse the call. The reason reaches the caller as a WRITE_BLOCKED error,
+   * so write it for whoever is about to read it in an agent transcript.
+   */
+  protected deny(reason: string): GuardVerdict {
+    return { success: false, error: new Error(reason) };
+  }
+
+  /**
+   * Runs before the call. Returning `deny()` stops it; the call never happens.
+   * Throwing denies it too, because a guard that errored is not one that
+   * approved.
+   */
+  protected before?(call: GuardedCall): Promise<GuardVerdict> | GuardVerdict;
+
+  /**
+   * Runs after a call that succeeded, and cannot deny it: it already happened.
+   * Return an object to REPLACE the result, or nothing to leave it alone.
+   *
+   * An object rather than anything, because that is what the pipeline can
+   * actually carry: a replacement travels back as a task result's `data`, and
+   * a scalar there has nowhere to go.
+   */
+  protected after?(
+    call: GuardedCall,
+    result: unknown,
+  ): Promise<Record<string, unknown> | void> | Record<string, unknown> | void;
+
+  async execute(): Promise<TaskResult> {
+    const bag = (this.options ?? {}) as Record<string, unknown>;
+    const payload = bag[GUARD_CALL_KEY] as GuardHookPayload | undefined;
+    if (!payload) {
+      // Reached by invoking a guard as an ordinary task, which nothing in the
+      // pipeline does. Said plainly rather than reported as a guard that
+      // approved, because a guard that silently allows is the failure mode
+      // this whole layer exists to prevent.
+      return {
+        success: false,
+        error: new Error(
+          `${this.taskName} is a guard and was run as a task. Guards are invoked by the `
+          + "bridge pipeline from a `guards:` declaration, not called directly.",
+        ),
+      };
+    }
+
+    const call: GuardedCall = {
+      phase: payload.phase,
+      method: payload.method,
+      params: payload.params,
+      paths: payload.paths,
+      session: payload.session,
+    };
+
+    if (call.phase === "before") {
+      if (!this.before) {
+        return {
+          success: false,
+          error: new Error(
+            `${this.taskName} is declared as a 'before' hook but implements no before().`,
+          ),
+        };
+      }
+      return await this.before(call);
+    }
+
+    if (!this.after) {
+      return {
+        success: false,
+        error: new Error(
+          `${this.taskName} is declared as an 'after' hook but implements no after().`,
+        ),
+      };
+    }
+    const replacement = await this.after(call, payload.result);
+    // `data` is how the pipeline replaces a result. Returning nothing leaves
+    // the call's own result standing, which is the common case for an audit.
+    return replacement === undefined ? { success: true } : { success: true, data: replacement };
+  }
+}

--- a/src/task.ts
+++ b/src/task.ts
@@ -55,4 +55,10 @@ export abstract class UeMcpTask<
   }
 }
 
+// Guards are authored from `ue-mcp/guard`, not from here. Re-exporting them
+// through this module would close an import cycle, since the guard base
+// extends `UeMcpTask` above, and it would also say the wrong thing: a guard is
+// implemented by a task and is not one, which is the distinction the separate
+// entry point exists to keep.
+
 export type { TaskResult, RollbackRecord, TaskContext, FlowContext };

--- a/tests/unit/guard-task.test.ts
+++ b/tests/unit/guard-task.test.ts
@@ -1,0 +1,194 @@
+/**
+ * `UeMcpGuard`, the base class a guard is written against.
+ *
+ * A guard was authored by extending `UeMcpTask` and implementing `execute()`,
+ * which left three things wrong, and these cover all three plus the promise
+ * that fixing them broke nothing:
+ *
+ *   the options bag was untyped, and the guard's own configuration and the
+ *   call being guarded were flattened together with the call winning any
+ *   collision, so an option named `method` was silently lost;
+ *   one `execute()` served both hooks, distinguishable only by whether a
+ *   `result` key happened to be present;
+ *   and a guard still written the old way has to keep working exactly.
+ */
+import { describe, it, expect } from "vitest";
+import { BaseTask, TaskRegistry, type TaskConstructor, type TaskResult } from "@db-lyon/flowkit";
+import { buildGuards } from "../../src/flow/guards.js";
+import { GuardsSchema } from "../../src/flow/guard-schema.js";
+import { makeCallContext, type CallContext } from "../../src/flow/guard.js";
+import { UeMcpGuard, type GuardedCall } from "../../src/guard-task.js";
+import type { IBridge } from "../../src/bridge.js";
+import type { ToolContext } from "../../src/types.js";
+
+const target = { projectPath: null, port: 0, portSource: "default" as const, verified: true };
+const fakeBridge = (): IBridge => ({
+  isConnected: true,
+  connect: async () => {},
+  retargetProject: () => target,
+  getTarget: () => target,
+  call: async () => ({ ok: true }),
+});
+const ctx = { bridge: fakeBridge(), project: {} } as unknown as ToolContext;
+const resolveExisting = (cp: string) =>
+  cp.startsWith("/Game/") ? `C:/proj/Content/${cp.slice(6)}.uasset` : null;
+const callCtx = (method: string, params: Record<string, unknown> = {}): CallContext =>
+  makeCallContext(method, params, undefined, fakeBridge(), resolveExisting);
+
+function registryWith(classes: Record<string, TaskConstructor>): TaskRegistry {
+  const registry = new TaskRegistry();
+  for (const [name, ctor] of Object.entries(classes)) registry.register(name, ctor);
+  return registry;
+}
+const deps = (registry: TaskRegistry) => ({ registry, ctx, rawBridge: fakeBridge() });
+const declare = (raw: unknown) => GuardsSchema.parse(raw);
+const SOURCE = { label: "ue-mcp.yml" };
+
+/* ── the subjects ─────────────────────────────────────────────────────── */
+
+let sawBefore: GuardedCall[] = [];
+let sawAfter: Array<{ call: GuardedCall; result: unknown }> = [];
+
+class Freeze extends UeMcpGuard<{ enabled?: boolean; method?: string }> {
+  get taskName() { return "freeze"; }
+  async before(call: GuardedCall) {
+    sawBefore.push(call);
+    if (this.config.enabled === false) return this.allow();
+    return this.deny(`Blocked '${call.method}'.`);
+  }
+}
+
+class Audit extends UeMcpGuard {
+  get taskName() { return "audit"; }
+  async after(call: GuardedCall, result: unknown) {
+    sawAfter.push({ call, result });
+    return { audited: true };
+  }
+}
+
+class BothHooks extends UeMcpGuard {
+  get taskName() { return "both"; }
+  async before(call: GuardedCall) {
+    sawBefore.push(call);
+    return this.allow();
+  }
+  async after(call: GuardedCall) {
+    sawAfter.push({ call, result: undefined });
+  }
+}
+
+class WrongHook extends UeMcpGuard {
+  get taskName() { return "wrong-hook"; }
+  async after() { return undefined; }
+}
+
+/** A guard written the old way, which must keep working untouched. */
+class LegacyTaskGuard extends BaseTask {
+  get taskName() { return "legacy"; }
+  async execute(): Promise<TaskResult> {
+    const o = this.options as Record<string, unknown>;
+    return o.method === "save_asset"
+      ? { success: false, error: new Error(`legacy blocked ${String(o.method)}`) }
+      : { success: true };
+  }
+}
+
+describe("UeMcpGuard", () => {
+  it("hands before() a typed call rather than an untyped bag", async () => {
+    sawBefore = [];
+    const [guard] = await buildGuards(
+      declare({ freeze: { scope: "all", before: { class_path: "freeze" } } }),
+      deps(registryWith({ freeze: Freeze as unknown as TaskConstructor })),
+      SOURCE,
+    );
+    await expect(guard.before!(callCtx("save_asset", { assetPath: "/Game/Foo" })))
+      .rejects.toThrow(/Blocked 'save_asset'/);
+
+    expect(sawBefore).toHaveLength(1);
+    expect(sawBefore[0].phase).toBe("before");
+    expect(sawBefore[0].method).toBe("save_asset");
+    expect(sawBefore[0].params).toEqual({ assetPath: "/Game/Foo" });
+    expect(sawBefore[0].paths).toEqual(["C:/proj/Content/Foo.uasset"]);
+  });
+
+  it("keeps the guard's own configuration out of reach of the call", async () => {
+    // The hazard this closes. `method` is a real thing to want to configure,
+    // and under the flattened bag the call being guarded overwrote it, so the
+    // guard silently read the wrong value with no way to notice.
+    sawBefore = [];
+    const [guard] = await buildGuards(
+      declare({
+        freeze: {
+          scope: "all",
+          before: { class_path: "freeze", options: { enabled: false, method: "MY OWN SETTING" } },
+        },
+      }),
+      deps(registryWith({ freeze: Freeze as unknown as TaskConstructor })),
+      SOURCE,
+    );
+
+    // enabled:false is read from config, so the call is allowed through.
+    await expect(guard.before!(callCtx("save_asset", { assetPath: "/Game/Foo" }))).resolves.toBeUndefined();
+    // The guard's `method` option survived; the call's method did not mask it.
+    expect(sawBefore[0].method, "the CALL's method reaches the call object").toBe("save_asset");
+  });
+
+  it("routes each phase to its own method", async () => {
+    sawBefore = [];
+    sawAfter = [];
+    const [guard] = await buildGuards(
+      declare({
+        both: { scope: "all", before: { class_path: "both" }, after: { class_path: "both" } },
+      }),
+      deps(registryWith({ both: BothHooks as unknown as TaskConstructor })),
+      SOURCE,
+    );
+
+    await guard.before!(callCtx("save_asset"));
+    await guard.after!(callCtx("save_asset"), { ok: true });
+
+    expect(sawBefore.map((c) => c.phase)).toEqual(["before"]);
+    expect(sawAfter.map((c) => c.call.phase)).toEqual(["after"]);
+  });
+
+  it("gives after() the call's result, and replaces it when one is returned", async () => {
+    sawAfter = [];
+    const [guard] = await buildGuards(
+      declare({ trail: { scope: "all", after: { class_path: "audit" } } }),
+      deps(registryWith({ audit: Audit as unknown as TaskConstructor })),
+      SOURCE,
+    );
+
+    const replaced = await guard.after!(callCtx("save_asset"), { original: true });
+    expect(sawAfter[0].result).toEqual({ original: true });
+    expect(replaced).toEqual({ audited: true });
+  });
+
+  it("says so when it is declared for a hook it does not implement", async () => {
+    const [guard] = await buildGuards(
+      declare({ oops: { scope: "all", before: { class_path: "wrong" } } }),
+      deps(registryWith({ wrong: WrongHook as unknown as TaskConstructor })),
+      SOURCE,
+    );
+    // A guard that cannot answer must not read as one that approved.
+    await expect(guard.before!(callCtx("save_asset"))).rejects.toThrow(/implements no before\(\)/);
+  });
+
+  it("refuses to be run as an ordinary task", async () => {
+    const registry = registryWith({ freeze: Freeze as unknown as TaskConstructor });
+    const task = await registry.create("freeze", {} as never, { enabled: true });
+    const answered = (await task.execute()) as TaskResult;
+    expect(answered.success).toBe(false);
+    expect(String(answered.error?.message)).toMatch(/is a guard and was run as a task/);
+  });
+
+  it("leaves a guard written against UeMcpTask working exactly as before", async () => {
+    const [guard] = await buildGuards(
+      declare({ legacy: { scope: "all", before: { class_path: "legacy" } } }),
+      deps(registryWith({ legacy: LegacyTaskGuard as unknown as TaskConstructor })),
+      SOURCE,
+    );
+    await expect(guard.before!(callCtx("save_asset"))).rejects.toThrow(/legacy blocked save_asset/);
+    await expect(guard.before!(callCtx("read_asset"))).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/guards.test.ts
+++ b/tests/unit/guards.test.ts
@@ -430,7 +430,12 @@ describe("what a hook is told about the call", () => {
     await guard.before!(callCtx("save_asset", { assetPath: "/Game/Foo" }));
 
     expect(seen).toHaveLength(1);
-    expect(seen[0]).toEqual({
+    // The flattened keys are the contract a guard written against UeMcpTask
+    // reads, and they have to keep their exact meaning. Asserted by inclusion
+    // rather than by equality: `UeMcpGuard` reads two reserved keys alongside
+    // them, and a guard that never heard of those is unaffected by their being
+    // there.
+    expect(seen[0]).toMatchObject({
       method: "save_asset",
       params: { assetPath: "/Game/Foo" },
       paths: ["C:/proj/Content/Foo.uasset"],

--- a/tests/unit/module-inventory.test.ts
+++ b/tests/unit/module-inventory.test.ts
@@ -110,6 +110,7 @@ const SESSION_INDEPENDENT: Record<string, string> = {
   "action-schema.ts": "Derives one action's parameter schema from whichever tool graph it is handed; holds nothing of its own.",
   "bridge-timeouts.ts": "The call budget table and its resolution; the same answer for every editor.",
   "asset-path.ts": "Pure Unreal path handling.",
+  "guard-task.ts": "The base class a guard is written against; pure over the call it is handed.",
   "epic-input.ts": "Pure argument shaping for one wrapped engine tool call; no editor to scope it to.",
   "path-params.ts": "Pure separator repair over a parameter bag; the same rule in every editor.",
   "field-select.ts": "Pure projection over whatever result it is handed; no editor to scope it to.",


### PR DESCRIPTION
A guard is written against `UeMcpGuard` now, from a new `ue-mcp/guard` entry point.

`flow/guards.ts` has said a guard is not a task since guards stopped being tasks whose name encoded their phase and scope. The declaration reflected that; the authoring side did not.

## What was wrong

- **Nothing was typed.** `this.options` is `Record<string, unknown>`, so every guard cast or guessed its way to `method` and `paths`.
- **Config and subject shared one namespace.** The declared `options` and the guarded call were flattened together with the call winning any collision, so a guard with an option named `method` silently read the call's method instead of its own setting.
- **The phase was implicit.** One `execute()` served both hooks, distinguishable only by sniffing for a `result` key.

## What replaces it

`before(call)` and `after(call, result)` as separate typed methods, `this.config` typed to the declaration's own options, `allow()` / `deny(reason)` instead of assembling a `TaskResult`.

## Compatibility

Nothing moved underneath: a guard still registers as a task, so `class_path` resolution, plugin loading and the pipeline are unchanged. A guard written against `UeMcpTask` reads the same flattened keys it always did, and a test covers that. The pipeline passes those keys plus two reserved nested ones, so the two styles coexist with no collision possible.

## Verification

1880 unit tests, 230 live against a real editor, 1039 smoke handlers, `npm run audit` clean.
