### PR TITLE
fix(dialog): press an answer that arrives after the call gave up

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,7 +137,7 @@ It lives with the feedback mode and for the same reason: whether somebody is at 
 
 | Mode | What happens to a blocking dialog |
 |------|-----------------------------------|
-| `interactive` | You get an elicitation form with the dialog's buttons as the choices, plus "leave it open". The button you pick is pressed and the blocked call then runs. The agent cannot press it for you: `editor(respond_to_dialog)` is refused in this mode. |
+| `interactive` | You get an elicitation form with the dialog's buttons as the choices, plus "leave it open", under the title "Submission". The button you pick is pressed and the blocked call then runs. A dialog that asks a question per row (the "Save Content" prompt is a checkbox per unsaved package) carries those rows in the same form as one checkbox group titled "Assets", ticked as the dialog has them, and what you tick travels with the button in one press. The agent cannot press it for you: `editor(respond_to_dialog)` is refused in this mode. |
 | `auto` | The refusal includes the `editor(action='respond_to_dialog')` call for each button. The agent picks one and makes that call. Nothing is pressed until it does. |
 | `defer` | The refusal names the dialog and its buttons but not the calls that press them, and `editor(respond_to_dialog)` is refused. Answer it in the Unreal Editor window. |
 
@@ -150,6 +150,8 @@ Set it with `npx ue-mcp dialog mode <interactive|auto|defer>` (add `--editor <na
 Under `interactive` the dialog is handed back whole on one call and the form goes up on the next, so its text lands somewhere nothing truncates it. An elicitation form is a few lines tall and the client decides how many of them it draws; one that keeps the opening line or two and collapses the rest would otherwise collapse the question itself. `dialogPhase` on the refusal says which call you are on: `relay` or `asking`.
 
 A client known to render the whole message skips that round trip. Every other client, including one nobody has checked, gets the handover: relaying needlessly costs one call, and not relaying against a client that collapses the message asks someone to choose a button for a question they cannot see. `UE_MCP_DIALOG_RELAY=off` turns the handover off whatever the client is, and `=on` forces it back on.
+
+The form outlives the call that raised it. A blocked call waits a minute for your answer and then refuses, so one open form does not hold every other call behind it, but the form stays up and the button you pick is still pressed whenever you get to it. The screen is re-read first, so an answer that arrives after the dialog was closed at the editor's own window, or after a different prompt replaced it, presses nothing.
 
 
 ### User-machine state (`~/.ue-mcp/`)

--- a/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DialogHandlers.cpp
+++ b/plugin/ue_mcp_bridge/Source/UE_MCP_Bridge/Private/Handlers/DialogHandlers.cpp
@@ -679,6 +679,10 @@ TSharedPtr<SWindow> FDialogHandlers::CollectActiveModal(FString& OutTitle, FStri
 	OutTitle = ActiveModal->GetTitle().ToString();
 
 	TArray<FString> TextContents;
+	// How many buttons the walk is inside. A button's label is not a cell of
+	// the row before it, and without this the last row of Save Content carried
+	// "Save Selected", "Don't Save" and "Cancel" as its own cells (#1076).
+	int32 ButtonDepth = 0;
 
 	TFunction<void(const TSharedRef<SWidget>&)> TraverseWidgets = [&](const TSharedRef<SWidget>& Widget)
 	{
@@ -693,7 +697,7 @@ TSharedPtr<SWindow> FDialogHandlers::CollectActiveModal(FString& OutTitle, FStri
 				// checkbox then its cells, so text after a checkbox belongs to
 				// that checkbox until the next one starts a new row. That is
 				// what pairs "L_MoverPawnTest" with the box that saves it.
-				if (OutItems && OutItems->Num() > 0)
+				if (OutItems && OutItems->Num() > 0 && ButtonDepth == 0)
 				{
 					OutItems->Last().Cells.Add(Text);
 				}
@@ -730,6 +734,8 @@ TSharedPtr<SWindow> FDialogHandlers::CollectActiveModal(FString& OutTitle, FStri
 			OutButtons.Add(Entry);
 		}
 
+		const bool bIsButton = Widget->GetType() == TEXT("SButton");
+		if (bIsButton) ++ButtonDepth;
 		FChildren* Children = Widget->GetChildren();
 		if (Children)
 		{
@@ -738,6 +744,7 @@ TSharedPtr<SWindow> FDialogHandlers::CollectActiveModal(FString& OutTitle, FStri
 				TraverseWidgets(Children->GetChildAt(i));
 			}
 		}
+		if (bIsButton) --ButtonDepth;
 	};
 
 	TraverseWidgets(ActiveModal.ToSharedRef());

--- a/src/dialog-guard.ts
+++ b/src/dialog-guard.ts
@@ -195,6 +195,20 @@ function itemKey(index: number): string {
 /** Schema key for the multi-select holding every tickable row. */
 const ITEMS_KEY = "items";
 
+/** A dialog's identity: the same prompt on screen reads the same. */
+function dialogIdentity(dialog: BlockingDialog): string {
+  return `${dialog.title} :: ${dialog.message}`;
+}
+
+/** The promise's value, or null if it has not settled within `ms`. */
+function within<T>(promise: Promise<T>, ms: number): Promise<T | null> {
+  let timer: NodeJS.Timeout | undefined;
+  const late = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), ms);
+  });
+  return Promise.race([promise, late]).finally(() => clearTimeout(timer));
+}
+
 /** Read a dialog out of whatever shape reported it. */
 function asDialog(v: unknown): BlockingDialog | null {
   if (typeof v !== "object" || v === null) return null;
@@ -280,6 +294,13 @@ export interface GuardDeps {
   readSnapshot?: () => { modal?: unknown; ageSeconds?: number } | null;
   /** Whether the bridge socket is currently up. */
   isConnected?: () => boolean;
+  /**
+   * How long one call waits on an open form before refusing, in ms.
+   *
+   * Internal and defaulted; it exists so the wait can be exercised in a test
+   * without sitting through it. The form itself outlives this wait.
+   */
+  askWaitMs?: number;
 }
 
 /**
@@ -291,6 +312,14 @@ export const STATUS_STALE_AFTER_MS = 15_000;
 /** How big a rendered dialog has to be before a form cannot carry it. */
 const RELAY_OVER_LINES = 12;
 const RELAY_OVER_CHARS = 700;
+
+/**
+ * How long a gated call waits for the person to answer an open form.
+ *
+ * The form is not bounded by this. When the wait runs out the call refuses and
+ * the form stays up; whatever the person picks later is still pressed.
+ */
+const ASK_WAIT_MS = 60_000;
 
 export class DialogGuard {
   private blocking: BlockingDialog | null = null;
@@ -523,7 +552,7 @@ export class DialogGuard {
     // shown the same prompt twice and the button was pressed TWICE, which on a
     // save prompt is two real answers for one action. If the same dialog is
     // still there after a press, pressing again will not help: report it.
-    const identity = `${dialog.title} :: ${dialog.message}`;
+    const identity = dialogIdentity(dialog);
     // canElicit: false means this route has nobody to ask. An HTTP request
     // has no person on it, and eliciting would raise a form in whichever
     // MCP client last touched this guard and press a real button on its
@@ -575,25 +604,31 @@ export class DialogGuard {
       // answering a question it was never shown.
       if (!this.asking || this.askingFor !== identity) {
         this.askingFor = identity;
-        this.asking = this.askUser(dialog).finally(() => {
-          this.asking = null;
-          this.askingFor = null;
-        });
+        // The outcome is recorded by the ask itself, not by whichever call is
+        // waiting on it. A person can answer long after every call has stopped
+        // waiting, and that answer is still theirs to have pressed (#1076).
+        this.asking = this.askUser(dialog)
+          .then((outcome) => {
+            // Recorded only once a form was actually SHOWN. Setting it before
+            // the ask meant an elicitation that threw or was declined consumed
+            // the one chance, and the person was never asked about that dialog
+            // again for the life of the process.
+            if (outcome.shown) this.lastAsked = identity;
+            this.pressed = outcome.press;
+            // Only a CONFIRMED press proves the way is clear. An unknown one
+            // is reported, not assumed.
+            if (outcome.press?.confirmed) this.clear();
+            return outcome;
+          })
+          .finally(() => {
+            this.asking = null;
+            this.askingFor = null;
+          });
       }
-      const outcome = await this.asking;
-      const pressed = outcome.press;
-      // Recorded only once a form was actually SHOWN. Setting it before the
-      // ask meant an elicitation that threw, timed out, or was declined
-      // consumed the one chance, and the person was never asked about that
-      // dialog again for the life of the process.
-      if (outcome.shown) this.lastAsked = identity;
-      this.pressed = pressed;
-      // Only a CONFIRMED press proves the way is clear. An unknown one is
-      // reported, not assumed.
-      if (pressed?.confirmed) {
-        this.clear();
-        return { allow: true };
-      }
+      // Bounded, where the form is not. A call that waited on the person for as
+      // long as they took would hold every gated call behind one open form.
+      const outcome = await within(this.asking, this.deps.askWaitMs ?? ASK_WAIT_MS);
+      if (outcome?.press?.confirmed) return { allow: true };
     }
     return { allow: false, refusal: this.refusal(subject, dialog, opts) };
   }
@@ -788,6 +823,11 @@ export class DialogGuard {
     const chosen = answer.content?.button;
     if (typeof chosen !== "string" || chosen === LEAVE_OPEN) return { shown: true, press: null };
     if (!dialog.buttons.includes(chosen)) return { shown: true, press: null };
+    // The answer can arrive long after the form went up, and the editor may be
+    // showing something else by then: the dialog answered at its own window, or
+    // a new one with the same buttons. A press is only for the dialog the
+    // person was shown.
+    if (!(await this.stillShowing(dialog))) return { shown: true, press: null };
     // Three outcomes, not two.
     //
     //   pressed      the editor confirmed it
@@ -832,6 +872,17 @@ export class DialogGuard {
       return { shown: true, press: { button: chosen, confirmed: false } };
     } catch {
       return { shown: true, press: null };
+    }
+  }
+
+  /** Whether the editor is still showing this dialog, read fresh. */
+  private async stillShowing(dialog: BlockingDialog): Promise<boolean> {
+    try {
+      const list = ((await this.deps.probe()) as { dialogs?: unknown })?.dialogs;
+      const current = Array.isArray(list) ? asDialog(list[0]) : null;
+      return current !== null && dialogIdentity(current) === dialogIdentity(dialog);
+    } catch {
+      return false;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -363,6 +363,10 @@ async function main() {
   // Elicitation is only meaningful once the client has advertised support
   // during initialize. We lazily probe at call time so the function is bound
   // to whatever the live capabilities are, not a stale snapshot.
+  // A person answers a form when they get to it, not within the SDK's 60
+  // second request default. An answer given after that was discarded with
+  // nothing pressed, and the same question went up again (#1076).
+  const ELICIT_TIMEOUT_MS = 24 * 60 * 60 * 1000;
   const buildElicit = (mcp: McpServer): ElicitFn | undefined => {
     const elicit: ElicitFn = async (params) => {
       const caps = mcp.server.getClientCapabilities();
@@ -374,7 +378,7 @@ async function main() {
           "Connected MCP client did not advertise the `elicitation` capability - cannot obtain a deterministic user approval. Upgrade your client (Claude Code >= 2.1.76) or run the action from a client that supports MCP elicitation.",
         );
       }
-      const result = await mcp.server.elicitInput(params);
+      const result = await mcp.server.elicitInput(params, { timeout: ELICIT_TIMEOUT_MS });
       return result as Awaited<ReturnType<ElicitFn>>;
     };
     // The gate is built before any client has connected, so this function

--- a/tests/unit/dialog-guard.test.ts
+++ b/tests/unit/dialog-guard.test.ts
@@ -38,6 +38,7 @@ function make(over: Omit<Partial<GuardDeps>, "mode"> & { mode?: DialogMode } = {
     elicit: over.elicit,
     readSnapshot: over.readSnapshot,
     isConnected: over.isConnected,
+    askWaitMs: over.askWaitMs,
   };
   return new DialogGuard(deps);
 }
@@ -1096,5 +1097,67 @@ describe("a dialog that asks a question per item", () => {
     await guard.check("asset.list", "action");
 
     expect(press).toHaveBeenCalledWith("Cancel");
+  });
+});
+
+describe("an answer that arrives after the call stopped waiting (#1076)", () => {
+  function deferred<T>() {
+    let resolve!: (v: T) => void;
+    const promise = new Promise<T>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  it("is still pressed", async () => {
+    // stop_editor gave up waiting, the person answered minutes later, and the
+    // answer went nowhere: the modal stayed up and they had to answer again.
+    const answer = deferred<unknown>();
+    const press = vi.fn(async () => ({ success: true, answered: true }));
+    const guard = make({
+      mode: "interactive",
+      press,
+      askWaitMs: 5,
+      elicit: () => (async () => answer.promise) as never,
+    });
+
+    const decision = await guard.check("asset.list", "action");
+    expect(decision.allow).toBe(false);
+    expect(press).not.toHaveBeenCalled();
+
+    answer.resolve({ action: "accept", content: { button: "Cancel" } });
+    await vi.waitFor(() => expect(press).toHaveBeenCalledWith("Cancel"));
+  });
+
+  it("raises one form, not one per call, while it is open", async () => {
+    const answer = deferred<unknown>();
+    const elicit = vi.fn(async () => answer.promise);
+    const guard = make({ mode: "interactive", askWaitMs: 5, elicit: () => elicit as never });
+
+    await guard.check("asset.list", "action");
+    await guard.check("asset.list", "action");
+
+    expect(elicit).toHaveBeenCalledTimes(1);
+    answer.resolve({ action: "decline" });
+  });
+
+  it("is not pressed on a different dialog that came up meanwhile", async () => {
+    const answer = deferred<unknown>();
+    const press = vi.fn(async () => ({ success: true, answered: true }));
+    let title = "Save Content";
+    const guard = make({
+      mode: "interactive",
+      press,
+      askWaitMs: 5,
+      probe: async () => listing(title),
+      elicit: () => (async () => answer.promise) as never,
+    });
+
+    await guard.check("asset.list", "action");
+    title = "Message Log";
+    answer.resolve({ action: "accept", content: { button: "Cancel" } });
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(press).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What changed

The dialog form outlives the call that raised it. A gated call waits 60 seconds for an answer and then refuses; the form stays open and whatever the person picks is still pressed, provided the same dialog is still on screen.

The elicitation request itself no longer expires after the SDK's 60 second default.

The Slate walk no longer attaches button labels to the last row's cells.

## Why

Refs #1076. `stop_editor` gave up after its wait, the person answered minutes later, and the answer went nowhere: nothing was pressed, the modal stayed up, and the same question was raised again because the form counted as never shown.

The header row is still reported as item 0. That is deliberate: the select-all box is a real tickable row, and the elicitation form already filters it out.

## Verification

- [x] `npx tsc --noEmit`
- [x] `npm run test:unit`
- [x] `npm run build` (required for any change under `plugin/`)

## Notes for the release

### Fixes
- An answer to the interactive dialog form is pressed even when it arrives after the call that raised the form has returned (#1076).
- The Save Content rows no longer carry the dialog's button labels as cells (#1076).

### Mentions
- **This release changes the C++ bridge.** Run `ue-mcp deploy <uproject>` and `ue-mcp build`, then restart the editor.
