### PR TITLE
Bind a call node to the Blueprint's own function

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -317,6 +317,28 @@ widget(action="remove_widget", assetPath="/Game/UI/WBP_ComputerTaskbar", widgetN
 
 The widget is already gone, so the call reports `alreadyDeleted: true`, drops the dead entries, and saves. `prunedGuidEntries` in the result says how many it removed; `0` means the map was already clean and nothing was written.
 
+## A Call Node Came Back With No Title and No Pins
+
+**Symptom:** `blueprint(add_node)` reports `created: true`, but the node it made has the title `None`, carries no pins, and cannot be wired to anything.
+
+That is an unbound stub: the node class was created, but no `UFunction` was attached to it, so there is nothing for it to call and nothing to draw pins from. The report is `created: true` because a node genuinely was added - the binding is the part that failed, and it used to fail silently.
+
+The case this used to happen in is a function the Blueprint declares itself:
+
+```
+blueprint(action="create_function", assetPath="/Game/BP_Thing", functionName="ComputeAimOffset")
+blueprint(action="add_node", assetPath="/Game/BP_Thing", graphName="EventGraph",
+          nodeClass="K2Node_CallFunction", nodeParams={"functionName": "ComputeAimOffset"})
+```
+
+The resolver looked at an explicit target class, the parent class, the common Kismet libraries, the Blueprint's component classes, and every loaded class - but not at the Blueprint itself. A function declared on a Blueprint lives on its generated class, and on the skeleton class from the moment it is declared, and both are searched now, so the sequence above binds without needing a compile in between.
+
+If you still get a stub, the function name is the thing to check first. `blueprint(action="list_functions", assetPath=...)` reports what the Blueprint actually declares, and for a C++ `UFUNCTION` on a class the Blueprint does not own, naming it explicitly is the reliable form:
+
+```
+nodeParams={"functionName": "MyFunction", "className": "/Script/MyModule.MyClass"}
+```
+
 ## Search Not Finding Assets
 
 If `asset(action="search")` misses assets in plugin directories:

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/BlueprintHandlers_Graph.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/BlueprintHandlers_Graph.cpp
@@ -240,13 +240,34 @@ TSharedPtr<FJsonValue> FBlueprintHandlers::AddNode(const TSharedPtr<FJsonObject>
 					}
 				}
 
-				// 2. Try blueprint parent class
+				// 2. #996: the Blueprint OWN functions. A function declared on the
+				// Blueprint by create_function lives on its generated class, and on
+				// the SKELETON class from the moment it is declared - before a full
+				// compile has produced the generated one. Neither was searched, so
+				// "declare a function, then add a call to it" produced an unbound
+				// stub with no title and no pins.
+				//
+				// ExcludeSuper on purpose: this step is only for what the Blueprint
+				// itself declares, so an inherited name keeps resolving through the
+				// parent-class step below exactly as it did before.
+				if (!FoundFunc && Blueprint->SkeletonGeneratedClass)
+				{
+					FoundFunc = Blueprint->SkeletonGeneratedClass->FindFunctionByName(
+						FName(*FunctionName), EIncludeSuperFlag::ExcludeSuper);
+				}
+				if (!FoundFunc && Blueprint->GeneratedClass)
+				{
+					FoundFunc = Blueprint->GeneratedClass->FindFunctionByName(
+						FName(*FunctionName), EIncludeSuperFlag::ExcludeSuper);
+				}
+
+				// 3. Try blueprint parent class
 				if (!FoundFunc && Blueprint->ParentClass)
 				{
 					FoundFunc = Blueprint->ParentClass->FindFunctionByName(FName(*FunctionName));
 				}
 
