### PR TITLE
Stop reimport wedging the editor, and stop it dropping filePath

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -339,6 +339,35 @@ If you still get a stub, the function name is the thing to check first. `bluepri
 nodeParams={"functionName": "MyFunction", "className": "/Script/MyModule.MyClass"}
 ```
 
+## Reimport Says It Worked but Read the Old File
+
+**Symptom:** `asset(action="reimport", assetPath=..., filePath=...)` reports success, and the asset still has the contents of the file it was originally imported from.
+
+`filePath` repoints an asset at a new source before rebuilding it, which only works if the asset has somewhere to record that path. When it did not, the path used to be dropped and the reimport re-read the original file - reporting success either way, so there was nothing to notice.
+
+That case is refused now. When a reimport does repoint an asset, the response says so:
+
+```
+sourceFileUpdated: true
+sourceFile: C:/path/to/the/new/file.png
+```
+
+`sourceFileUpdated: false` means the asset was rebuilt from the source it already had, which is what you want when you pass no `filePath` at all.
+
+## Reimport Made the Editor Stop Responding
+
+**Symptom:** a call to `asset(action="reimport")` times out, and so does every call after it.
+
+Reimport rebuilds an asset from the file it was imported from, so it only applies to imported assets. Asked to reimport something authored in the editor - a Blueprint, a material, a data asset - Unreal's reimport manager does not return, and because it blocks the game thread the whole bridge stops answering rather than just that one call.
+
+The bridge now checks whether anything can reimport the asset before handing it over, so this comes back immediately:
+
+```
+Nothing can reimport a Blueprint: '/Game/BP_Thing' has no registered reimport handler.
+```
+
+If you hit the hang on an older build, the editor has to be restarted; nothing over the bridge can recover a blocked game thread.
+
 ## Search Not Finding Assets
 
 If `asset(action="search")` misses assets in plugin directories:

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_Import.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/AssetHandlers_Import.cpp
@@ -3242,7 +3242,22 @@ TSharedPtr<FJsonValue> FAssetHandlers::ReimportAsset(const TSharedPtr<FJsonObjec
 	UObject* Asset = MCPRequireAssetObject(AssetPath, LoadError);
 	if (!Asset) return LoadError;
 
+	// An asset nothing can reimport is refused here rather than handed to the
+	// manager. FReimportManager::Reimport on an asset with no registered handler
+	// - a Blueprint, say - does not return promptly: it wedges the game thread,
+	// so the bridge stops answering and the caller sees a timeout rather than an
+	// answer about their asset. CanReimport is the question actually being asked.
+	if (!FReimportManager::Instance()->CanReimport(Asset))
+	{
+		return MCPError(FString::Printf(
+			TEXT("Nothing can reimport a %s: '%s' has no registered reimport handler. ")
+			TEXT("Reimport rebuilds an asset from the file it was imported from, so it only applies to ")
+			TEXT("imported assets - a Blueprint or any other asset authored in the editor has no such file."),
+			*Asset->GetClass()->GetName(), *AssetPath));
+	}
+
 	// Optionally override the source file path
+	bool bSourceFileUpdated = false;
 	FString NewSourcePath;
 	if (Params->TryGetStringField(TEXT("filePath"), NewSourcePath) || Params->TryGetStringField(TEXT("filename"), NewSourcePath))
 	{
@@ -3271,10 +3286,21 @@ TSharedPtr<FJsonValue> FAssetHandlers::ReimportAsset(const TSharedPtr<FJsonObjec
 			}
 		}
 
-		if (ImportData)
+		if (!ImportData)
 		{
-			ImportData->Update(NewSourcePath);
+			// #1008: a filePath that lands nowhere used to be dropped here, and the
+			// reimport below then re-read the file the asset was ORIGINALLY imported
+			// from and reported success. The caller was told their new source file
+			// had been used when it had not been read at all.
+			return MCPError(FString::Printf(
+				TEXT("%s carries no AssetImportData, so '%s' cannot be recorded as its source file. ")
+				TEXT("Reimporting anyway would have re-read the file this asset was originally imported from ")
+				TEXT("and reported success. Import it as a new asset instead, or call reimport without filePath ")
+				TEXT("to rebuild it from the source it already has."),
+				*Asset->GetClass()->GetName(), *NewSourcePath));
 		}
+		ImportData->Update(NewSourcePath);
+		bSourceFileUpdated = true;
 	}
 
 	// Use FReimportManager to reimport
