### PR TITLE
fix(dialog): title the form fields Assets and Submission

### DIFF
--- a/src/dialog-guard.ts
+++ b/src/dialog-guard.ts
@@ -734,7 +734,7 @@ export class DialogGuard {
     const tickable = (dialog.items ?? []).filter((i) => i.cells.some((c) => c.startsWith("/")));
     const button: ElicitPrimitiveSchema = {
       type: "string",
-      title: "Button",
+      title: "Submission",
       description: "The dialog's own buttons, in the order it lays them out.",
       enum: [...dialog.buttons, LEAVE_OPEN],
     };
@@ -748,7 +748,7 @@ export class DialogGuard {
     const grouped: Record<string, ElicitPrimitiveSchema> = tickable.length === 0 ? {} : {
       [ITEMS_KEY]: {
         type: "array",
-        title: "Items",
+        title: "Assets",
         description: "Ticked rows are what the dialog acts on.",
         items: {
           anyOf: tickable.map((item) => ({

--- a/tests/unit/dialog-guard.test.ts
+++ b/tests/unit/dialog-guard.test.ts
@@ -1015,7 +1015,8 @@ describe("a dialog that asks a question per item", () => {
     await guard.check("asset.list", "action");
 
     // One field holding the two real rows, keyed by index, titled by the asset.
-    expect(schema.properties.items).toMatchObject({ type: "array", default: ["item_1", "item_2"] });
+    expect(schema.properties.items).toMatchObject({ type: "array", title: "Assets", default: ["item_1", "item_2"] });
+    expect(schema.properties.button.title).toBe("Submission");
     expect(schema.properties.items.items.anyOf).toEqual([
       { const: "item_1", title: "L_Test  /Game/Maps/L_Test" },
       { const: "item_2", title: "M_Rock  /Game/Mat/M_Rock" },


### PR DESCRIPTION
## What changed

The dialog form's multi-select is titled "Assets" and the button choice "Submission". Answer keys are unchanged.

## Verification

- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/unit/dialog-guard.test.ts tests/unit/dialog-gate-wiring.test.ts`

## Notes for the release

### Features
- The dialog form labels its fields "Assets" and "Submission".