-				// 3. Search common library classes
+				// 4. Search common library classes
 				if (!FoundFunc)
 				{
 					static UClass* LibraryClasses[] = {
@@ -263,7 +284,7 @@ TSharedPtr<FJsonValue> FBlueprintHandlers::AddNode(const TSharedPtr<FJsonObject>
 					}
 				}
 
-				// 4. #546: search the Blueprint's own component classes - a very
+				// 5. #546: search the Blueprint's own component classes - a very
 				// common case is calling a BlueprintCallable UFUNCTION on a custom
 				// C++ component the BP owns, without naming the class explicitly.
 				if (!FoundFunc && Blueprint->SimpleConstructionScript)
@@ -278,7 +299,7 @@ TSharedPtr<FJsonValue> FBlueprintHandlers::AddNode(const TSharedPtr<FJsonObject>
 					}
 				}
 
-				// 5. #546: last resort - scan loaded classes for a single
+				// 6. #546: last resort - scan loaded classes for a single
 				// BlueprintCallable function with this exact name. Resolves
 				// freshly-compiled custom C++ UFUNCTIONs that the palette index
 				// has not picked up. Only binds on an unambiguous match.

--- a/tests/live/blueprint-self-function-call.test.ts
+++ b/tests/live/blueprint-self-function-call.test.ts
@@ -1,0 +1,119 @@
+/**
+ * `blueprint(add_node)` binding a function the Blueprint declares itself
+ * (#996, gap 1).
+ *
+ * The failure this covers is quiet, which is why it needs a live assertion.
+ * add_node reported `created: true` and returned a node - just an unbound
+ * stub, title "None" and no pins, that cannot be wired or called. Nothing in
+ * the response said so.
+ *
+ * So "the call succeeded" is not the assertion here. The node has to come back
+ * bound, and two readers have to agree that it is: search_call_sites has to
+ * see a call site for the function, and the node's own title has to be the
+ * function's name rather than "None".
+ *
+ * Runs only against the dedicated disposable test project.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { callBridge, disconnectBridge, getBridge, resultArray, TEST_PREFIX } from "../setup.js";
+import type { EditorBridge } from "../../src/bridge.js";
+
+const BP = `${TEST_PREFIX}/BP_SelfCall`;
+const SELF_FUNCTION = "ComputeAimOffset";
+/** Declared by AActor, so it exercises the parent-class path unchanged. */
+const PARENT_FUNCTION = "K2_DestroyActor";
+
+type CallSite = { memberName?: string; nodeTitle?: string; assetPath?: string };
+type FoundNode = { nodeTitle?: string; nodeClass?: string };
+
+let bridge: EditorBridge;
+
+/** Call sites as search_call_sites reports them: the authoritative reader for
+ *  a K2Node_CallFunction, and the one that names the member it resolved to. */
+async function callSites(functionName: string): Promise<CallSite[]> {
+  const found = await callBridge(bridge, "search_blueprint_call_sites", {
+    functionNames: [functionName],
+    directory: TEST_PREFIX,
+    // Narrowing rules a Blueprint out by its Asset Registry dependencies on
+    // the declaring package, which does not resolve for a function declared
+    // in /Script/Engine. Off here so the reader is deterministic rather than
+    // dependent on what the registry recorded for a just-created asset.
+    narrowByRegistry: false,
+  });
+  expect(found.ok, found.error).toBe(true);
+  return ((resultArray(found.result, "callSites") ?? []) as CallSite[])
+    .filter((c) => (c.assetPath ?? "").includes("BP_SelfCall"));
+}
+
+async function callNodeTitles(): Promise<string[]> {
+  const read = await callBridge(bridge, "search_blueprint_nodes", {
+    assetPath: BP,
+    nodeClasses: ["K2Node_CallFunction"],
+  });
+  expect(read.ok, read.error).toBe(true);
+  return ((resultArray(read.result, "nodes") ?? []) as FoundNode[]).map((n) => String(n.nodeTitle ?? ""));
+}
+
+beforeAll(async () => {
+  bridge = await getBridge();
+  await callBridge(bridge, "delete_asset", { assetPath: BP, force: true });
+  const created = await callBridge(bridge, "create_blueprint", { path: BP, parentClass: "Actor" });
+  expect(created.ok, created.error).toBe(true);
+
+  const fn = await callBridge(bridge, "create_function", { path: BP, functionName: SELF_FUNCTION });
+  expect(fn.ok, fn.error).toBe(true);
+});
+
+afterAll(async () => {
+  if (bridge) {
+    await callBridge(bridge, "delete_asset", { assetPath: BP, force: true });
+    disconnectBridge();
+  }
+});
+
+describe("calling a function the Blueprint declares itself (#996)", () => {
+  beforeAll(async () => {
+    const added = await callBridge(bridge, "add_node", {
+      path: BP,
+      graphName: "EventGraph",
+      nodeClass: "K2Node_CallFunction",
+      nodeParams: { functionName: SELF_FUNCTION },
+    });
+    // created:true was already true when this was broken, so it is a
+    // precondition here rather than the thing being asserted.
+    expect(added.ok, added.error).toBe(true);
+  });
+
+  it("is a real call site, not an unbound stub", async () => {
+    const sites = await callSites(SELF_FUNCTION);
+    expect(sites.length).toBeGreaterThan(0);
+    expect(sites[0].memberName).toBe(SELF_FUNCTION);
+  });
+
+  it("carries the function's name as its title rather than 'None'", async () => {
+    // "None" is exactly what the unbound stub reported, and it is the symptom
+    // the report leads with.
+    const titles = await callNodeTitles();
+    expect(titles).not.toContain("None");
+    expect(titles.some((t) => t.includes(SELF_FUNCTION))).toBe(true);
+  });
+});
+
+describe("the paths that already worked (#996)", () => {
+  it("still binds a function the parent class declares", async () => {
+    // The self lookup is ExcludeSuper so an inherited name keeps resolving
+    // through the parent-class step. A regression here would mean the new step
+    // swallowed the old one.
+    const added = await callBridge(bridge, "add_node", {
+      path: BP,
+      graphName: "EventGraph",
+      nodeClass: "K2Node_CallFunction",
+      nodeParams: { functionName: PARENT_FUNCTION },
+    });
+    expect(added.ok, added.error).toBe(true);
+
+    const sites = await callSites(PARENT_FUNCTION);
+    expect(sites.length).toBeGreaterThan(0);
+    expect(sites[0].memberName).toBe(PARENT_FUNCTION);
+  });
+});