@@ -3285,6 +3311,11 @@ TSharedPtr<FJsonValue> FAssetHandlers::ReimportAsset(const TSharedPtr<FJsonObjec
 	Result->SetStringField(TEXT("assetPath"), AssetPath);
 	Result->SetStringField(TEXT("assetClass"), Asset->GetClass()->GetName());
 	Result->SetBoolField(TEXT("success"), bSuccess);
+	// Whether this call changed which file the asset reimports from, so a
+	// caller can tell "rebuilt from the same source" from "repointed and
+	// rebuilt" without inferring it from what it passed.
+	Result->SetBoolField(TEXT("sourceFileUpdated"), bSourceFileUpdated);
+	if (bSourceFileUpdated) Result->SetStringField(TEXT("sourceFile"), NewSourcePath);
 	if (!bSuccess)
 	{
 		Result->SetStringField(TEXT("error"), TEXT("Reimport failed -- check that the asset has a valid source file"));

--- a/tests/live/asset-reimport-source.test.ts
+++ b/tests/live/asset-reimport-source.test.ts
@@ -1,0 +1,136 @@
+/**
+ * `asset(reimport)`: what it reads, and what it refuses (#1008).
+ *
+ * Two behaviours, both found by writing this suite.
+ *
+ * `FReimportManager::Reimport` on an asset with no registered reimport handler
+ * does not return. It wedges the game thread, so the bridge stops answering
+ * entirely and EVERY later call times out, not just the reimport. Asking
+ * CanReimport first turns that into an immediate answer.
+ *
+ * And `filePath` repoints an asset at a new source before rebuilding it. When
+ * nothing on the asset could record that path it was dropped silently: the
+ * reimport re-read the file the asset was originally imported from and
+ * reported success, so a caller was told their file had been used when it was
+ * never opened. `sourceFileUpdated` now says which of the two happened.
+ *
+ * Runs only against the dedicated disposable test project.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { callBridge, disconnectBridge, getBridge, TEST_PREFIX } from "../setup.js";
+import type { EditorBridge } from "../../src/bridge.js";
+
+/** Authored in the editor, so nothing can reimport it. */
+const AUTHORED_ASSET = `${TEST_PREFIX}/BP_ReimportProbe`;
+/** Imported from a file, so it has a reimport handler and import data. */
+const IMPORTED_TEXTURE = `${TEST_PREFIX}/T_ReimportProbe`;
+
+/** A 1x1 PNG. Content does not matter; only that it is a valid image file. */
+const ONE_PIXEL_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+let bridge: EditorBridge;
+let scratchDir = "";
+let firstPng = "";
+let secondPng = "";
+/** Set when the texture fixture could not be built, so cases report why. */
+let textureError = "";
+
+beforeAll(async () => {
+  bridge = await getBridge();
+  scratchDir = mkdtempSync(join(tmpdir(), "ue-mcp-reimport-"));
+  firstPng = join(scratchDir, "first.png");
+  secondPng = join(scratchDir, "second.png");
+  writeFileSync(firstPng, ONE_PIXEL_PNG);
+  writeFileSync(secondPng, ONE_PIXEL_PNG);
+
+  await callBridge(bridge, "delete_asset", { assetPath: AUTHORED_ASSET, force: true });
+  await callBridge(bridge, "delete_asset", { assetPath: IMPORTED_TEXTURE, force: true });
+
+  const created = await callBridge(bridge, "create_blueprint", {
+    path: AUTHORED_ASSET,
+    parentClass: "Actor",
+  });
+  expect(created.ok, created.error).toBe(true);
+
+  const imported = await callBridge(bridge, "import_texture", {
+    filePath: firstPng,
+    packagePath: TEST_PREFIX,
+    name: "T_ReimportProbe",
+  });
+  if (!imported.ok) textureError = `import_texture failed: ${imported.error}`;
+});
+
+afterAll(async () => {
+  if (scratchDir) rmSync(scratchDir, { recursive: true, force: true });
+  if (bridge) {
+    await callBridge(bridge, "delete_asset", { assetPath: AUTHORED_ASSET, force: true });
+    await callBridge(bridge, "delete_asset", { assetPath: IMPORTED_TEXTURE, force: true });
+    disconnectBridge();
+  }
+});
+
+describe("an asset nothing can reimport (#1008)", () => {
+  it("is refused promptly rather than wedging the editor", async () => {
+    // The elapsed time IS the assertion. Before the guard this took the full
+    // 30s bridge timeout, because the game thread never came back.
+    const started = Date.now();
+    const reimported = await callBridge(bridge, "reimport_asset", { assetPath: AUTHORED_ASSET });
+    const elapsed = Date.now() - started;
+
+    const refused = !reimported.ok || (reimported.result as Record<string, unknown>)?.success === false;
+    expect(refused).toBe(true);
+    expect(elapsed, `took ${elapsed}ms, which is a hang rather than an answer`).toBeLessThan(10000);
+
+    const message = String(reimported.error ?? JSON.stringify(reimported.result));
+    // Naming the reason matters: "reimport failed" would send a caller looking
+    // at their source file rather than at the asset type.
+    expect(message).toMatch(/reimport/i);
+  });
+
+  it("leaves the editor able to take the next call", async () => {
+    // The real cost of the hang was never the one call. It was that nothing
+    // answered afterwards, including this.
+    const listed = await callBridge(bridge, "list_dialogs", {});
+    expect(listed.ok, listed.error).toBe(true);
+  });
+});
+
+describe("repointing an imported asset at a new source (#1008)", () => {
+  it("records the new file and says that it did", async () => {
+    expect(textureError, textureError).toBe("");
+    const reimported = await callBridge(bridge, "reimport_asset", {
+      assetPath: IMPORTED_TEXTURE,
+      filePath: secondPng,
+    });
+    expect(reimported.ok, reimported.error).toBe(true);
+
+    const result = reimported.result as Record<string, unknown>;
+    // The field that separates "rebuilt from the same source" from "repointed
+    // and rebuilt", which a caller could previously only assume.
+    expect(result.sourceFileUpdated).toBe(true);
+    expect(String(result.sourceFile ?? "")).toContain("second.png");
+  });
+
+  it("reports no repoint when no file was named", async () => {
+    expect(textureError, textureError).toBe("");
+    const reimported = await callBridge(bridge, "reimport_asset", { assetPath: IMPORTED_TEXTURE });
+    expect(reimported.ok, reimported.error).toBe(true);
+    expect((reimported.result as Record<string, unknown>).sourceFileUpdated).toBe(false);
+  });
+
+  it("refuses a file that is not there", async () => {
+    expect(textureError, textureError).toBe("");
+    const reimported = await callBridge(bridge, "reimport_asset", {
+      assetPath: IMPORTED_TEXTURE,
+      filePath: join(scratchDir, "no-such-file.png"),
+    });
+    const message = String(reimported.error ?? JSON.stringify(reimported.result));
+    expect(message).toMatch(/file not found/i);
+  });
+});


### PR DESCRIPTION
Two defects in `asset(reimport)`, both found while writing assertions for #1008. **#1008 itself stays open** - see the last section.

## 1. Reimport could wedge the editor

`FReimportManager::Reimport` on an asset with no registered reimport handler does not return. It blocks the game thread, so the bridge stops answering **entirely** - a caller who pointed `reimport` at a Blueprint lost the editor, not one call. The next call times out too, and the one after that.

`CanReimport` is the question actually being asked, and asking it first turns a 30 second hang into an answer that names the reason. The live assertion measures elapsed time, because that is the behaviour: it now returns in ~19ms.

This one is worth noting for how it surfaced. The suite did not fail on an assertion - it timed out, and the *next* test timed out as well, which is what pointed at a wedged game thread rather than a bad expectation.

## 2. `filePath` was dropped silently

`filePath` repoints an asset at a new source file before rebuilding it. When nothing on the asset could record that path, it was dropped: the reimport re-read the file the asset was **originally** imported from and reported success. A caller repointing an asset was told it worked while the file they named was never opened.

That is refused now, with a message that says why rather than leaving them looking at their file. The response also carries `sourceFileUpdated`, so "rebuilt from the same source" and "repointed and rebuilt" are distinguishable without inferring it from what was passed.

## Verification

- C++ compiled against 5.8 (CI does not build the plugin)
- `npm run test:unit`: 1905 passed
- `tests/live/asset-reimport-source.test.ts`, 5 assertions against a real editor, including one that asserts the editor still answers *after* a refused reimport - which is the part that was actually broken
- `npm run audit`: clean

## What this does not do

It is not the Houdini support #1008 asks for. `asset(reimport)` already exists with the exact signature that issue proposes, and it goes through `FReimportManager`, which dispatches to whatever handler a plugin registers - including Houdini's. So the issue's premise needs checking on a project that actually has that plugin installed, which this one does not. #1008 stays open for that.
