### PR TITLE
feat(dialog): offer tickable rows as one multi-select field

### DIFF
--- a/src/dialog-guard.ts
+++ b/src/dialog-guard.ts
@@ -26,7 +26,7 @@
  */
 import type { EditorSession } from "./session.js";
 import type { IBridge } from "./bridge.js";
-import type { ElicitFn } from "./types.js";
+import type { ElicitFn, ElicitPrimitiveSchema } from "./types.js";
 import type { DialogMode } from "./user-state.js";
 import { elicitationNeedsRelay } from "./client-quirks.js";
 
@@ -187,12 +187,15 @@ export function isDialogRefusal(v: unknown): boolean {
     && (v as Record<string, unknown>).dialogBlocking === true;
 }
 
-/** Read a dialog out of whatever shape reported it. */
 /** Schema key for one tickable row. Kept in one place so both ends agree. */
 function itemKey(index: number): string {
   return `item_${index}`;
 }
 
+/** Schema key for the multi-select holding every tickable row. */
+const ITEMS_KEY = "items";
+
+/** Read a dialog out of whatever shape reported it. */
 function asDialog(v: unknown): BlockingDialog | null {
   if (typeof v !== "object" || v === null) return null;
   const r = v as Record<string, unknown>;
@@ -715,44 +718,71 @@ export class DialogGuard {
       body,
     ];
     message.push("", "Nothing else can run until this is answered, and nothing is pressed unless you choose it.");
-    // One toggle per row the dialog lets a person tick.
+    // The rows the dialog lets a person tick, as ONE multi-select field.
     //
     // Save Content is N questions, not one, and "Save Selected" saves whatever
     // is ticked. Offering the buttons alone made it all or nothing, so a person
     // who wanted two of five files had no way to say so.
     //
+    // One field, not a boolean per row. A client draws a multi-select as a
+    // checkbox group on the same screen as the buttons; a boolean per row is
+    // drawn by some clients as a page per asset, which on a save of forty files
+    // is forty pages before the button.
+    //
     // Only rows carrying a path: the header's select-all box owns the column
-    // headings, and a toggle labelled "Asset" is not a question anybody asked.
+    // headings, and a row labelled "Asset" is not a question anybody asked.
     const tickable = (dialog.items ?? []).filter((i) => i.cells.some((c) => c.startsWith("/")));
-    const itemProps: Record<string, unknown> = {};
+    const button: ElicitPrimitiveSchema = {
+      type: "string",
+      title: "Button",
+      description: "The dialog's own buttons, in the order it lays them out.",
+      enum: [...dialog.buttons, LEAVE_OPEN],
+    };
+    const schemaWith = (itemProps: Record<string, ElicitPrimitiveSchema>) => ({
+      type: "object" as const,
+      properties: { ...itemProps, button },
+      required: ["button"],
+    });
+    const itemTitle = (item: DialogItem) => item.label === "" ? `Item ${item.index}` : item.label;
+    const itemPath = (item: DialogItem) => item.cells.find((c) => c.startsWith("/")) ?? "";
+    const grouped: Record<string, ElicitPrimitiveSchema> = tickable.length === 0 ? {} : {
+      [ITEMS_KEY]: {
+        type: "array",
+        title: "Items",
+        description: "Ticked rows are what the dialog acts on.",
+        items: {
+          anyOf: tickable.map((item) => ({
+            const: itemKey(item.index),
+            title: `${itemTitle(item)}  ${itemPath(item)}`,
+          })),
+        },
+        default: tickable.filter((item) => item.checked).map((item) => itemKey(item.index)),
+      },
+    };
+    // A boolean per row, for a client that refuses the multi-select. Array
+    // fields arrived in a later revision of the protocol than the form itself,
+    // and a refused form is otherwise never shown at all.
+    const perRow: Record<string, ElicitPrimitiveSchema> = {};
     for (const item of tickable) {
-      itemProps[itemKey(item.index)] = {
+      perRow[itemKey(item.index)] = {
         type: "boolean",
-        title: item.label === "" ? `Item ${item.index}` : item.label,
-        description: item.cells.find((c) => c.startsWith("/")) ?? "",
+        title: itemTitle(item),
+        description: itemPath(item),
         default: item.checked,
       };
     }
+    let asked: "grouped" | "perRow" = "grouped";
     try {
-      answer = await elicit({
-        message: message.join("\n"),
-        requestedSchema: {
-          type: "object",
-          properties: {
-            ...itemProps,
-            button: {
-              type: "string",
-              title: "Button",
-              description: "The dialog's own buttons, in the order it lays them out.",
-              enum: [...dialog.buttons, LEAVE_OPEN],
-            },
-          },
-          required: ["button"],
-        },
-      });
+      answer = await elicit({ message: message.join("\n"), requestedSchema: schemaWith(grouped) });
     } catch {
-      // The form never rendered. Not an answer, and not a used-up chance.
-      return { shown: false, press: null };
+      if (tickable.length === 0) return { shown: false, press: null };
+      try {
+        asked = "perRow";
+        answer = await elicit({ message: message.join("\n"), requestedSchema: schemaWith(perRow) });
+      } catch {
+        // The form never rendered. Not an answer, and not a used-up chance.
+        return { shown: false, press: null };
+      }
     }
     if (answer.action !== "accept") return { shown: true, press: null };
     const chosen = answer.content?.button;
@@ -771,9 +801,16 @@ export class DialogGuard {
     try {
       // What the person ticked travels WITH the button. Sending it separately
       // would leave a modal holding a selection nobody had pressed anything on.
+      //
+      // A grouped answer with no list at all leaves every row as the dialog
+      // had it. A client that drops a field it cannot draw would otherwise
+      // untick everything, and "Save Selected" would save nothing.
+      const picked = answer.content?.[ITEMS_KEY];
       const selections = tickable.map((item) => ({
         index: item.index,
-        checked: answer.content?.[itemKey(item.index)] === true,
+        checked: asked === "perRow"
+          ? answer.content?.[itemKey(item.index)] === true
+          : Array.isArray(picked) ? picked.includes(itemKey(item.index)) : item.checked,
       }));
       // Called with ONE argument when there is nothing to tick, so a dialog
       // that offers no items presses exactly as it always did.

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,19 @@ export interface ElicitParams {
 export type ElicitPrimitiveSchema =
   | { type: "string"; title?: string; description?: string; enum?: string[]; enumNames?: string[]; default?: string }
   | { type: "number" | "integer"; title?: string; description?: string; default?: number }
-  | { type: "boolean"; title?: string; description?: string; default?: boolean };
+  | { type: "boolean"; title?: string; description?: string; default?: boolean }
+  | (ElicitMultiSelectBase & { items: { type: "string"; enum: string[] } })
+  | (ElicitMultiSelectBase & { items: { anyOf: Array<{ const: string; title: string }> } });
+
+/** A checkbox group: the answer is the list of ticked values. */
+interface ElicitMultiSelectBase {
+  type: "array";
+  title?: string;
+  description?: string;
+  minItems?: number;
+  maxItems?: number;
+  default?: string[];
+}
 
 export interface ElicitResult {
   action: "accept" | "decline" | "cancel";

--- a/tests/unit/dialog-guard.test.ts
+++ b/tests/unit/dialog-guard.test.ts
@@ -1001,7 +1001,7 @@ describe("a dialog that asks a question per item", () => {
     ],
   };
 
-  it("offers a toggle per tickable row, and none for the select-all header", async () => {
+  it("offers the tickable rows as one multi-select, without the select-all header", async () => {
     let schema: any;
     const guard = make({
       mode: "interactive",
@@ -1014,11 +1014,14 @@ describe("a dialog that asks a question per item", () => {
 
     await guard.check("asset.list", "action");
 
-    // The two real rows, keyed by index, titled by the asset.
-    expect(schema.properties.item_1).toMatchObject({ type: "boolean", title: "L_Test", default: true });
-    expect(schema.properties.item_2).toMatchObject({ type: "boolean", title: "M_Rock" });
-    // The header row carries no path, so it is not a question.
-    expect(schema.properties.item_0).toBeUndefined();
+    // One field holding the two real rows, keyed by index, titled by the asset.
+    expect(schema.properties.items).toMatchObject({ type: "array", default: ["item_1", "item_2"] });
+    expect(schema.properties.items.items.anyOf).toEqual([
+      { const: "item_1", title: "L_Test  /Game/Maps/L_Test" },
+      { const: "item_2", title: "M_Rock  /Game/Mat/M_Rock" },
+    ]);
+    // No field per row: that is what some clients drew as a page per asset.
+    expect(Object.keys(schema.properties)).toEqual(["items", "button"]);
     // The buttons are still the decision.
     expect(schema.properties.button.enum).toContain("Save Selected");
   });
@@ -1031,7 +1034,7 @@ describe("a dialog that asks a question per item", () => {
       probe: async () => ({ dialogs: [SAVE_ITEMS] }),
       elicit: () => (async () => ({
         action: "accept",
-        content: { button: "Save Selected", item_1: true, item_2: false },
+        content: { button: "Save Selected", items: ["item_1"] },
       })) as never,
     });
 
@@ -1040,6 +1043,47 @@ describe("a dialog that asks a question per item", () => {
     expect(press).toHaveBeenCalledWith("Save Selected", [
       { index: 1, checked: true },
       { index: 2, checked: false },
+    ]);
+  });
+
+  it("leaves every row as it was when the answer carries no list", async () => {
+    const press = vi.fn(async () => ({ success: true, answered: true }));
+    const guard = make({
+      mode: "interactive",
+      press,
+      probe: async () => ({ dialogs: [SAVE_ITEMS] }),
+      elicit: () => (async () => ({ action: "accept", content: { button: "Save Selected" } })) as never,
+    });
+
+    await guard.check("asset.list", "action");
+
+    expect(press).toHaveBeenCalledWith("Save Selected", [
+      { index: 1, checked: true },
+      { index: 2, checked: true },
+    ]);
+  });
+
+  it("falls back to a boolean per row when the client refuses the multi-select", async () => {
+    const press = vi.fn(async () => ({ success: true, answered: true }));
+    const schemas: any[] = [];
+    const guard = make({
+      mode: "interactive",
+      press,
+      probe: async () => ({ dialogs: [SAVE_ITEMS] }),
+      elicit: () => (async (req: any) => {
+        schemas.push(req.requestedSchema);
+        if (req.requestedSchema.properties.items) throw new Error("unsupported schema");
+        return { action: "accept", content: { button: "Save Selected", item_1: false, item_2: true } };
+      }) as never,
+    });
+
+    await guard.check("asset.list", "action");
+
+    expect(schemas).toHaveLength(2);
+    expect(schemas[1].properties.item_1).toMatchObject({ type: "boolean", title: "L_Test", default: true });
+    expect(press).toHaveBeenCalledWith("Save Selected", [
+      { index: 1, checked: false },
+      { index: 2, checked: true },
     ]);
   });
 


### PR DESCRIPTION
## What changed

The interactive dialog form sends the tickable rows (Save Content's unsaved packages) as one `items` multi-select field instead of a boolean per row. The button stays a single-select beside it.

## Why

A boolean per row was drawn by field-by-field clients (pi's MCP adapter) as one page per asset before the button. Claude Code's form draws an array field with `items.anyOf` as a checkbox group on the same screen as the button.

A client that rejects the array schema is asked again with the old boolean-per-row form. An accepted answer with no list leaves every row as the dialog had it, so Save Selected cannot silently save nothing.

## Verification

- [x] `npx tsc --noEmit`
- [x] `npm run test:unit`

## Notes for the release

### Features
- The interactive Save Content form shows unsaved packages as one checkbox group beside the buttons.