### PR DESCRIPTION
Addresses gap 1 of #996. **The issue stays open** - gap 2 is untouched.

## The gap

`add_node` resolved a `K2Node_CallFunction` against an explicit target class, the parent class, a few common libraries, the Blueprint's component classes, and finally every loaded class. It never looked at the Blueprint itself.

So the sequence the report gives - declare a function with `create_function`, then add a call to it - produced an unbound stub: title `None`, no pins, nothing that can be wired or called. And `add_node` reported `created: true`, which is what made it quiet rather than obvious.

## The fix

A function declared on a Blueprint lives on its generated class, and on the **skeleton** class from the moment it is declared, before a full compile has produced the generated one. Searching both is what makes declare-then-call work without a compile in between.

The lookup uses `ExcludeSuper` deliberately: it is only for what the Blueprint itself declares, so an inherited name keeps resolving through the existing parent-class step, unchanged. The live test asserts that alongside the fix, because the cheap version of this change would have been to search the skeleton class inclusively and quietly reroute every inherited call through a new path.

## Verification

- C++ compiled against 5.8 (CI does not build the plugin)
- `npm run test:unit`: 1905 passed
- `tests/live/blueprint-self-function-call.test.ts`, 3 assertions against a real editor

The assertions deliberately do not check that the call returned success - it already did when this was broken. Two independent readers have to agree the node is bound: `search_call_sites` has to report a call site whose `memberName` is the function, and the node's own title has to be the function's name rather than `None`, which is the symptom the report leads with.

## Not in this PR

**Gap 2**, reading the target of a data connection, is a read gap in the graph reader rather than a binding gap in `add_node`. It needs its own change and its own assertions, so #996 remains open for it.
